### PR TITLE
Setup initial Easy UI repo structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vscode
+.DS_STORE
+node_modules

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The EasyPost/easy-ui repository is a monorepo made up of NPM packages and websit
 easy-ui/
 ├── documentation               # Documentation for working with Easy UI
 ├── easy-ui-icons               # Icons for Easy UI
-├── easy-ui-react               # Components for @easypost/ui package
+├── easy-ui-react               # Components for @easypost/easy-ui package
 ├── easy-ui-tokens              # Design tokens for Easy UI
 ├── easy-ui-storybook           # Storybook website
 └── stylelint-easy-ui           # Style rules for Easy UI

--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-# easy-ui
+# Easy UI
+
+> Resources, components, and design guidelines for shaping the shipper experience at EasyPost.
+
+| Status | Owner            | Help                                                        |
+| ------ | ---------------- | ----------------------------------------------------------- |
+| Active | EasyPost/easy-ui | [New issue](https://github.com/EasyPost/easy-ui/issues/new) |
+
+## About this repo
+
+The EasyPost/easy-ui repository is a monorepo made up of NPM packages and websites.
+
+```sh
+easy-ui/
+├── documentation               # Documentation for working with Easy UI
+├── easy-ui-icons               # Icons for Easy UI
+├── easy-ui-react               # Components for @easypost/ui package
+├── easy-ui-tokens              # Design tokens for Easy UI
+├── easy-ui-storybook           # Storybook website
+└── stylelint-easy-ui           # Style rules for Easy UI
+└── eslint-config-easy-ui       # ESLint rules for Easy UI
+```
+
+## Commands
+
+### Install dependencies
+
+```sh
+npm i
+```
+
+## Contribute to this repo
+
+Pull requests are welcome. See the [contribution guidelines](https://github.com/EasyPost/.github/blob/main/CONTRIBUTING.md) for more information.
+
+## Licenses
+
+Source code is under an [MIT license](https://github.com/EasyPost/.github/blob/main/LICENSE).

--- a/easy-ui-icons/package.json
+++ b/easy-ui-icons/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@easypost/easy-ui-icons",
+  "version": "1.0.0"
+}

--- a/easy-ui-react/package.json
+++ b/easy-ui-react/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@easypost/easy-ui",
+  "version": "1.0.0"
+}

--- a/easy-ui-storybook/package.json
+++ b/easy-ui-storybook/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@easypost/easy-ui-storybook",
+  "version": "1.0.0"
+}

--- a/easy-ui-tokens/package.json
+++ b/easy-ui-tokens/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@easypost/easy-ui-tokens",
+  "version": "1.0.0"
+}

--- a/eslint-config-easy-ui/package.json
+++ b/eslint-config-easy-ui/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@easypost/eslint-config-easy-ui",
+  "version": "1.0.0"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,91 @@
+{
+  "name": "easy-ui",
+  "version": "0.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "easy-ui",
+      "version": "0.0.0",
+      "workspaces": [
+        "easy-ui-icons",
+        "easy-ui-react",
+        "easy-ui-tokens",
+        "easy-ui-storybook",
+        "stylelint-easy-ui",
+        "eslint-config-easy-ui"
+      ],
+      "engines": {
+        "node": "^16.14.0"
+      }
+    },
+    "easy-ui-icons": {
+      "name": "@easypost/easy-ui-icons",
+      "version": "1.0.0"
+    },
+    "easy-ui-react": {
+      "name": "@easypost/easy-ui",
+      "version": "1.0.0"
+    },
+    "easy-ui-storybook": {
+      "name": "@easypost/easy-ui-storybook",
+      "version": "1.0.0"
+    },
+    "easy-ui-tokens": {
+      "name": "@easypost/easy-ui-tokens",
+      "version": "1.0.0"
+    },
+    "eslint-config-easy-ui": {
+      "name": "@easypost/eslint-config-easy-ui",
+      "version": "1.0.0"
+    },
+    "node_modules/@easypost/easy-ui": {
+      "resolved": "easy-ui-react",
+      "link": true
+    },
+    "node_modules/@easypost/easy-ui-icons": {
+      "resolved": "easy-ui-icons",
+      "link": true
+    },
+    "node_modules/@easypost/easy-ui-storybook": {
+      "resolved": "easy-ui-storybook",
+      "link": true
+    },
+    "node_modules/@easypost/easy-ui-tokens": {
+      "resolved": "easy-ui-tokens",
+      "link": true
+    },
+    "node_modules/@easypost/eslint-config-easy-ui": {
+      "resolved": "eslint-config-easy-ui",
+      "link": true
+    },
+    "node_modules/@easypost/stylelint-easy-ui": {
+      "resolved": "stylelint-easy-ui",
+      "link": true
+    },
+    "stylelint-easy-ui": {
+      "name": "@easypost/stylelint-easy-ui",
+      "version": "1.0.0"
+    }
+  },
+  "dependencies": {
+    "@easypost/easy-ui": {
+      "version": "file:easy-ui-react"
+    },
+    "@easypost/easy-ui-icons": {
+      "version": "file:easy-ui-icons"
+    },
+    "@easypost/easy-ui-storybook": {
+      "version": "file:easy-ui-storybook"
+    },
+    "@easypost/easy-ui-tokens": {
+      "version": "file:easy-ui-tokens"
+    },
+    "@easypost/eslint-config-easy-ui": {
+      "version": "file:eslint-config-easy-ui"
+    },
+    "@easypost/stylelint-easy-ui": {
+      "version": "file:stylelint-easy-ui"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "easy-ui",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Resources, components, and guidelines behind UI at EasyPost",
+  "author": "EasyPost",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/EasyPost/easy-ui.git"
+  },
+  "bugs": {
+    "url": "https://github.com/EasyPost/easy-ui/issues"
+  },
+  "engines": {
+    "node": "^16.14.0"
+  },
+  "keywords": [
+    "react",
+    "components",
+    "library",
+    "design-system"
+  ],
+  "workspaces": [
+    "easy-ui-icons",
+    "easy-ui-react",
+    "easy-ui-tokens",
+    "easy-ui-storybook",
+    "stylelint-easy-ui",
+    "eslint-config-easy-ui"
+  ]
+}

--- a/stylelint-easy-ui/package.json
+++ b/stylelint-easy-ui/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@easypost/stylelint-easy-ui",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
Sets up the initial, skeleton Easy UI repo structure:

- Initializes as NPM project
- Creates initial workspaces
- Fills out initial README