### PR TITLE
Update typography tokens

### DIFF
--- a/easy-ui-tokens/src/font/base.json
+++ b/easy-ui-tokens/src/font/base.json
@@ -12,28 +12,29 @@
       }
     },
     "size": {
-      "3xs": { "value": "10px", "attributes": { "unit": "rem" } },
-      "2xs": { "value": "12px", "attributes": { "unit": "rem" } },
-      "xs": { "value": "13px", "attributes": { "unit": "rem" } },
-      "sm": { "value": "15px", "attributes": { "unit": "rem" } },
-      "base": { "value": "16px", "attributes": { "unit": "rem" } },
-      "lg": { "value": "19px", "attributes": { "unit": "rem" } },
-      "xl": { "value": "23px", "attributes": { "unit": "rem" } },
-      "2xl": { "value": "33px", "attributes": { "unit": "rem" } },
-      "3xl": { "value": "46px", "attributes": { "unit": "rem" } },
-      "4xl": { "value": "58px", "attributes": { "unit": "rem" } }
+      "25": { "value": "10px", "attributes": { "unit": "rem" } },
+      "50": { "value": "12px", "attributes": { "unit": "rem" } },
+      "75": { "value": "13px", "attributes": { "unit": "rem" } },
+      "100": { "value": "15px", "attributes": { "unit": "rem" } },
+      "200": { "value": "19px", "attributes": { "unit": "rem" } },
+      "300": { "value": "23px", "attributes": { "unit": "rem" } },
+      "400": { "value": "33px", "attributes": { "unit": "rem" } },
+      "500": { "value": "46px", "attributes": { "unit": "rem" } },
+      "600": { "value": "52px", "attributes": { "unit": "rem" } }
+    },
+    "line_height": {
+      "1": { "value": "16px", "attributes": { "unit": "rem" } },
+      "2": { "value": "24px", "attributes": { "unit": "rem" } },
+      "3": { "value": "32px", "attributes": { "unit": "rem" } },
+      "4": { "value": "40px", "attributes": { "unit": "rem" } },
+      "5": { "value": "56px", "attributes": { "unit": "rem" } },
+      "6": { "value": "64px", "attributes": { "unit": "rem" } }
     },
     "weight": {
       "normal": { "value": "400" },
       "medium": { "value": "500" },
       "semibold": { "value": "600" },
       "bold": { "value": "700" }
-    },
-    "line_height": {
-      "none": { "value": "1" },
-      "tight": { "value": "1.25" },
-      "normal": { "value": "1.5" },
-      "relaxed": { "value": "1.7" }
     },
     "letter_spacing": {
       "tighten_6": { "value": "-1.5px", "attributes": { "unit": "rem" } },

--- a/easy-ui-tokens/src/font/styles.json
+++ b/easy-ui-tokens/src/font/styles.json
@@ -3,7 +3,7 @@
     "style": {
       "heading1": {
         "family": { "value": "{font.family.sans.value}" },
-        "weight": { "value": "{font.weight.normal.value}" },
+        "weight": { "value": "{font.weight.medium.value}" },
         "size": { "value": "{font.size.600.value}" },
         "letter_spacing": {
           "value": "{font.letter_spacing.tighten_5.value}"
@@ -12,7 +12,7 @@
       },
       "heading2": {
         "family": { "value": "{font.family.sans.value}" },
-        "weight": { "value": "{font.weight.normal.value}" },
+        "weight": { "value": "{font.weight.medium.value}" },
         "size": { "value": "{font.size.500.value}" },
         "letter_spacing": {
           "value": "{font.letter_spacing.normal.value}"
@@ -108,6 +108,15 @@
           "value": "{font.letter_spacing.normal.value}"
         },
         "line_height": { "value": "{font.line_height.2.value}" }
+      },
+      "small_button": {
+        "family": { "value": "{font.family.sans.value}" },
+        "weight": { "value": "{font.weight.medium.value}" },
+        "size": { "value": "{font.size.50.value}" },
+        "letter_spacing": {
+          "value": "{font.letter_spacing.normal.value}"
+        },
+        "line_height": { "value": "{font.line_height.1.value}" }
       }
     }
   }

--- a/easy-ui-tokens/src/font/styles.json
+++ b/easy-ui-tokens/src/font/styles.json
@@ -4,110 +4,110 @@
       "heading1": {
         "family": { "value": "{font.family.sans.value}" },
         "weight": { "value": "{font.weight.normal.value}" },
-        "size": { "value": "{font.size.4xl.value}" },
+        "size": { "value": "{font.size.600.value}" },
         "letter_spacing": {
           "value": "{font.letter_spacing.tighten_5.value}"
         },
-        "line_height": { "value": "{font.line_height.tight.value}" }
+        "line_height": { "value": "{font.line_height.6.value}" }
       },
       "heading2": {
         "family": { "value": "{font.family.sans.value}" },
         "weight": { "value": "{font.weight.normal.value}" },
-        "size": { "value": "{font.size.3xl.value}" },
+        "size": { "value": "{font.size.500.value}" },
         "letter_spacing": {
           "value": "{font.letter_spacing.normal.value}"
         },
-        "line_height": { "value": "{font.line_height.tight.value}" }
+        "line_height": { "value": "{font.line_height.5.value}" }
       },
       "heading3": {
         "family": { "value": "{font.family.sans.value}" },
         "weight": { "value": "{font.weight.normal.value}" },
-        "size": { "value": "{font.size.2xl.value}" },
+        "size": { "value": "{font.size.400.value}" },
         "letter_spacing": {
           "value": "{font.letter_spacing.widen_3.value}"
         },
-        "line_height": { "value": "{font.line_height.tight.value}" }
+        "line_height": { "value": "{font.line_height.4.value}" }
       },
       "heading4": {
         "family": { "value": "{font.family.sans.value}" },
         "weight": { "value": "{font.weight.normal.value}" },
-        "size": { "value": "{font.size.xl.value}" },
+        "size": { "value": "{font.size.300.value}" },
         "letter_spacing": {
           "value": "{font.letter_spacing.normal.value}"
         },
-        "line_height": { "value": "{font.line_height.tight.value}" }
+        "line_height": { "value": "{font.line_height.3.value}" }
       },
       "heading5": {
         "family": { "value": "{font.family.sans.value}" },
         "weight": { "value": "{font.weight.semibold.value}" },
-        "size": { "value": "{font.size.lg.value}" },
+        "size": { "value": "{font.size.200.value}" },
         "letter_spacing": {
           "value": "{font.letter_spacing.widen_2.value}"
         },
-        "line_height": { "value": "{font.line_height.normal.value}" }
+        "line_height": { "value": "{font.line_height.2.value}" }
       },
       "subtitle1": {
         "family": { "value": "{font.family.sans.value}" },
         "weight": { "value": "{font.weight.semibold.value}" },
-        "size": { "value": "{font.size.sm.value}" },
+        "size": { "value": "{font.size.100.value}" },
         "letter_spacing": {
           "value": "{font.letter_spacing.widen_2.value}"
         },
-        "line_height": { "value": "{font.line_height.normal.value}" }
+        "line_height": { "value": "{font.line_height.2.value}" }
       },
       "subtitle2": {
         "family": { "value": "{font.family.sans.value}" },
         "weight": { "value": "{font.weight.medium.value}" },
-        "size": { "value": "{font.size.xs.value}" },
+        "size": { "value": "{font.size.75.value}" },
         "letter_spacing": {
           "value": "{font.letter_spacing.widen_1.value}"
         },
-        "line_height": { "value": "{font.line_height.normal.value}" }
+        "line_height": { "value": "{font.line_height.1.value}" }
       },
       "body1": {
         "family": { "value": "{font.family.sans.value}" },
         "weight": { "value": "{font.weight.normal.value}" },
-        "size": { "value": "{font.size.sm.value}" },
+        "size": { "value": "{font.size.100.value}" },
         "letter_spacing": {
           "value": "{font.letter_spacing.widen_5.value}"
         },
-        "line_height": { "value": "{font.line_height.normal.value}" }
+        "line_height": { "value": "{font.line_height.2.value}" }
       },
       "body2": {
         "family": { "value": "{font.family.sans.value}" },
         "weight": { "value": "{font.weight.normal.value}" },
-        "size": { "value": "{font.size.xs.value}" },
+        "size": { "value": "{font.size.75.value}" },
         "letter_spacing": {
           "value": "{font.letter_spacing.widen_3.value}"
         },
-        "line_height": { "value": "{font.line_height.relaxed.value}" }
+        "line_height": { "value": "{font.line_height.1.value}" }
       },
       "caption": {
         "family": { "value": "{font.family.sans.value}" },
         "weight": { "value": "{font.weight.normal.value}" },
-        "size": { "value": "{font.size.2xs.value}" },
+        "size": { "value": "{font.size.50.value}" },
         "letter_spacing": {
           "value": "{font.letter_spacing.widen_4.value}"
         },
-        "line_height": { "value": "{font.line_height.relaxed.value}" }
+        "line_height": { "value": "{font.line_height.1.value}" }
       },
       "overline": {
         "family": { "value": "{font.family.sans.value}" },
         "weight": { "value": "{font.weight.normal.value}" },
-        "size": { "value": "{font.size.3xs.value}" },
+        "size": { "value": "{font.size.25.value}" },
         "letter_spacing": {
           "value": "{font.letter_spacing.widen_6.value}"
         },
-        "line_height": { "value": "{font.line_height.relaxed.value}" }
+        "line_height": { "value": "{font.line_height.1.value}" }
       },
       "button": {
         "family": { "value": "{font.family.sans.value}" },
         "weight": { "value": "{font.weight.medium.value}" },
-        "size": { "value": "{font.size.base.value}" },
+        "size": { "value": "{font.size.100.value}" },
         "letter_spacing": {
           "value": "{font.letter_spacing.normal.value}"
         },
-        "line_height": { "value": "{font.line_height.normal.value}" }
+        "line_height": { "value": "{font.line_height.2.value}" }
       }
     }
   }


### PR DESCRIPTION
- Uses updated typography values per spec from Rachel
- Adjusts the scale to be numeric
- `line_height` uses `rem` instead of unitless values (which are usually preferred) to snap to our pixel grid. recommendations for use in long form copy is TBD