### PR TITLE
Set up dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    versioning-strategy: increase
+    # # Disable version checks while keeping dependabot config
+    # open-pull-requests-limit: 0
+    # ignore:
+    #   # Ignore updates to packages that start with 'aws'
+    #   # Wildcards match zero or more arbitrary characters
+    #   - dependency-name: "aws*"
+    #   # Ignore some updates to the 'express' package
+    #   - dependency-name: "express"
+    #     # Ignore only new versions for 4.x and 5.x
+    #     versions: ["4.x", "5.x"]
+    #   # For all packages, ignore all patch updates
+    #   - dependency-name: "*"
+    #     update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
Sets up the repo to check for dependency updates based on the defined package manifest configurations in the repo. Will create pull requests for each dependency update. This will help the repo not to go stale on our dependency versions, which is easy to do without an active process like this.

- Set to a `daily` schedule, which is recommended for initial usage. Can bump to a longer cadence after initial set of processing
- Set to update the `package-lock.json` file as well with the `increase` version strategy
- Includes commented out lines for understanding how to ignore certain dependencies or pause the integration
- This likely will initially create a lot of pull requests (within the default `5` limit) but should normalize after the initial set. May want to disable our Slack Github integration when merging