### PR TITLE
Skip running chromatic on dependabot pull requests

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -3,6 +3,7 @@ on: push
 jobs:
   deployment:
     runs-on: ubuntu-latest
+    if: ${{ github.triggering_actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js v16


### PR DESCRIPTION
Only run CI and not automatically publish to Chromatic on dependabot builds. Chromatic can still be manually triggered if needed.