### PR TITLE
use UnstyledButton in Button, DropdownButton, and IconButton

### DIFF
--- a/.changeset/fresh-kids-peel.md
+++ b/.changeset/fresh-kids-peel.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+Use `UnstyledButton` to carry core button logic for `Button`, `DropdownButton`, and `IconButton`

--- a/documentation/specs/Button.md
+++ b/documentation/specs/Button.md
@@ -67,7 +67,7 @@ export type ButtonProps = {
 ### Example Usage
 
 ```tsx
-import Button from "@easypost/easy-ui/Button";
+import { Button } from "@easypost/easy-ui/Button";
 import AddIcon from "@easypost/easy-ui-icons/Add";
 // Filled
 <Button color="primary" />

--- a/documentation/specs/DropdownButton.md
+++ b/documentation/specs/DropdownButton.md
@@ -41,7 +41,7 @@ export type DropdownButtonProps = {
 ### Example Usage
 
 ```tsx
-import DropdownButton from "@easypost/easy-ui/DropdownButton";
+import { DropdownButton } from "@easypost/easy-ui/DropdownButton";
 // Filled
 <DropdownButton color="primary" />
 <DropdownButton color="secondary" />

--- a/documentation/specs/IconButton.md
+++ b/documentation/specs/IconButton.md
@@ -40,7 +40,7 @@ export type IconButtonProps = {
 ### Example Usage
 
 ```tsx
-import IconButton from "@easypost/easy-ui/IconButton";
+import { IconButton } from "@easypost/easy-ui/IconButton";
 import Icon from "@easypost/easy-ui/Icon"
 import ArrowBackIcon from "@easypost/easy-ui-icons/ArrowBack";
 // Filled

--- a/easy-ui-react/src/Button/Button.tsx
+++ b/easy-ui-react/src/Button/Button.tsx
@@ -1,5 +1,4 @@
-import { mergeRefs } from "@react-aria/utils";
-import React, { ReactNode, forwardRef, useRef } from "react";
+import React, { ReactNode, forwardRef } from "react";
 import { UnstyledButton } from "../UnstyledButton";
 import { Icon } from "../Icon";
 import { IconSymbol } from "../types";
@@ -56,8 +55,6 @@ export const Button = forwardRef<null, ButtonProps>((props, inRef) => {
     ...restProps
   } = props;
 
-  const ref = useRef(null);
-
   const bothIconPropsDefined = iconAtEnd && iconAtStart;
   if (bothIconPropsDefined) {
     // eslint-disable-next-line no-console
@@ -75,7 +72,7 @@ export const Button = forwardRef<null, ButtonProps>((props, inRef) => {
   return (
     <UnstyledButton
       isDisabled={isDisabled}
-      ref={mergeRefs(ref, inRef)}
+      ref={inRef}
       className={classNames(
         styles.Button,
         styles[variationName("color", color)],

--- a/easy-ui-react/src/Button/Button.tsx
+++ b/easy-ui-react/src/Button/Button.tsx
@@ -1,13 +1,11 @@
 import { mergeRefs } from "@react-aria/utils";
 import React, { ReactNode, forwardRef, useRef } from "react";
-import { AriaButtonProps, mergeProps, useButton } from "react-aria";
+import { UnstyledButton } from "../UnstyledButton";
 import { Icon } from "../Icon";
 import { IconSymbol } from "../types";
 import { classNames, variationName } from "../utilities/css";
-import {
-  omitReactAriaSpecificProps,
-  logWarningIfInvalidColorVariantCombination,
-} from "./utilities";
+import { AriaButtonProps } from "react-aria";
+import { logWarningIfInvalidColorVariantCombination } from "./utilities";
 
 import styles from "./Button.module.scss";
 
@@ -59,11 +57,6 @@ export const Button = forwardRef<null, ButtonProps>((props, inRef) => {
   } = props;
 
   const ref = useRef(null);
-  const As = href ? "a" : "button";
-  const { buttonProps: elementProps } = useButton(
-    { ...props, elementType: As },
-    ref,
-  );
 
   const bothIconPropsDefined = iconAtEnd && iconAtStart;
   if (bothIconPropsDefined) {
@@ -80,9 +73,8 @@ export const Button = forwardRef<null, ButtonProps>((props, inRef) => {
   logWarningIfInvalidColorVariantCombination(color, variant);
 
   return (
-    <As
-      {...mergeProps(omitReactAriaSpecificProps(restProps), elementProps)}
-      disabled={isDisabled}
+    <UnstyledButton
+      isDisabled={isDisabled}
       ref={mergeRefs(ref, inRef)}
       className={classNames(
         styles.Button,
@@ -91,6 +83,8 @@ export const Button = forwardRef<null, ButtonProps>((props, inRef) => {
         styles[variationName("size", size)],
         isBlock && styles.block,
       )}
+      href={href}
+      {...restProps}
     >
       {iconAtStart && canUseIcon && <Icon symbol={iconAtStart} />}
       <span
@@ -102,7 +96,7 @@ export const Button = forwardRef<null, ButtonProps>((props, inRef) => {
         {children}
       </span>
       {iconAtEnd && canUseIcon && <Icon symbol={iconAtEnd} />}
-    </As>
+    </UnstyledButton>
   );
 });
 

--- a/easy-ui-react/src/DropdownButton/DropdownButton.tsx
+++ b/easy-ui-react/src/DropdownButton/DropdownButton.tsx
@@ -1,15 +1,13 @@
 import ExpandMoreIcon400 from "@easypost/easy-ui-icons/ExpandMore400";
 import { mergeRefs } from "@react-aria/utils";
 import React, { ReactNode, forwardRef, useRef } from "react";
-import { AriaButtonProps, mergeProps, useButton } from "react-aria";
+import { AriaButtonProps } from "react-aria";
 import { ButtonColor } from "../Button";
-import {
-  omitReactAriaSpecificProps,
-  logWarningIfInvalidColorVariantCombination,
-} from "../Button/utilities";
+import { logWarningIfInvalidColorVariantCombination } from "../Button/utilities";
 import { Icon } from "../Icon";
 import { classNames, variationName } from "../utilities/css";
 import styles from "./DropdownButton.module.scss";
+import { UnstyledButton } from "../UnstyledButton";
 
 export type DropdownButtonVariant = "filled" | "outlined";
 
@@ -35,25 +33,24 @@ export const DropdownButton = forwardRef<null, DropdownButtonProps>(
     } = props;
 
     const ref = useRef(null);
-    const { buttonProps } = useButton(props, ref);
 
     logWarningIfInvalidColorVariantCombination(color, variant);
 
     return (
-      <button
-        {...mergeProps(omitReactAriaSpecificProps(restProps), buttonProps)}
-        disabled={isDisabled}
+      <UnstyledButton
+        isDisabled={isDisabled}
         ref={mergeRefs(ref, inRef)}
         className={classNames(
           styles.DropdownButton,
           styles[variationName("variant", variant)],
           styles[variationName("color", color)],
         )}
+        {...restProps}
       >
         <span>{children}</span>
         <span className={classNames(styles.pipeSeparator)}></span>
         <Icon symbol={ExpandMoreIcon400} />
-      </button>
+      </UnstyledButton>
     );
   },
 );

--- a/easy-ui-react/src/DropdownButton/DropdownButton.tsx
+++ b/easy-ui-react/src/DropdownButton/DropdownButton.tsx
@@ -1,6 +1,5 @@
 import ExpandMoreIcon400 from "@easypost/easy-ui-icons/ExpandMore400";
-import { mergeRefs } from "@react-aria/utils";
-import React, { ReactNode, forwardRef, useRef } from "react";
+import React, { ReactNode, forwardRef } from "react";
 import { AriaButtonProps } from "react-aria";
 import { ButtonColor } from "../Button";
 import { logWarningIfInvalidColorVariantCombination } from "../Button/utilities";
@@ -32,14 +31,12 @@ export const DropdownButton = forwardRef<null, DropdownButtonProps>(
       ...restProps
     } = props;
 
-    const ref = useRef(null);
-
     logWarningIfInvalidColorVariantCombination(color, variant);
 
     return (
       <UnstyledButton
         isDisabled={isDisabled}
-        ref={mergeRefs(ref, inRef)}
+        ref={inRef}
         className={classNames(
           styles.DropdownButton,
           styles[variationName("variant", variant)],

--- a/easy-ui-react/src/IconButton/IconButton.tsx
+++ b/easy-ui-react/src/IconButton/IconButton.tsx
@@ -1,5 +1,4 @@
-import { mergeRefs } from "@react-aria/utils";
-import React, { forwardRef, useRef } from "react";
+import React, { forwardRef } from "react";
 import { AriaButtonProps } from "react-aria";
 import { ButtonColor } from "../Button";
 import { logWarningIfInvalidColorVariantCombination } from "../Button/utilities";
@@ -35,14 +34,12 @@ export const IconButton = forwardRef<null, IconButtonProps>((props, inRef) => {
     ...restProps
   } = props;
 
-  const ref = useRef(null);
-
   logWarningIfInvalidColorVariantCombination(color, variant);
 
   return (
     <UnstyledButton
       isDisabled={isDisabled}
-      ref={mergeRefs(ref, inRef)}
+      ref={inRef}
       className={classNames(
         styles.IconButton,
         styles[variationName("variant", variant)],

--- a/easy-ui-react/src/IconButton/IconButton.tsx
+++ b/easy-ui-react/src/IconButton/IconButton.tsx
@@ -1,16 +1,14 @@
 import { mergeRefs } from "@react-aria/utils";
 import React, { forwardRef, useRef } from "react";
-import { AriaButtonProps, mergeProps, useButton } from "react-aria";
+import { AriaButtonProps } from "react-aria";
 import { ButtonColor } from "../Button";
-import {
-  omitReactAriaSpecificProps,
-  logWarningIfInvalidColorVariantCombination,
-} from "../Button/utilities";
+import { logWarningIfInvalidColorVariantCombination } from "../Button/utilities";
 import { Icon } from "../Icon";
 import { Text } from "../Text";
 import { IconSymbol } from "../types";
 import { classNames, variationName } from "../utilities/css";
 import styles from "./IconButton.module.scss";
+import { UnstyledButton } from "../UnstyledButton";
 
 export type IconButtonVariant = "filled" | "outlined";
 
@@ -38,24 +36,23 @@ export const IconButton = forwardRef<null, IconButtonProps>((props, inRef) => {
   } = props;
 
   const ref = useRef(null);
-  const { buttonProps } = useButton(props, ref);
 
   logWarningIfInvalidColorVariantCombination(color, variant);
 
   return (
-    <button
-      {...mergeProps(omitReactAriaSpecificProps(restProps), buttonProps)}
-      disabled={isDisabled}
+    <UnstyledButton
+      isDisabled={isDisabled}
       ref={mergeRefs(ref, inRef)}
       className={classNames(
         styles.IconButton,
         styles[variationName("variant", variant)],
         styles[variationName("color", color)],
       )}
+      {...restProps}
     >
       <Text visuallyHidden>{accessibilityLabel}</Text>
       <Icon symbol={icon} />
-    </button>
+    </UnstyledButton>
   );
 });
 


### PR DESCRIPTION
- uses `UnstyledButton` in `Button`, `DropdownButton`, and `IconButton` to DRY up code and defer core button logic to the `UnstyledButton` component