### PR TITLE
Create pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,10 @@
-## Changes
+## 📝 Changes
 
 Please provide a brief summary of the changes made and why they were made.
 
 Include any notes, screenshots, or videos that may be helpful for developers reviewing this pull request.
 
-## Checklist
+## ✅ Checklist
 
 - [ ] Visuals are complete and match Figma
 - [ ] Code is complete and in accordance with our style guide

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Changes
+
+Please provide a brief summary of the changes made and why they were made.
+
+Include any notes, screenshots, or videos that may be helpful for developers reviewing this pull request.
+
+## Checklist
+
+- [ ] Visuals are complete and match Figma
+- [ ] Code is complete and in accordance with our style guide
+- [ ] Design and theme tokens are audited for any relevant changes
+- [ ] Unit tests are written and passing
+- [ ] TSDoc is written or updated for any component API surface area
+- [ ] Stories in Storybook accompany any relevant component changes
+- [ ] Specs and documentation are up-to-date
+- [ ] Cross-browser check is performed (Chrome, Safari, Firefox)
+- [ ] Changeset is added


### PR DESCRIPTION
I looked into creating multiple PR templates and you have to use query parameters to specify the template when creating a pull request, which feels a little too complicated for now.

I think this PR template won't be relevant for all PRs, mostly for component ones, but we can always simply edit it when creating a PR if it's not relevant. So using it as the default makes sense to me for now. We can adjust as we use it.

Thoughts on the emojis? lol. I'm not super great at picking emojis to use so any input is welcome there.