### PR TITLE
Add automerge to dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,7 +1,8 @@
-name: Dependabot auto-approve
+name: Dependabot
 on: pull_request
 
 permissions:
+  contents: write
   pull-requests: write
 
 jobs:
@@ -16,6 +17,12 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve PR
         run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Merge PR
+        if: ${{!contains(steps.metadata.outputs.dependency-names, 'storybook') && (steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor')}}
+        run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -6,7 +6,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  dependabot:
+  approve-and-merge:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:


### PR DESCRIPTION
## 📝 Changes

Adds auto merging to dependabot workflow after approval. Only runs for non-storybook minor/patch packages. Tested as much as I could using [act](https://github.com/nektos/act) locally.