### PR TITLE
add plugin to remove test attributes in build

### DIFF
--- a/easy-ui-react/package.json
+++ b/easy-ui-react/package.json
@@ -59,6 +59,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "sass": "^1.63.4",
+    "vite-plugin-react-remove-attributes": "^1.0.3",
     "vite-plugin-static-copy": "^0.16.0"
   }
 }

--- a/easy-ui-react/vite.config.ts
+++ b/easy-ui-react/vite.config.ts
@@ -4,10 +4,14 @@ import react from "@vitejs/plugin-react";
 import { glob } from "glob";
 import { defineConfig } from "vite";
 import { viteStaticCopy } from "vite-plugin-static-copy";
+import VitePluginReactRemoveAttributes from "vite-plugin-react-remove-attributes";
 import { cleanPkgJsonForDist } from "../scripts/copyDistFiles.mjs";
 
 export default defineConfig({
   plugins: [
+    VitePluginReactRemoveAttributes({
+      attributes: ["data-testid"],
+    }),
     react({ jsxRuntime: "classic" }),
     viteStaticCopy({
       targets: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -154,6 +154,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "sass": "^1.63.4",
+        "vite-plugin-react-remove-attributes": "^1.0.3",
         "vite-plugin-static-copy": "^0.16.0"
       },
       "peerDependencies": {
@@ -21746,6 +21747,15 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/vite-plugin-react-remove-attributes": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-remove-attributes/-/vite-plugin-react-remove-attributes-1.0.3.tgz",
+      "integrity": "sha512-f+ox+GFeqyBHzOe94Tcf1knFXEYWMhOGH04glIZRoXoIXQJD23Z1KFgQ7/JwOoLydsvQTlGzUJ/BpLeL7lh2LQ==",
+      "dev": true,
+      "peerDependencies": {
+        "vite": "^2.4.4"
+      }
+    },
     "node_modules/vite-plugin-static-copy": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-0.16.0.tgz",
@@ -25076,6 +25086,7 @@
         "react-stately": "^3.23.0",
         "react-syntax-highlighter": "^15.5.0",
         "sass": "^1.63.4",
+        "vite-plugin-react-remove-attributes": "^1.0.3",
         "vite-plugin-static-copy": "^0.16.0"
       },
       "dependencies": {
@@ -37423,6 +37434,12 @@
         "picocolors": "^1.0.0",
         "vite": "^3.0.0 || ^4.0.0"
       }
+    },
+    "vite-plugin-react-remove-attributes": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-remove-attributes/-/vite-plugin-react-remove-attributes-1.0.3.tgz",
+      "integrity": "sha512-f+ox+GFeqyBHzOe94Tcf1knFXEYWMhOGH04glIZRoXoIXQJD23Z1KFgQ7/JwOoLydsvQTlGzUJ/BpLeL7lh2LQ==",
+      "dev": true
     },
     "vite-plugin-static-copy": {
       "version": "0.16.0",


### PR DESCRIPTION
## 📝 Changes

- adds [vite-plugin-react-remove-attributes](https://github.com/l-mbert/vite-plugin-react-remove-attributes) as a dev dep to `easy-ui-react` to remove `data-testid` from prod build

before:
![before](https://github.com/EasyPost/easy-ui/assets/44451175/ab3de97f-c3a7-4ff6-8228-d52a849e694b)

after:
![after](https://github.com/EasyPost/easy-ui/assets/44451175/6a5d0fec-2ec4-456b-b959-b9b39f1fbc72)


