### PR TITLE
Add `<Tooltip />` max width

### DIFF
--- a/.changeset/fifty-years-relate.md
+++ b/.changeset/fifty-years-relate.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": minor
+---
+
+Add max width to `<Tooltip />`

--- a/easy-ui-react/src/Tooltip/Tooltip.mdx
+++ b/easy-ui-react/src/Tooltip/Tooltip.mdx
@@ -34,6 +34,12 @@ By default, tooltips show on mouse hover and keyboard focus. They can be set to 
 
 <Canvas of={TooltipStories.FocusOnly} />
 
+## Long Text
+
+Tooltips will wrap long lines of text.
+
+<Canvas of={TooltipStories.LongText} />
+
 ## Button as Trigger
 
 Tooltips can be attached to focusable Easy UI elements.

--- a/easy-ui-react/src/Tooltip/Tooltip.module.scss
+++ b/easy-ui-react/src/Tooltip/Tooltip.module.scss
@@ -18,6 +18,7 @@
     "shadow",
     theme-token("shadow.overlay.subdued")
   );
+  @include component-token("tooltip", "max-width", 232px);
 
   background: component-token("tooltip", "background");
   border-radius: component-token("tooltip", "border_radius");
@@ -25,7 +26,10 @@
   display: inline-flex;
   filter: drop-shadow(#{component-token("tooltip", "shadow")});
   max-width: calc(
-    100% - (#{component-token("tooltip", "container_padding")} * 2)
+    #{component-token("tooltip", "max-width")} - (#{component-token(
+            "tooltip",
+            "container_padding"
+          )} * 2)
   );
   padding: design-token("space.1");
   will-change: filter;

--- a/easy-ui-react/src/Tooltip/Tooltip.stories.tsx
+++ b/easy-ui-react/src/Tooltip/Tooltip.stories.tsx
@@ -88,6 +88,13 @@ export const FocusOnly: Story = {
   },
 };
 
+export const LongText: Story = {
+  render: Template.bind({}),
+  args: {
+    content: "This is a really long tooltip that wraps to the next line",
+  },
+};
+
 export const ButtonTrigger: Story = {
   render: Template.bind({}),
   args: {


### PR DESCRIPTION
## 📝 Changes

- Per design, set max width for tooltip to `232px`
- Since this is a visual change, no tests were added/modified
- Added tooltip story for long content to show max width

## ✅ Checklist

- [x] Visuals are complete and match Figma
- [x] Code is complete and in accordance with our style guide
- [x] Design and theme tokens are audited for any relevant changes
- [x] Unit tests are written and passing
- [x] TSDoc is written or updated for any component API surface area
- [x] Stories in Storybook accompany any relevant component changes
- [x] Ensure no accessibility violations are reported in Storybook
- [x] Specs and documentation are up-to-date
- [x] Cross-browser check is performed (Chrome, Safari, Firefox)
- [x] Changeset is added
