### PR TITLE
fix(TextField,Textarea): pass all properties through to InputField

### DIFF
--- a/.changeset/dirty-pillows-love.md
+++ b/.changeset/dirty-pillows-love.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+fix(TextField,Textarea): pass all properties through to InputField

--- a/easy-ui-react/src/TextField/TextField.test.tsx
+++ b/easy-ui-react/src/TextField/TextField.test.tsx
@@ -1,9 +1,19 @@
-import { render, screen } from "@testing-library/react";
 import SearchIcon from "@easypost/easy-ui-icons/Search";
+import { screen } from "@testing-library/react";
 import React from "react";
+import { vi } from "vitest";
+import { render } from "../utilities/test";
 import { TextField } from "./TextField";
 
 describe("<TextField />", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("should render a standard textfield", () => {
     render(<TextField label="label" />);
     expect(
@@ -55,5 +65,24 @@ describe("<TextField />", () => {
     render(<TextField label="label" isLabelEmphasized />);
     expect(screen.getByText("label")).toBeInTheDocument();
     expect(screen.getByText("label").tagName).toBe("STRONG");
+  });
+
+  it("should support passing through properties", async () => {
+    const handleChange = vi.fn();
+    const { user } = render(
+      <TextField
+        label="label"
+        defaultValue="test"
+        onChange={handleChange}
+        data-custom-attribute="text"
+      />,
+    );
+    expect(screen.getByLabelText("label")).toHaveValue("test");
+    const textField = screen.getByLabelText("label");
+    await user.type(textField, "value");
+    expect(handleChange).toBeCalled();
+    expect(screen.getByLabelText("label")).toHaveAttribute(
+      "data-custom-attribute",
+    );
   });
 });

--- a/easy-ui-react/src/TextField/TextField.tsx
+++ b/easy-ui-react/src/TextField/TextField.tsx
@@ -118,16 +118,8 @@ export function TextField(props: TextFieldProps) {
     validationState = "valid",
     isLabelEmphasized = false,
     autoFocus = false,
-    label,
-    errorText,
-    helperText,
-    placeholder,
-    value,
-    defaultValue,
-    iconAtStart,
-    iconAtEnd,
+    ...restProps
   } = props;
-
   return (
     <InputField
       type={type}
@@ -138,14 +130,7 @@ export function TextField(props: TextFieldProps) {
       validationState={validationState}
       isLabelEmphasized={isLabelEmphasized}
       autoFocus={autoFocus}
-      label={label}
-      errorText={errorText}
-      helperText={helperText}
-      placeholder={placeholder}
-      value={value}
-      defaultValue={defaultValue}
-      iconAtStart={iconAtStart}
-      iconAtEnd={iconAtEnd}
+      {...restProps}
     />
   );
 }

--- a/easy-ui-react/src/Textarea/Textarea.test.tsx
+++ b/easy-ui-react/src/Textarea/Textarea.test.tsx
@@ -1,8 +1,18 @@
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import React from "react";
+import { vi } from "vitest";
+import { render } from "../utilities/test";
 import { Textarea } from "./Textarea";
 
 describe("<Textarea />", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("should render a standard textarea", () => {
     render(<Textarea label="label" />);
     expect(
@@ -44,5 +54,24 @@ describe("<Textarea />", () => {
     render(<Textarea label="label" isLabelEmphasized />);
     expect(screen.getByText("label")).toBeInTheDocument();
     expect(screen.getByText("label").tagName).toBe("STRONG");
+  });
+
+  it("should support passing through properties", async () => {
+    const handleChange = vi.fn();
+    const { user } = render(
+      <Textarea
+        label="label"
+        defaultValue="test"
+        onChange={handleChange}
+        data-custom-attribute="text"
+      />,
+    );
+    expect(screen.getByLabelText("label")).toHaveValue("test");
+    const textField = screen.getByLabelText("label");
+    await user.type(textField, "value");
+    expect(handleChange).toBeCalled();
+    expect(screen.getByLabelText("label")).toHaveAttribute(
+      "data-custom-attribute",
+    );
   });
 });

--- a/easy-ui-react/src/Textarea/Textarea.tsx
+++ b/easy-ui-react/src/Textarea/Textarea.tsx
@@ -98,13 +98,8 @@ export function Textarea(props: TextareaProps) {
     validationState = "valid",
     isLabelEmphasized = false,
     autoFocus = false,
-    label,
-    errorText,
-    helperText,
-    placeholder,
-    value,
-    defaultValue,
     rows = 1,
+    ...restProps
   } = props;
   return (
     <InputField
@@ -116,13 +111,8 @@ export function Textarea(props: TextareaProps) {
       validationState={validationState}
       isLabelEmphasized={isLabelEmphasized}
       autoFocus={autoFocus}
-      label={label}
-      errorText={errorText}
-      helperText={helperText}
-      placeholder={placeholder}
-      value={value}
-      defaultValue={defaultValue}
       rows={rows}
+      {...restProps}
     />
   );
 }


### PR DESCRIPTION
## 📝 Changes

- Passes properties through to `InputField`. Fixes problem of consumers not having their events registered
- Adds tests for use case

## ✅ Checklist

- [x] Code is complete and in accordance with our style guide
- [x] Unit tests are written and passing
- [x] Changeset is added
- [x] Cross-browser check is performed (Chrome, Safari, Firefox)
