### PR TITLE
fix(Card): card area should behave rules of parent layout

### DIFF
--- a/.changeset/tidy-pans-lick.md
+++ b/.changeset/tidy-pans-lick.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+fix(Card): card area should behave rules of parent layout

--- a/.changeset/tidy-pans-lick.md
+++ b/.changeset/tidy-pans-lick.md
@@ -2,4 +2,4 @@
 "@easypost/easy-ui": patch
 ---
 
-fix(Card): card area should behave rules of parent layout
+fix(Card): Card area behavior should follow the rules of their parent layout

--- a/easy-ui-react/src/Card/Card.mdx
+++ b/easy-ui-react/src/Card/Card.mdx
@@ -85,7 +85,7 @@ To create a card with two columns, for instance, use `<Card.Container />` and `<
 
 ### Layouts
 
-Card content should behave the rules of their parent layouts.
+Card content behavior should follow the rules of their parent layouts.
 
 In the example below, a `HorizontalGrid` is set to stretch each `Card` to the height of the tallest `Card` in the row. `Card` content will behave that rule and stretch with it.
 

--- a/easy-ui-react/src/Card/Card.mdx
+++ b/easy-ui-react/src/Card/Card.mdx
@@ -85,9 +85,11 @@ To create a card with two columns, for instance, use `<Card.Container />` and `<
 
 ### Layouts
 
-Cards should behave the rules of their parent layouts.
+Card content should behave the rules of their parent layouts.
 
-<Canvas of={CardStories.ExampleLayouts} />
+In the example below, a `HorizontalGrid` is set to stretch each `Card` to the height of the tallest `Card` in the row. `Card` content will behave that rule and stretch with it.
+
+<Canvas of={CardStories.ExampleStretch} />
 
 ## Properties
 

--- a/easy-ui-react/src/Card/Card.mdx
+++ b/easy-ui-react/src/Card/Card.mdx
@@ -83,6 +83,12 @@ To create a card with two columns, for instance, use `<Card.Container />` and `<
 
 <Canvas of={CardStories.ExampleCallout} />
 
+### Layouts
+
+Cards should behave the rules of their parent layouts.
+
+<Canvas of={CardStories.ExampleLayouts} />
+
 ## Properties
 
 ### Card

--- a/easy-ui-react/src/Card/Card.module.scss
+++ b/easy-ui-react/src/Card/Card.module.scss
@@ -15,7 +15,12 @@ button.container:not([disabled]) {
 .area {
   @include responsive-prop("card-area", "padding", padding);
   background: component-token("card-area", "background");
+  display: flex;
+  flex-direction: column;
   min-height: 100%;
+  > * {
+    flex: 1 0 auto;
+  }
 }
 
 .variantOutlined,

--- a/easy-ui-react/src/Card/Card.module.scss
+++ b/easy-ui-react/src/Card/Card.module.scss
@@ -15,6 +15,7 @@ button.container:not([disabled]) {
 .area {
   @include responsive-prop("card-area", "padding", padding);
   background: component-token("card-area", "background");
+  min-height: 100%;
 }
 
 .variantOutlined,

--- a/easy-ui-react/src/Card/Card.stories.tsx
+++ b/easy-ui-react/src/Card/Card.stories.tsx
@@ -261,54 +261,24 @@ export const ExampleCallout: Story = {
   ),
 };
 
-export const ExampleLayouts: Story = {
+export const ExampleStretch: Story = {
   render: () => (
-    <VerticalStack gap="4">
-      <VerticalStack gap="2">
-        <Text variant="subtitle1">Stretch-aligned Horizontal Grid</Text>
-        <HorizontalGrid columns={2} gap="2">
-          <Card background="secondary">
-            <div>
-              This card&apos;s area should behave rules of parent layout
-            </div>
-          </Card>
-          <Card>
-            <div style={{ border: "1px solid", height: 200 }}>
-              Content with a height set to 200px
-            </div>
-          </Card>
-        </HorizontalGrid>
-      </VerticalStack>
-      <VerticalStack gap="2">
-        <Text variant="subtitle1">Center-aligned Horizontal Grid</Text>
-        <HorizontalGrid columns={2} gap="2" alignItems="center">
-          <Card background="secondary">
-            <div>
-              This card&apos;s area should behave rules of parent layout
-            </div>
-          </Card>
-          <Card>
-            <div style={{ border: "1px solid", height: 200 }}>
-              Content with a height set to 200px
-            </div>
-          </Card>
-        </HorizontalGrid>
-      </VerticalStack>
-      <VerticalStack gap="2">
-        <Text variant="subtitle1">Bottom-aligned Horizontal Grid</Text>
-        <HorizontalGrid columns={2} gap="2" alignItems="end">
-          <Card background="secondary">
-            <div>
-              This card&apos;s area should behave rules of parent layout
-            </div>
-          </Card>
-          <Card>
-            <div style={{ border: "1px solid", height: 200 }}>
-              Content with a height set to 200px
-            </div>
-          </Card>
-        </HorizontalGrid>
-      </VerticalStack>
-    </VerticalStack>
+    <HorizontalGrid columns={2} gap="2">
+      <Card background="secondary">
+        <VerticalStack gap="2" align="space-between">
+          <div>Short content</div>
+          <div>Card footer</div>
+        </VerticalStack>
+      </Card>
+      <Card>
+        <VerticalStack gap="2" align="space-between">
+          <div>
+            Long content that stretches the height of the grid row to show that
+            the footer in the first card will stay aligned to the bottom
+          </div>
+          <div>Card footer</div>
+        </VerticalStack>
+      </Card>
+    </HorizontalGrid>
   ),
 };

--- a/easy-ui-react/src/Card/Card.stories.tsx
+++ b/easy-ui-react/src/Card/Card.stories.tsx
@@ -260,3 +260,55 @@ export const ExampleCallout: Story = {
     </div>
   ),
 };
+
+export const ExampleLayouts: Story = {
+  render: () => (
+    <VerticalStack gap="4">
+      <VerticalStack gap="2">
+        <Text variant="subtitle1">Stretch-aligned Horizontal Grid</Text>
+        <HorizontalGrid columns={2} gap="2">
+          <Card background="secondary">
+            <div>
+              This card&apos;s area should behave rules of parent layout
+            </div>
+          </Card>
+          <Card>
+            <div style={{ border: "1px solid", height: 200 }}>
+              Content with a height set to 200px
+            </div>
+          </Card>
+        </HorizontalGrid>
+      </VerticalStack>
+      <VerticalStack gap="2">
+        <Text variant="subtitle1">Center-aligned Horizontal Grid</Text>
+        <HorizontalGrid columns={2} gap="2" alignItems="center">
+          <Card background="secondary">
+            <div>
+              This card&apos;s area should behave rules of parent layout
+            </div>
+          </Card>
+          <Card>
+            <div style={{ border: "1px solid", height: 200 }}>
+              Content with a height set to 200px
+            </div>
+          </Card>
+        </HorizontalGrid>
+      </VerticalStack>
+      <VerticalStack gap="2">
+        <Text variant="subtitle1">Bottom-aligned Horizontal Grid</Text>
+        <HorizontalGrid columns={2} gap="2" alignItems="end">
+          <Card background="secondary">
+            <div>
+              This card&apos;s area should behave rules of parent layout
+            </div>
+          </Card>
+          <Card>
+            <div style={{ border: "1px solid", height: 200 }}>
+              Content with a height set to 200px
+            </div>
+          </Card>
+        </HorizontalGrid>
+      </VerticalStack>
+    </VerticalStack>
+  ),
+};


### PR DESCRIPTION
## 📝 Changes

- fixes card area not stretching to layouts properly
- adds example story

## ✅ Checklist

- [x] Code is complete and in accordance with our style guide
- [x] Stories in Storybook accompany any relevant component changes
- [x] Ensure no accessibility violations are reported in Storybook
- [x] Cross-browser check is performed (Chrome, Safari, Firefox)
- [x] Changeset is added
