### PR TITLE
Set color for hover on `<Button>` with href

### DIFF
--- a/.changeset/orange-rockets-compare.md
+++ b/.changeset/orange-rockets-compare.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+Specify color for Button filled variant to avoid collisons with `a` element selector style rules

--- a/easy-ui-react/src/Button/_mixins.scss
+++ b/easy-ui-react/src/Button/_mixins.scss
@@ -45,6 +45,7 @@
 
   &:hover:not(:disabled):not(:active) {
     background-color: component-token("button", "hover.focus.color");
+    color: component-token("button", "filled.font.color");
   }
 }
 


### PR DESCRIPTION
## 📝 Changes

Adds a color declaration for `<Button variant="filled">` to avoid collisions with `a:hover` element selector rules.

To verify, in Chrome Devtools, this CSS rule was added:
```css
a, a:hover {
  color: deeppink;
}
```
Before this PR:
![image](https://github.com/EasyPost/easy-ui/assets/1400051/9aca1a6a-0ada-4e93-bf8d-390c7ccc89ce)

After:
![image](https://github.com/EasyPost/easy-ui/assets/1400051/75fb56ec-0c86-48a1-9bb4-111d5463e8f6)


## ✅ Checklist

- [X] Code is complete and in accordance with our style guide
- [X] Ensure no accessibility violations are reported in Storybook
- [X] Cross-browser check is performed (Chrome, Safari, Firefox)
- [X] Changeset is added
