### PR TITLE
fix(Menu): return focus to trigger after closing menu

### DIFF
--- a/.changeset/silent-beans-try.md
+++ b/.changeset/silent-beans-try.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+fix(Menu): return focus to trigger after closing menu

--- a/easy-ui-react/src/Menu/MenuOverlay.tsx
+++ b/easy-ui-react/src/Menu/MenuOverlay.tsx
@@ -2,7 +2,7 @@ import { CollectionChildren } from "@react-types/shared";
 import React, { Key } from "react";
 import {
   DismissButton,
-  OverlayContainer,
+  Overlay,
   Placement,
   mergeProps,
   useMenu,
@@ -119,7 +119,7 @@ function MenuOverlayContent<T extends object>(props: MenuOverlayProps<T>) {
   } as React.CSSProperties;
 
   return (
-    <OverlayContainer>
+    <Overlay>
       <div {...underlayProps} className={styles.underlay} />
       <div
         {...mergeProps(popoverProps, { style })}
@@ -155,6 +155,6 @@ function MenuOverlayContent<T extends object>(props: MenuOverlayProps<T>) {
         </div>
         <DismissButton onDismiss={menuTriggerState.close} />
       </div>
-    </OverlayContainer>
+    </Overlay>
   );
 }


### PR DESCRIPTION
## 📝 Changes

- uses `Overlay` instead of `OverlayContainer` to return focus back to trigger after closing menu. this is per Aria documentation and was simply missed in the implementation
- attempted to write a unit test for this but couldn't get user event, jsdom, and Aria to play nicely together for this change. will come back to it when i figure out how to test focus in these cases

## ✅ Checklist

- [x] Code is complete and in accordance with our style guide
- [x] Ensure no accessibility violations are reported in Storybook
- [x] Cross-browser check is performed (Chrome, Safari, Firefox)
- [x] Changeset is added
