### PR TITLE
Revert "Bump @testing-library/jest-dom from 6.0.1 to 6.1.0"

### DIFF
--- a/easy-ui-react/package.json
+++ b/easy-ui-react/package.json
@@ -51,7 +51,7 @@
     "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "^6.1.0",
+    "@testing-library/jest-dom": "^6.0.1",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "@types/react-is": "^18.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -147,7 +147,7 @@
         "use-clipboard-copy": "^0.2.0"
       },
       "devDependencies": {
-        "@testing-library/jest-dom": "^6.1.0",
+        "@testing-library/jest-dom": "^6.0.1",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "@types/react-is": "^18.2.1",
@@ -8696,9 +8696,9 @@
       }
     },
     "node_modules/@testing-library/jest-dom": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.1.0.tgz",
-      "integrity": "sha512-EUAg9pvOkzmGXUSyAPt0h6yAXHxsn+FMNS1o7OX8TErmldZML2ywt10lotZXx/a1PDiSnq0fGGyEV/ybKSLPWQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.0.1.tgz",
+      "integrity": "sha512-0hx/AWrJp8EKr8LmC5jrV3Lx8TZySH7McU1Ix2czBPQnLd458CefSEGjZy7w8kaBRA6LhoPkGjoZ3yqSs338IQ==",
       "dev": true,
       "dependencies": {
         "@adobe/css-tools": "^4.0.1",
@@ -25003,7 +25003,7 @@
         "@react-aria/utils": "^3.19.0",
         "@react-stately/toast": "^3.0.0-beta.1",
         "@react-types/shared": "^3.19.0",
-        "@testing-library/jest-dom": "^6.1.0",
+        "@testing-library/jest-dom": "^6.0.1",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "@types/react": "^18.2.21",
@@ -28654,9 +28654,9 @@
       }
     },
     "@testing-library/jest-dom": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.1.0.tgz",
-      "integrity": "sha512-EUAg9pvOkzmGXUSyAPt0h6yAXHxsn+FMNS1o7OX8TErmldZML2ywt10lotZXx/a1PDiSnq0fGGyEV/ybKSLPWQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.0.1.tgz",
+      "integrity": "sha512-0hx/AWrJp8EKr8LmC5jrV3Lx8TZySH7McU1Ix2czBPQnLd458CefSEGjZy7w8kaBRA6LhoPkGjoZ3yqSs338IQ==",
       "dev": true,
       "requires": {
         "@adobe/css-tools": "^4.0.1",


### PR DESCRIPTION
Reverts EasyPost/easy-ui#562

there's a bug crashing our tests. we need to get our CI check requirement in place