### PR TITLE
fix(Modal): support ReactNode as ModalContainer children

### DIFF
--- a/.changeset/forty-bears-heal.md
+++ b/.changeset/forty-bears-heal.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+fix(Modal): support ReactNode as ModalContainer children

--- a/easy-ui-react/src/Modal/Modal.stories.tsx
+++ b/easy-ui-react/src/Modal/Modal.stories.tsx
@@ -215,6 +215,7 @@ export const MenuTrigger: ModalTriggerStory = {
           </Menu.Trigger>
           <Menu.Overlay onAction={(key) => setModal(key)}>
             <Menu.Item key="manage">Manage Account</Menu.Item>
+            <Menu.Item key="delete">Delete Account</Menu.Item>
           </Menu.Overlay>
         </Menu>
         <ModalContainer
@@ -222,26 +223,27 @@ export const MenuTrigger: ModalTriggerStory = {
             setModal(null);
           }}
         >
-          {modal === "manage" && <ManageAccountModel />}
+          {modal === "manage" && <ManageAccountModel title="Manage" />}
+          {modal === "delete" && <ManageAccountModel title="Delete" />}
         </ModalContainer>
       </>
     );
   },
 };
 
-function ManageAccountModel() {
+function ManageAccountModel({ title }: { title: string }) {
   const modalTriggerState = useModalTrigger();
   return (
     <Modal>
-      <Modal.Header>Manage Account</Modal.Header>
+      <Modal.Header>{`${title} Account`}</Modal.Header>
       <Modal.Body>
         <PlaceholderBox width="100%">Space for content</PlaceholderBox>
       </Modal.Body>
       <Modal.Footer
         primaryAction={{
-          content: "Save",
+          content: "Action",
           onAction: () => {
-            action("Save clicked!");
+            action("Action clicked!");
             modalTriggerState.close();
           },
         }}


### PR DESCRIPTION
## 📝 Changes

- Adds support for passing in a ReactNode as a ModalContainer children, which allows more lax conditions inside the body of the ModalContainer JSX tag such as multiple boolean conditions. this also lines up more closely with [React Spectrum's implementation](https://github.com/adobe/react-spectrum/blob/main/packages/%40react-spectrum/dialog/src/DialogContainer.tsx#L33)

## ✅ Checklist

- [x] Code is complete and in accordance with our style guide
- [x] Stories in Storybook accompany any relevant component changes
- [x] Cross-browser check is performed (Chrome, Safari, Firefox)
- [x] Changeset is added
