### PR TITLE
Revert "build(deps): Bump overlayscrollbars from 2.3.0 to 2.3.1"

### DIFF
--- a/easy-ui-react/package.json
+++ b/easy-ui-react/package.json
@@ -38,7 +38,7 @@
     "@types/react": "^18.2.22",
     "@types/react-dom": "^18.2.7",
     "lodash": "^4.17.21",
-    "overlayscrollbars": "^2.3.1",
+    "overlayscrollbars": "^2.3.0",
     "overlayscrollbars-react": "^0.5.2",
     "react-aria": "^3.28.0",
     "react-is": "^18.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -138,7 +138,7 @@
         "@types/react": "^18.2.22",
         "@types/react-dom": "^18.2.7",
         "lodash": "^4.17.21",
-        "overlayscrollbars": "^2.3.1",
+        "overlayscrollbars": "^2.3.0",
         "overlayscrollbars-react": "^0.5.2",
         "react-aria": "^3.28.0",
         "react-is": "^18.2.0",
@@ -17811,9 +17811,9 @@
       "dev": true
     },
     "node_modules/overlayscrollbars": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/overlayscrollbars/-/overlayscrollbars-2.3.1.tgz",
-      "integrity": "sha512-fTg8dhcgEhUBZpqadKSfaz6ILnEmaOhTnRiqPTmuVx8v2leI6lZREZZc+vs03GKu9/n0N1v+kRvzoWTmwvdM4g=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/overlayscrollbars/-/overlayscrollbars-2.3.0.tgz",
+      "integrity": "sha512-4h6wtdTzqDFBGcNeoXObulJ8uQ1MkcMrtFDnqfQDaRp4dRfzsxSwi4PnsWsObcEm4AQPkMNUJsFHUNlRq4ZQbg=="
     },
     "node_modules/overlayscrollbars-react": {
       "version": "0.5.2",
@@ -24989,7 +24989,7 @@
         "glob": "^10.2.5",
         "jsdom": "^22.1.0",
         "lodash": "^4.17.21",
-        "overlayscrollbars": "^2.3.1",
+        "overlayscrollbars": "^2.3.0",
         "overlayscrollbars-react": "^0.5.2",
         "react": "^18.2.0",
         "react-aria": "^3.28.0",
@@ -34876,9 +34876,9 @@
       "dev": true
     },
     "overlayscrollbars": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/overlayscrollbars/-/overlayscrollbars-2.3.1.tgz",
-      "integrity": "sha512-fTg8dhcgEhUBZpqadKSfaz6ILnEmaOhTnRiqPTmuVx8v2leI6lZREZZc+vs03GKu9/n0N1v+kRvzoWTmwvdM4g=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/overlayscrollbars/-/overlayscrollbars-2.3.0.tgz",
+      "integrity": "sha512-4h6wtdTzqDFBGcNeoXObulJ8uQ1MkcMrtFDnqfQDaRp4dRfzsxSwi4PnsWsObcEm4AQPkMNUJsFHUNlRq4ZQbg=="
     },
     "overlayscrollbars-react": {
       "version": "0.5.2",


### PR DESCRIPTION
Reverts EasyPost/easy-ui#631

again, breaking the build. this time i ignored the dependency