### PR TITLE
Create `<ProductLayout />` spec

### DIFF
--- a/documentation/specs/ProductLayout.md
+++ b/documentation/specs/ProductLayout.md
@@ -12,13 +12,13 @@
 
 ## Design
 
-`ProductLayout` will be a compound component consisting of `ProductLayout`, `ProductLayout.Sidebar`, `ProductLayout.Header`, `ProductLayout.Content`, and `ProductLayout.TabbedContent`.
+`ProductLayout` will be a compound component consisting of `ProductLayout`, `ProductLayout.Sidebar`, `ProductLayout.Header`, and either `ProductLayout.Content` or `ProductLayout.TabbedContent`.
 
 `ProductLayout` will use "slots" to render subcomponents into the appropriate nested HTML element. See an example `useSlots` reference [implementation](https://github.com/primer/react/blob/main/src/hooks/useSlots.ts#L16). This pattern allows the component surface area to map cleanly to the consumer concerns without having to know about the inner HTML tree.
 
-`ProductLayout` will be concerned with the presentational page structure and ensuring it folds properly across breakpoints. This includes managing the positioning of the sidebar panel as it changes from desktop to mobile. It won't include any business logic of its own.
+`ProductLayout` will be concerned with the presentational page structure and ensuring it folds properly across breakpoints. This includes managing the positioning of the sidebar panel as it changes from desktop to mobile. It won't include the actual navigation component nor any business logic of its own.
 
-`ProductLayout` can render either an empty content section using `ProductLayout.Content`, or a tabbed content section using `ProductLayout.TabbedContent`.
+`ProductLayout` can render either an empty content section using `ProductLayout.Content`, or a tabbed content section using `ProductLayout.TabbedContent`. A tabbed content section utilizes the `TabNav` component to provide accessible navigation across subpages. Tabbed content is expected to navigate users to different URLs, either through the pathname or through query params.
 
 `ProductLayout.Header` accepts a title, a primary CTA, and a secondary CTA. Both CTAs are optional. A help menu is always rendered to the left of the CTAs. On mobile, the primary CTA, or the help menu if no primary CTA is specified, is shown in the top-right bar. CTAs are specific button variants, so customization of the CTA buttons themselves are intentionally limited.
 
@@ -57,7 +57,7 @@ type ProductLayoutTabbedContentProps = AriaLabelingProps & {
 
 ### Example Usage
 
-_Basic content:_
+_Simple content:_
 
 ```tsx
 import { ProductLayout } from "@easypost/easy-ui/ProductLayout";

--- a/documentation/specs/ProductLayout.md
+++ b/documentation/specs/ProductLayout.md
@@ -1,0 +1,139 @@
+# `ProductLayout` Component Specification
+
+## Overview
+
+`ProductLayout` defines the header, sidebar, and main areas of a product page.
+
+### Prior Art
+
+- [Primer `<PageLayout />`](https://primer.style/design/components/page-layout/react)
+
+---
+
+## Design
+
+`ProductLayout` will be a compound component consisting of `ProductLayout`, `ProductLayout.Sidebar`, `ProductLayout.Header`, `ProductLayout.Content`, and `ProductLayout.TabbedContent`.
+
+`ProductLayout` will use "slots" to render subcomponents into the appropriate nested HTML element. See an example `useSlots` reference [implementation](https://github.com/primer/react/blob/main/src/hooks/useSlots.ts#L16). This pattern allows the component surface area to map cleanly to the consumer concerns without having to know about the inner HTML tree.
+
+`ProductLayout` will be concerned with the presentational page structure and ensuring it folds properly across breakpoints. This includes managing the positioning of the sidebar panel as it changes from desktop to mobile. It won't include any business logic of its own.
+
+`ProductLayout` can render either an empty content section using `ProductLayout.Content`, or a tabbed content section using `ProductLayout.TabbedContent`.
+
+`ProductLayout.Header` accepts a title, a primary CTA, and a secondary CTA. Both CTAs are optional. A help menu is always rendered to the left of the CTAs. On mobile, the primary CTA, or the help menu if no primary CTA is specified, is shown in the top-right bar. CTAs are specific button variants, so customization of the CTA buttons themselves are intentionally limited.
+
+### API
+
+```ts
+type ProductLayoutProps = {
+  children: ReactNode;
+};
+
+type ProductLayoutSidebarProps = {
+  children: ReactNode;
+};
+
+type ProductLayoutHeaderProps = {
+  title: ReactNode;
+  primaryAction?: ProductLayoutHeaderActionProps;
+  secondaryAction?: ProductLayoutHeaderActionProps;
+};
+
+type ProductLayoutHeaderActionProps = {
+  content: string;
+  onAction: () => void;
+  isDisabled?: boolean;
+};
+
+type ProductLayoutContentProps = {
+  children: ReactNode;
+};
+
+type ProductLayoutTabbedContentProps = AriaLabelingProps & {
+  children: ReactNode;
+  tabs: ReactElement[];
+};
+```
+
+### Example Usage
+
+_Basic content:_
+
+```tsx
+import { ProductLayout } from "@easypost/easy-ui/ProductLayout";
+
+function App() {
+  return (
+    <ProductLayout>
+      <ProductLayout.Sidebar>
+        <ProductNav />
+      </ProductLayout.Sidebar>
+      <ProductLayout.Header
+        title="Page title"
+        primaryAction={{
+          content: "CTA 1",
+          onAction: () => {},
+        }}
+        secondaryAction={{
+          content: "CTA 2",
+          onAction: () => {},
+        }}
+      />
+      <ProductLayout.Content>
+        <div>Content</div>
+      </ProductLayout.Content>
+    </ProductLayout>
+  );
+}
+```
+
+_Tabbed content:_
+
+```tsx
+import { ProductLayout } from "@easypost/easy-ui/ProductLayout";
+
+function App() {
+  return (
+    <ProductLayout>
+      <ProductLayout.Sidebar>
+        <ProductNav />
+      </ProductLayout.Sidebar>
+      <ProductLayout.Header title="Page title" />
+      <ProductLayout.TabbedContent
+        tabs={[
+          <TabNav.Item key="1" href="/billing" isCurrentPage>
+            Billing
+          </TabNav.Item>,
+          <TabNav.Item key="2" href="/members">
+            Members
+          </TabNav.Item>,
+          <TabNav.Item key="3" href="/api-keys">
+            API Keys
+          </TabNav.Item>,
+          <TabNav.Item key="4" href="/branded-tracker">
+            Branded Tracker
+          </TabNav.Item>,
+          <TabNav.Item key="5" href="/shipping-settings">
+            Shipping Settings
+          </TabNav.Item>,
+        ]}
+      >
+        <div style={{ marginTop: 24, padding: "0 16px" }}>
+          {startCase(page)}
+        </div>
+      </ProductLayout.TabbedContent>
+    </ProductLayout>
+  );
+}
+```
+
+---
+
+## Behavior
+
+### Accessibility
+
+- `ProductLayout.Sidebar` will have `role="region"` and `aria-label="Sidebar"`
+- `ProductLayout.Header` will be rendered as a `header` element with the title wrapped in an `h2`
+- `ProductLayout.Content` will be rendered as a `main` element. `ProductLayout.TabbedContent` will render the content under the tab bar as a `main` element.
+- `ProductLayout.TabbedContent` will accept an `aria-label` for labeling the tab navigation bar for assistive agents.

--- a/documentation/specs/ProductLayout.md
+++ b/documentation/specs/ProductLayout.md
@@ -16,11 +16,11 @@
 
 `ProductLayout` will use "slots" to render subcomponents into the appropriate nested HTML element. See an example `useSlots` reference [implementation](https://github.com/primer/react/blob/main/src/hooks/useSlots.ts#L16). This pattern allows the component surface area to map cleanly to the consumer concerns without having to know about the inner HTML tree.
 
-`ProductLayout` will be concerned with the presentational page structure and ensuring it folds properly across breakpoints. This includes managing the positioning of the sidebar panel as it changes from desktop to mobile. It won't include the actual navigation component nor any business logic of its own.
+`ProductLayout` will be concerned with the presentational page structure and ensuring it folds properly across breakpoints. This includes managing the positioning of the sidebar panel as it changes from desktop to mobile. It also includes the rendering of the help menu. It won't include the actual navigation component, nor the items for the help menu (as those can be context dependent), nor any business logic of its own. `ProductLayout` is intended to be wrapped by an app-specific layout that includes app-specific business logic and configuration.
 
 `ProductLayout` can render either an empty content section using `ProductLayout.Content`, or a tabbed content section using `ProductLayout.TabbedContent`. A tabbed content section utilizes the `TabNav` component to provide accessible navigation across subpages. Tabbed content is expected to navigate users to different URLs, either through the pathname or through query params.
 
-`ProductLayout.Header` accepts a title, a primary CTA, and a secondary CTA. Both CTAs are optional. A help menu is always rendered to the left of the CTAs. On mobile, the primary CTA, or the help menu if no primary CTA is specified, is shown in the top-right bar. CTAs are specific button variants, so customization of the CTA buttons themselves are intentionally limited.
+`ProductLayout.Header` accepts a title, help menu items, a primary CTA, and a secondary CTA. Both CTAs are optional. A help menu is always rendered to the left of the CTAs. On mobile, only a single action is shown in the top-right bar. It will either be one of the primary CTA, secondary CTA, or help menu, depending on what's specified by the consumer. CTAs are specific button variants, so customization of the CTA buttons themselves are intentionally limited.
 
 ### API
 
@@ -35,6 +35,7 @@ type ProductLayoutSidebarProps = {
 
 type ProductLayoutHeaderProps = {
   title: ReactNode;
+  helpMenuItems: MenuItemProps[];
   primaryAction?: ProductLayoutHeaderActionProps;
   secondaryAction?: ProductLayoutHeaderActionProps;
 };
@@ -70,6 +71,17 @@ function App() {
       </ProductLayout.Sidebar>
       <ProductLayout.Header
         title="Page title"
+        helpMenuItems={[
+          <Menu.Item href="https://www.easypost.com/docs/api">
+            Documentation
+          </Menu.Item>,
+          <Menu.Item href="https://support.easypost.com/hc/en-us">
+            Support
+          </Menu.Item>,
+          <Menu.Item href="https://www.easypost.com/getting-started">
+            Guides
+          </Menu.Item>,
+        ]}
         primaryAction={{
           content: "CTA 1",
           onAction: () => {},
@@ -98,7 +110,20 @@ function App() {
       <ProductLayout.Sidebar>
         <ProductNav />
       </ProductLayout.Sidebar>
-      <ProductLayout.Header title="Page title" />
+      <ProductLayout.Header
+        title="Page title"
+        helpMenuItems={[
+          <Menu.Item href="https://www.easypost.com/docs/api">
+            Documentation
+          </Menu.Item>,
+          <Menu.Item href="https://support.easypost.com/hc/en-us">
+            Support
+          </Menu.Item>,
+          <Menu.Item href="https://www.easypost.com/getting-started">
+            Guides
+          </Menu.Item>,
+        ]}
+      />
       <ProductLayout.TabbedContent
         tabs={[
           <TabNav.Item key="1" href="/billing" isCurrentPage>


### PR DESCRIPTION
## 📝 Changes

- Adds spec for `ProductLayout`

This does not include specs for the more specialized "focused" and "wizard" product layouts. Those will be spec'd in followup work.

_`ProductLayout.Content`:_

<img width="689" alt="image" src="https://github.com/EasyPost/easy-ui/assets/752942/9c79191b-df53-4cb6-9418-4c555d055bff">

_`ProductLayout.TabbedContent`:_

<img width="690" alt="image" src="https://github.com/EasyPost/easy-ui/assets/752942/1c74c226-26d2-46ee-8c82-1f085e5b4b25">
