### PR TITLE
fix(DataGrid): close column gap in some edge cases

### DIFF
--- a/.changeset/thirty-guests-exist.md
+++ b/.changeset/thirty-guests-exist.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+fix(DataGrid): close column gap in some edge cases"

--- a/easy-ui-react/src/DataGrid/Cell.module.scss
+++ b/easy-ui-react/src/DataGrid/Cell.module.scss
@@ -39,7 +39,7 @@
 .secondWithActions {
   padding-left: 0;
   position: sticky;
-  left: 44px;
+  left: component-token("data-grid", "action-cell-width");
   z-index: component-token("data-grid", "cell-stuck-z-index");
 }
 

--- a/easy-ui-react/src/DataGrid/ColumnHeader.module.scss
+++ b/easy-ui-react/src/DataGrid/ColumnHeader.module.scss
@@ -45,6 +45,11 @@
   z-index: component-token("data-grid", "column-stuck-z-index");
 }
 
+.firstWithActions,
+.secondWithActions {
+  min-width: 44px;
+}
+
 .last {
   padding-right: design-token("space.5");
 }

--- a/easy-ui-react/src/DataGrid/ColumnHeader.module.scss
+++ b/easy-ui-react/src/DataGrid/ColumnHeader.module.scss
@@ -35,6 +35,7 @@
 
 .firstWithActions {
   left: 0;
+  min-width: 44px;
   padding-left: design-token("space.2");
   padding-right: design-token("space.1.5");
 }
@@ -43,11 +44,6 @@
   padding-left: 0;
   left: 44px;
   z-index: component-token("data-grid", "column-stuck-z-index");
-}
-
-.firstWithActions,
-.secondWithActions {
-  min-width: 44px;
 }
 
 .last {

--- a/easy-ui-react/src/DataGrid/ColumnHeader.module.scss
+++ b/easy-ui-react/src/DataGrid/ColumnHeader.module.scss
@@ -35,14 +35,14 @@
 
 .firstWithActions {
   left: 0;
-  min-width: 44px;
+  min-width: component-token("data-grid", "action-cell-width");
   padding-left: design-token("space.2");
   padding-right: design-token("space.1.5");
 }
 
 .secondWithActions {
   padding-left: 0;
-  left: 44px;
+  left: component-token("data-grid", "action-cell-width");
   z-index: component-token("data-grid", "column-stuck-z-index");
 }
 

--- a/easy-ui-react/src/DataGrid/DataGrid.module.scss
+++ b/easy-ui-react/src/DataGrid/DataGrid.module.scss
@@ -48,6 +48,7 @@
   @include component-token("data-grid", "column-stuck-z-index", 4);
   @include component-token("data-grid", "sticky-left-offset", -16px);
   @include component-token("data-grid", "sticky-right-offset", -12px);
+  @include component-token("data-grid", "action-cell-width", 44px);
 
   border: component-token("data-grid", "border-width") solid
     component-token("data-grid", "border-color");


### PR DESCRIPTION
## 📝 Changes

- on the DataGrid, when there are no rows and `rowExpansion` is enabled, there is a gap between the first two columns due to not having content in its column. this fixes that

Before:

<img width="1024" alt="image" src="https://github.com/EasyPost/easy-ui/assets/752942/951973d8-738e-421c-8159-96189909ef80">

After:

<img width="1022" alt="image" src="https://github.com/EasyPost/easy-ui/assets/752942/e03257f8-877d-4a86-901f-6a7563d0141b">

## ✅ Checklist

- [x] Visuals are complete and match Figma
- [x] Code is complete and in accordance with our style guide
- [x] Design and theme tokens are audited for any relevant changes
- [x] Unit tests are written and passing
- [x] TSDoc is written or updated for any component API surface area
- [x] Stories in Storybook accompany any relevant component changes
- [x] Ensure no accessibility violations are reported in Storybook
- [x] Specs and documentation are up-to-date
- [x] Cross-browser check is performed (Chrome, Safari, Firefox)
- [x] Changeset is added
