### PR TITLE
feat(SearchNav): add condensedBehavior prop

### DIFF
--- a/.changeset/mean-pants-smile.md
+++ b/.changeset/mean-pants-smile.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": minor
+---
+
+feat(SearchNav): add condensedBehavior prop

--- a/easy-ui-react/src/SearchNav/CondensedSearchNav.tsx
+++ b/easy-ui-react/src/SearchNav/CondensedSearchNav.tsx
@@ -9,6 +9,7 @@ import { UnstyledButton } from "../UnstyledButton";
 import { Icon } from "../Icon";
 import { classNames } from "../utilities/css";
 import { useInternalSearchNavContext } from "./context";
+import { LogoGroup } from "./LogoGroup";
 
 import styles from "./CondensedSearchNav.module.scss";
 import { getFlattenedKey } from "../utilities/react";
@@ -30,55 +31,69 @@ export function CondensedSearchNav() {
     primaryCTAItem,
     selectorLabel,
     menuOverlayProps,
+    condensedBehavior,
   } = useInternalSearchNavContext();
 
   const hasMenuToShow = !!selectorChildren || !!secondaryCTAItems;
-  const hasSearchToShow = !!search;
 
   return (
     <div className={classNames(styles.condensed)}>
-      {!isSearchOpen && hasMenuToShow ? (
+      {isSearchOpen ? (
+        <div className={classNames(styles.condensedSearch)}>
+          {search}
+          <UnstyledButton
+            className={classNames(styles.btn)}
+            onPress={() => setIsSearchOpen((prev) => !prev)}
+          >
+            <Icon symbol={Close} size="xs" />
+          </UnstyledButton>
+        </div>
+      ) : (
         <>
-          <Menu isOpen={isMenuOpen} onOpenChange={setIsMenuOpen}>
-            <Menu.Trigger>
-              <UnstyledButton
-                className={classNames(
-                  styles.btn,
-                  styles.menuBtn,
-                  isMenuOpen && styles.menuOpen,
-                )}
-              >
-                <Icon symbol={MenuSymbol} />
-                <Text visuallyHidden>menu</Text>
-              </UnstyledButton>
-            </Menu.Trigger>
-            <Menu.Overlay placement="bottom left" {...menuOverlayProps}>
-              <Menu.Section aria-label={selectorLabel}>
-                {selectorChildren?.map((item) => {
-                  const itemEle = item as ReactElement;
-                  return (
-                    <Menu.Item key={getFlattenedKey(itemEle.key)}>
-                      {itemEle.props.children}
-                    </Menu.Item>
-                  );
-                })}
-              </Menu.Section>
-              <Menu.Section aria-label="Nav actions">
-                {secondaryCTAItems?.map((item) => {
-                  const itemEle = item as ReactElement;
-                  return (
-                    <Menu.Item
-                      key={getFlattenedKey(itemEle.key)}
-                      href={itemEle.props.href}
-                      target={itemEle.props.target}
-                    >
-                      {itemEle.props.label}
-                    </Menu.Item>
-                  );
-                })}
-              </Menu.Section>
-            </Menu.Overlay>
-          </Menu>
+          {condensedBehavior === "collapse-to-menu" && hasMenuToShow ? (
+            <Menu isOpen={isMenuOpen} onOpenChange={setIsMenuOpen}>
+              <Menu.Trigger>
+                <UnstyledButton
+                  className={classNames(
+                    styles.btn,
+                    styles.menuBtn,
+                    isMenuOpen && styles.menuOpen,
+                  )}
+                >
+                  <Icon symbol={MenuSymbol} />
+                  <Text visuallyHidden>menu</Text>
+                </UnstyledButton>
+              </Menu.Trigger>
+              <Menu.Overlay placement="bottom left" {...menuOverlayProps}>
+                <Menu.Section aria-label={selectorLabel}>
+                  {selectorChildren?.map((item) => {
+                    const itemEle = item as ReactElement;
+                    return (
+                      <Menu.Item key={getFlattenedKey(itemEle.key)}>
+                        {itemEle.props.children}
+                      </Menu.Item>
+                    );
+                  })}
+                </Menu.Section>
+                <Menu.Section aria-label="Nav actions">
+                  {secondaryCTAItems?.map((item) => {
+                    const itemEle = item as ReactElement;
+                    return (
+                      <Menu.Item
+                        key={getFlattenedKey(itemEle.key)}
+                        href={itemEle.props.href}
+                        target={itemEle.props.target}
+                      >
+                        {itemEle.props.label}
+                      </Menu.Item>
+                    );
+                  })}
+                </Menu.Section>
+              </Menu.Overlay>
+            </Menu>
+          ) : (
+            <LogoGroup>{null}</LogoGroup>
+          )}
           {(search || primaryCTAItem) && (
             <HorizontalStack gap="2">
               {search && (
@@ -94,18 +109,6 @@ export function CondensedSearchNav() {
             </HorizontalStack>
           )}
         </>
-      ) : (
-        hasSearchToShow && (
-          <div className={classNames(styles.condensedSearch)}>
-            {search}
-            <UnstyledButton
-              className={classNames(styles.btn)}
-              onPress={() => setIsSearchOpen((prev) => !prev)}
-            >
-              <Icon symbol={Close} size="xs" />
-            </UnstyledButton>
-          </div>
-        )
       )}
     </div>
   );

--- a/easy-ui-react/src/SearchNav/SearchNav.mdx
+++ b/easy-ui-react/src/SearchNav/SearchNav.mdx
@@ -57,6 +57,12 @@ less than `640px`.
 
 <Canvas of={SearchNavStories.FullBar} />
 
+## Preserve Logo on Small Screens
+
+`<SearchNav />` can preserve its logo instead of collapsing to a menu on small screens by specifying `condensedBehavior="preserve-logo"`.
+
+<Canvas of={SearchNavStories.PreserveLogoWhenCondensed} />
+
 ## Properties
 
 ### SearchNav

--- a/easy-ui-react/src/SearchNav/SearchNav.module.scss
+++ b/easy-ui-react/src/SearchNav/SearchNav.module.scss
@@ -12,16 +12,12 @@
     "border-color",
     theme-token("color.neutral.100")
   );
-  padding: 0 design-token("space.1.5");
+  padding: 0 design-token("space.3");
   height: component-token("search-nav", "height");
   background-color: component-token("search-nav", "background-color");
   border-bottom: 1px solid component-token("search-nav", "border-color");
   display: flex;
   align-items: center;
-
-  @include breakpoint-md-up {
-    padding: 0 design-token("space.3");
-  }
 }
 
 .desktop {

--- a/easy-ui-react/src/SearchNav/SearchNav.stories.tsx
+++ b/easy-ui-react/src/SearchNav/SearchNav.stories.tsx
@@ -10,13 +10,14 @@ import { EasyPostFullLogo, PlaceholderBox } from "../utilities/storybook";
 type Story = StoryObj<typeof SearchNav>;
 
 const Template = (args: SearchNavProps<object>) => {
-  const { children } = args;
+  const { children, ...restArgs } = args;
   return (
     <SearchNav
       menuOverlayProps={{
         onAction: action("Menu item"),
         disabledKeys: ["V99.99"],
       }}
+      {...restArgs}
     >
       {children}
     </SearchNav>
@@ -272,6 +273,38 @@ export const FullBar: Story = {
             label="Sign up"
             onPress={action("pressed")}
           />
+        </SearchNav.CTAGroup>
+      </>
+    ),
+  },
+};
+
+export const PreserveLogoWhenCondensed: Story = {
+  render: Template.bind({}),
+  args: {
+    condensedBehavior: "preserve-logo",
+    children: (
+      <>
+        <SearchNav.LogoGroup>
+          <SearchNav.Logo>
+            <EasyPostFullLogo />
+          </SearchNav.Logo>
+          <SearchNav.Title>Docs</SearchNav.Title>
+        </SearchNav.LogoGroup>
+        <SearchNav.Search>
+          <PlaceholderBox width="100%" height={36}>
+            Search
+          </PlaceholderBox>
+        </SearchNav.Search>
+        <SearchNav.CTAGroup>
+          <SearchNav.SecondaryCTAItem
+            symbol={Brightness5}
+            key="Brightness"
+            label="Toggle theme"
+            onPress={action("pressed")}
+            hideLabelOnDesktop
+          />
+          <SearchNav.PrimaryCTAItem label="Login" />
         </SearchNav.CTAGroup>
       </>
     ),

--- a/easy-ui-react/src/SearchNav/SearchNav.tsx
+++ b/easy-ui-react/src/SearchNav/SearchNav.tsx
@@ -42,6 +42,12 @@ export type SearchNavProps<T> = {
    * `<SearchNav.Search>`, and `<SearchNav.CTAGroup>`
    */
   children: ReactNode;
+  /**
+   * Defines the behavior in which the menu condenses on mobile screens.
+   *
+   * @default collapse-to-menu
+   */
+  condensedBehavior?: "collapse-to-menu" | "preserve-logo";
 };
 
 /**
@@ -49,7 +55,7 @@ export type SearchNavProps<T> = {
  *
  * @remarks
  * Use on a docs page where users can leverage a dropdown, a seach input, and CTAs to find information.
- * `<SearchNav.LogoGroup />` and `<SearchNav.Logo />` are required. 
+ * `<SearchNav.LogoGroup />` and `<SearchNav.Logo />` are required.
  *
  * @example
  * _Full nav bar:_
@@ -110,7 +116,12 @@ export type SearchNavProps<T> = {
 ```
  */
 export function SearchNav<T>(props: SearchNavProps<T>) {
-  const { menuOverlayProps, ctaMenuSymbol, children } = props;
+  const {
+    menuOverlayProps,
+    ctaMenuSymbol,
+    children,
+    condensedBehavior = "collapse-to-menu",
+  } = props;
 
   const { onlyLogoGroup, context } = useMemo(() => {
     // To support the various configurations on smaller screens,
@@ -150,9 +161,10 @@ export function SearchNav<T>(props: SearchNavProps<T>) {
         menuOverlayProps,
         selectorLabel,
         ctaMenuSymbol,
+        condensedBehavior,
       },
     };
-  }, [children, menuOverlayProps, ctaMenuSymbol]);
+  }, [children, menuOverlayProps, ctaMenuSymbol, condensedBehavior]);
 
   return (
     <InternalSearchNavContext.Provider value={context}>

--- a/easy-ui-react/src/SearchNav/context.ts
+++ b/easy-ui-react/src/SearchNav/context.ts
@@ -1,5 +1,5 @@
 import { createContext, useContext, ReactNode } from "react";
-import { SearchNavOverlayMenuProps } from "./SearchNav";
+import type { SearchNavOverlayMenuProps, SearchNavProps } from "./SearchNav";
 import { IconSymbol } from "../types";
 
 type InternalSearchNavContextType = {
@@ -13,6 +13,7 @@ type InternalSearchNavContextType = {
   menuOverlayProps?: SearchNavOverlayMenuProps<object>;
   selectorLabel?: string;
   ctaMenuSymbol?: IconSymbol;
+  condensedBehavior?: SearchNavProps<object>["condensedBehavior"];
 };
 
 export const InternalSearchNavContext =


### PR DESCRIPTION
## 📝 Changes

Makes a couple updates to support updated docs designs where the logo group is preserved on small screens:

<img width="538" alt="image" src="https://github.com/EasyPost/easy-ui/assets/752942/bf5bb7d0-a46d-44f7-99e7-c260c71f452e">


- Adds `condensedBehavior` prop to allow for preserving the logo on small screens
- Adjusts horizontal padding to be `24px` on small screens too

```
<SearchNav condensedBehavior="preserve-logo">
  {/* etc */}
</SearchNav>
```

_Unable to add specific unit test due to jsdom limitations around a media query related behavior._

## ✅ Checklist

- [x] Visuals are complete and match Figma
- [x] Code is complete and in accordance with our style guide
- [x] Design and theme tokens are audited for any relevant changes
- [x] Unit tests are written and passing
- [x] TSDoc is written or updated for any component API surface area
- [x] Stories in Storybook accompany any relevant component changes
- [x] Ensure no accessibility violations are reported in Storybook
- [x] Specs and documentation are up-to-date
- [x] Cross-browser check is performed (Chrome, Safari, Firefox)
- [x] Changeset is added
