### PR TITLE
feat(CodeBlock): support hiding copy button

### DIFF
--- a/.changeset/tall-dragons-laugh.md
+++ b/.changeset/tall-dragons-laugh.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": minor
+---
+
+feat(CodeBlock): support hiding copy button

--- a/documentation/specs/CodeBlock.md
+++ b/documentation/specs/CodeBlock.md
@@ -64,6 +64,13 @@ type CodeBlockHeaderProps = {
    * @default neutral
    */
   color?: "neutral" | "primary" | "secondary";
+
+  /**
+   * Whether or not to hide the copy button.
+   *
+   * @default false
+   */
+  hideCopy?: boolean;
 };
 
 type CodeBlockSnippetProps = CodeSnippetProps;

--- a/easy-ui-react/src/CodeBlock/CodeBlock.stories.tsx
+++ b/easy-ui-react/src/CodeBlock/CodeBlock.stories.tsx
@@ -82,6 +82,7 @@ export const CustomHeader: StoryObj<typeof CodeBlock.Header> = {
   args: {
     children: "Header",
     color: "primary",
+    hideCopy: false,
   },
   argTypes: {
     children: { control: "text" },

--- a/easy-ui-react/src/CodeBlock/CodeBlock.test.tsx
+++ b/easy-ui-react/src/CodeBlock/CodeBlock.test.tsx
@@ -49,6 +49,19 @@ describe("<CodeBlock />", () => {
     );
   });
 
+  it("should support hiding copy", async () => {
+    render(
+      <CodeBlock language="javascript" onLanguageChange={() => {}}>
+        <CodeBlock.Header hideCopy>Header</CodeBlock.Header>
+        <CodeBlock.Snippet code={`hello javascript`} language="javascript" />
+        <CodeBlock.Snippet code={`hello php`} language="php" />
+      </CodeBlock>,
+    );
+    expect(
+      screen.queryByRole("button", { name: /copy code/i }),
+    ).not.toBeInTheDocument();
+  });
+
   it("should support language change", async () => {
     const handleLanguageChange = vi.fn();
 

--- a/easy-ui-react/src/CodeBlock/CodeBlock.tsx
+++ b/easy-ui-react/src/CodeBlock/CodeBlock.tsx
@@ -43,6 +43,8 @@ export type CodeBlockHeaderProps = {
 
   /**
    * Whether or not to hide the copy button.
+   *
+   * @default false
    */
   hideCopy?: boolean;
 };

--- a/easy-ui-react/src/CodeBlock/CodeBlock.tsx
+++ b/easy-ui-react/src/CodeBlock/CodeBlock.tsx
@@ -40,12 +40,17 @@ export type CodeBlockHeaderProps = {
    * @default neutral
    */
   color?: "neutral" | "primary" | "secondary";
+
+  /**
+   * Whether or not to hide the copy button.
+   */
+  hideCopy?: boolean;
 };
 
 export type CodeBlockSnippetProps = CodeSnippetProps;
 
 function CodeBlockHeader(props: CodeBlockHeaderProps) {
-  const { children, color = "neutral" } = props;
+  const { children, color = "neutral", hideCopy = false } = props;
   const { snippet, languages, language, onLanguageChange } = useCodeBlock();
   const className = classNames(
     styles.header,
@@ -62,16 +67,16 @@ function CodeBlockHeader(props: CodeBlockHeaderProps) {
         <Text variant="subtitle1">{children}</Text>
         <HorizontalStack gap="2" wrap={false}>
           {languages.length > 1 && (
-            <>
-              <LanguageMenu
-                languages={languages}
-                language={language}
-                onChange={onLanguageChange}
-              />
-              <span className={styles.divider} />
-            </>
+            <LanguageMenu
+              languages={languages}
+              language={language}
+              onChange={onLanguageChange}
+            />
           )}
-          <CopyButton text={snippet.props.code} />
+          {languages.length > 1 && !hideCopy && (
+            <span className={styles.divider} />
+          )}
+          {!hideCopy && <CopyButton text={snippet.props.code} />}
         </HorizontalStack>
       </HorizontalStack>
     </div>


### PR DESCRIPTION
## 📝 Changes

- Allows hiding the copy button for text that doesn't make sense to copy

## ✅ Checklist

- [x] Code is complete and in accordance with our style guide
- [x] Design and theme tokens are audited for any relevant changes
- [x] Unit tests are written and passing
- [x] TSDoc is written or updated for any component API surface area
- [x] Stories in Storybook accompany any relevant component changes
- [x] Ensure no accessibility violations are reported in Storybook
- [x] Specs and documentation are up-to-date
- [x] Cross-browser check is performed (Chrome, Safari, Firefox)
- [x] Changeset is added
