### PR TITLE
patch(CodeSnippet): disable automatic prism highlighting

### DIFF
--- a/.changeset/hungry-avocados-jump.md
+++ b/.changeset/hungry-avocados-jump.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+patch(CodeSnippet): disable automatic prism highlighting"

--- a/easy-ui-react/src/CodeSnippet/SyntaxHighlighter.tsx
+++ b/easy-ui-react/src/CodeSnippet/SyntaxHighlighter.tsx
@@ -10,6 +10,23 @@ import python from "react-syntax-highlighter/dist/esm/languages/prism/python";
 import ruby from "react-syntax-highlighter/dist/esm/languages/prism/ruby";
 import shell from "react-syntax-highlighter/dist/esm/languages/prism/shell-session";
 
+declare global {
+  interface Window {
+    Prism: { manual: boolean };
+  }
+}
+
+// react-syntax-highlighter uses refractor which handles the Prism highlighting
+// automatically, so we need to disable Prism from running on page load with
+// the following configuration, otherwise we will run into hydration errors
+//
+// this is fixed in a later version of refractor that isn't supported in
+// react-syntax-highlighter currently
+if (typeof window !== "undefined") {
+  window.Prism = window.Prism || {};
+  window.Prism.manual = true;
+}
+
 export type SnippetLanguage =
   | "csharp"
   | "go"

--- a/easy-ui-react/src/CodeSnippet/theme.ts
+++ b/easy-ui-react/src/CodeSnippet/theme.ts
@@ -90,6 +90,7 @@ export function buildTheme(
         position: "relative",
         paddingRight: 4,
         WebkitLineClamp: `${config.maxLines}`,
+        overflow: "auto",
       }),
       WebkitBoxOrient: "vertical",
       width: "100%",


### PR DESCRIPTION
## 📝 Changes

- Disables automatic Prism highlighting on page load, which can trigger hydration errors in react and flash of unstyled content on our code blocks
- Adjusts theme to ensure line clamping works correctly on initial load

## ✅ Checklist

- [x] Visuals are complete and match Figma
- [x] Code is complete and in accordance with our style guide
- [x] Design and theme tokens are audited for any relevant changes
- [x] Unit tests are written and passing
- [x] TSDoc is written or updated for any component API surface area
- [x] Stories in Storybook accompany any relevant component changes
- [x] Ensure no accessibility violations are reported in Storybook
- [x] Specs and documentation are up-to-date
- [x] Cross-browser check is performed (Chrome, Safari, Firefox)
- [x] Changeset is added
