### PR TITLE
fix(CodeBlock): header title should support collapsing

### DIFF
--- a/.changeset/chilly-spies-cheer.md
+++ b/.changeset/chilly-spies-cheer.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+fix(CodeBlock): header title should collapse

--- a/easy-ui-react/src/CodeBlock/CodeBlock.module.scss
+++ b/easy-ui-react/src/CodeBlock/CodeBlock.module.scss
@@ -25,6 +25,11 @@
   color: component-token("card-header", "color");
 }
 
+.headerTitle {
+  flex: 1;
+  @include font-style("subtitle1");
+}
+
 .divider {
   align-self: stretch;
   display: inline-flex;

--- a/easy-ui-react/src/CodeBlock/CodeBlock.tsx
+++ b/easy-ui-react/src/CodeBlock/CodeBlock.tsx
@@ -2,7 +2,6 @@ import React, { ReactNode, useMemo } from "react";
 import { CodeSnippet, CodeSnippetProps } from "../CodeSnippet";
 import { SnippetLanguage } from "../CodeSnippet/SyntaxHighlighter";
 import { HorizontalStack } from "../HorizontalStack";
-import { Text } from "../Text";
 import { classNames, variationName } from "../utilities/css";
 import { filterChildrenByDisplayName } from "../utilities/react";
 import { CopyButton } from "./CopyButton";
@@ -66,7 +65,7 @@ function CodeBlockHeader(props: CodeBlockHeaderProps) {
         wrap={false}
         blockAlign="start"
       >
-        <Text variant="subtitle1">{children}</Text>
+        <span className={styles.headerTitle}>{children}</span>
         <HorizontalStack gap="2" wrap={false}>
           {languages.length > 1 && (
             <LanguageMenu


### PR DESCRIPTION
## 📝 Changes

- fixes the scenario where CodeBlock headers don't always collapse with long titles due to invalid flex positioning

before:

<img width="498" alt="image" src="https://github.com/EasyPost/easy-ui/assets/752942/7d021ea6-c621-4c0d-8d68-1fce43a1f356">

after:

<img width="500" alt="image" src="https://github.com/EasyPost/easy-ui/assets/752942/7006da04-6eaa-4928-b299-ace649256a0d">


## ✅ Checklist

- [x] Visuals are complete and match Figma
- [x] Code is complete and in accordance with our style guide
- [x] Design and theme tokens are audited for any relevant changes
- [x] Unit tests are written and passing
- [x] TSDoc is written or updated for any component API surface area
- [x] Stories in Storybook accompany any relevant component changes
- [x] Ensure no accessibility violations are reported in Storybook
- [x] Specs and documentation are up-to-date
- [x] Cross-browser check is performed (Chrome, Safari, Firefox)
- [x] Changeset is added
