### PR TITLE
fix(CodeBlock): add min height to tooltip

### DIFF
--- a/.changeset/tricky-kids-fix.md
+++ b/.changeset/tricky-kids-fix.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+fix(CodeBlock): add min height to tooltip

--- a/easy-ui-react/src/Tooltip/Tooltip.module.scss
+++ b/easy-ui-react/src/Tooltip/Tooltip.module.scss
@@ -23,6 +23,7 @@
     design-token("shadow.overlay_subdued")
   );
   @include component-token("tooltip", "max-width", 232px);
+  @include component-token("tooltip", "min-height", 40px);
 
   background: component-token("tooltip", "background");
   border-radius: component-token("tooltip", "border_radius");
@@ -35,6 +36,7 @@
             "container_padding"
           )} * 2)
   );
+  min-height: component-token("tooltip", "min-height");
   padding: design-token("space.1");
   will-change: filter;
 }


### PR DESCRIPTION
## 📝 Changes

- Fixes a case where react-aria's tooltip positioning logic would apply both `bottom` and `top` measurements at the edge of the screen

<img width="513" alt="image" src="https://github.com/EasyPost/easy-ui/assets/752942/6f597b3d-f1b7-47b8-8376-a87d7b641983">

## ✅ Checklist

- [x] Visuals are complete and match Figma
- [x] Code is complete and in accordance with our style guide
- [x] Design and theme tokens are audited for any relevant changes
- [x] Unit tests are written and passing
- [x] TSDoc is written or updated for any component API surface area
- [x] Stories in Storybook accompany any relevant component changes
- [x] Ensure no accessibility violations are reported in Storybook
- [x] Specs and documentation are up-to-date
- [x] Cross-browser check is performed (Chrome, Safari, Firefox)
- [x] Changeset is added
