### PR TITLE
fix(VerticalNav): add hover state to subnav items

### DIFF
--- a/.changeset/great-rockets-know.md
+++ b/.changeset/great-rockets-know.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+fix(VerticalNav): add hover state to subnav items

--- a/easy-ui-react/src/VerticalNav/SubnavItem.module.scss
+++ b/easy-ui-react/src/VerticalNav/SubnavItem.module.scss
@@ -18,6 +18,10 @@
   cursor: pointer;
 }
 
+.hovered > .link {
+  color: theme-token("color.primary.600");
+}
+
 .selected:has(.selected) > .link {
   font-weight: design-token("font.weight.medium");
   color: theme-token("color.primary.700");

--- a/easy-ui-react/src/VerticalNav/SubnavItem.tsx
+++ b/easy-ui-react/src/VerticalNav/SubnavItem.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { mergeProps } from "react-aria";
+import { mergeProps, useHover } from "react-aria";
 import { ListState, Node } from "react-stately";
 import { Text } from "../Text";
 import { classNames } from "../utilities/css";
@@ -26,9 +26,11 @@ export function SubnavItem(props: SubnavItemProps) {
     ...linkProps
   } = item.props as ItemPropsForStately;
   const isSelected = state.selectionManager.isSelected(item.key);
+  const { hoverProps, isHovered } = useHover({});
   const className = classNames(
     styles.SubnavItem,
     isSelected && styles.selected,
+    isHovered && styles.hovered,
   );
   if (icon) {
     throw new Error("icon is unsupported on <Subnav.Item />s");
@@ -38,7 +40,7 @@ export function SubnavItem(props: SubnavItemProps) {
       <As
         className={styles.link}
         aria-current={isSelected ? "true" : undefined}
-        {...mergeProps(linkProps)}
+        {...mergeProps(hoverProps, linkProps)}
       >
         {(type === "list" || level > 1) && (
           <SubnavItemDot isCozy={type === "list"} isVisible={isSelected} />


### PR DESCRIPTION
## 📝 Changes

- Add hover state to VerticalNav subnav items

## ✅ Checklist

- [x] Visuals are complete and match Figma
- [x] Code is complete and in accordance with our style guide
- [x] Design and theme tokens are audited for any relevant changes
- [x] Unit tests are written and passing
- [x] TSDoc is written or updated for any component API surface area
- [x] Stories in Storybook accompany any relevant component changes
- [x] Ensure no accessibility violations are reported in Storybook
- [x] Specs and documentation are up-to-date
- [x] Cross-browser check is performed (Chrome, Safari, Firefox)
- [x] Changeset is added
