### PR TITLE
fix: exclude SSRProvider from build

### DIFF
--- a/.changeset/quiet-singers-switch.md
+++ b/.changeset/quiet-singers-switch.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+fix: exclude SSRProvider from build

--- a/easy-ui-react/README.md
+++ b/easy-ui-react/README.md
@@ -81,7 +81,7 @@ ReactDOM.render(
 
 ### Server Rendering
 
-When server rendering an app that uses Easy UI and React <18, your app must wrapped with a singleton instance of React Aria's `SSRProvider`. If an app is using an additional version of React Aria, ensure there's only one version of `@react-aria/ssr` using NPM's `overrides` or Yarn's `resolutions` property.
+When server rendering an app that uses Easy UI and React <18, your app must be wrapped with a single instance of React Aria's `SSRProvider`. If an app is using an additional version of React Aria, ensure there's only one version of `@react-aria/ssr` using NPM's `overrides` or Yarn's `resolutions` property.
 
 ## Development
 

--- a/easy-ui-react/README.md
+++ b/easy-ui-react/README.md
@@ -79,6 +79,10 @@ ReactDOM.render(
 );
 ```
 
+### Server Rendering
+
+When server rendering an app that uses Easy UI and React <18, your app must wrapped with a singleton instance of React Aria's `SSRProvider`. If an app is using an additional version of React Aria, ensure there's only one version of `@react-aria/ssr` using NPM's `overrides` or Yarn's `resolutions` property.
+
 ## Development
 
 We use Storybook to create a simple, hot-reloading playground for development on these components.

--- a/easy-ui-react/vite.config.mts
+++ b/easy-ui-react/vite.config.mts
@@ -45,7 +45,7 @@ export default defineConfig({
       ]),
     },
     rollupOptions: {
-      external: ["react", "react-dom"],
+      external: ["react", "react-dom", "@react-aria/ssr"],
       output: [
         {
           format: "cjs",


### PR DESCRIPTION
## 📝 Changes

- Remove `@react-aria/ssr` from being embedded in the build to allow for apps to have a singleton instance of `SSRProvider`. Addresses `When server rendering, you must wrap your application in an <SSRProvider> to ensure consistent ids are generated between the client and server.` warnings.

## ✅ Checklist

- [x] Visuals are complete and match Figma
- [x] Code is complete and in accordance with our style guide
- [x] Design and theme tokens are audited for any relevant changes
- [x] Unit tests are written and passing
- [x] TSDoc is written or updated for any component API surface area
- [x] Stories in Storybook accompany any relevant component changes
- [x] Ensure no accessibility violations are reported in Storybook
- [x] Specs and documentation are up-to-date
- [x] Cross-browser check is performed (Chrome, Safari, Firefox)
- [x] Changeset is added
