### PR TITLE
fix: typescript version for lint warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "storybook": "7.6.20",
         "stylelint": "^16.9.0",
         "turbo": "^1.13.4",
-        "typescript": "^5.6.2",
+        "typescript": "~5.5.4",
         "vite": "^5.4.8",
         "vitest": "^1.6.0"
       },
@@ -20073,9 +20073,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
-      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -35487,9 +35487,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
-      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true
     },
     "ufo": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "storybook": "7.6.20",
     "stylelint": "^16.9.0",
     "turbo": "^1.13.4",
-    "typescript": "^5.6.2",
+    "typescript": "~5.5.4",
     "vite": "^5.4.8",
     "vitest": "^1.6.0"
   }


### PR DESCRIPTION
## 📝 Changes

Fixes typescript version warning:

<img width="1120" alt="image" src="https://github.com/user-attachments/assets/166bd4ba-ef2c-4d63-a9db-f137ba333f9d">

## ✅ ~Checklist~

_Not applicable to change._

- [ ] Visuals are complete and match Figma
- [ ] Code is complete and in accordance with our style guide
- [ ] Design and theme tokens are audited for any relevant changes
- [ ] Unit tests are written and passing
- [ ] TSDoc is written or updated for any component API surface area
- [ ] Stories in Storybook accompany any relevant component changes
- [ ] Ensure no accessibility violations are reported in Storybook
- [ ] Specs and documentation are up-to-date
- [ ] Cross-browser check is performed (Chrome, Safari, Firefox)
- [ ] Changeset is added
