### PR TITLE
feat(DataGrid): add size, header variant, row click, and new colors

### DIFF
--- a/.changeset/clean-pugs-provide.md
+++ b/.changeset/clean-pugs-provide.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": minor
+---
+
+feat(DataGrid): add size support and fix colors

--- a/.changeset/nervous-goats-mate.md
+++ b/.changeset/nervous-goats-mate.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+fix(DataGrid): update header, hover, kebab colors

--- a/.changeset/nervous-goats-mate.md
+++ b/.changeset/nervous-goats-mate.md
@@ -1,5 +1,0 @@
----
-"@easypost/easy-ui": patch
----
-
-fix(DataGrid): update header, hover, kebab colors

--- a/documentation/specs/DataGrid.md
+++ b/documentation/specs/DataGrid.md
@@ -62,7 +62,7 @@ type DataGridProps<C extends Column> = AriaLabelingProps & {
    * Variant of the data grid header to use.
    * @default primary
    */
-  headerVariant?: "primary" | "secondary";
+  headerVariant?: "primary" | "secondary" | "emphasized";
 
   /** Constrains the height of the data grid to a set number of rows. */
   maxRows?: number;
@@ -103,16 +103,14 @@ type DataGridProps<C extends Column> = AriaLabelingProps & {
   /** The type of selection that is allowed in the collection. */
   selectionMode?: "none" | "single" | "multiple";
 
+  /**
+   * Visual compactness of the DataGrid.
+   * @default md
+   */
+  size?: "sm" | "md" | "lg";
+
   /** The current sorted column and direction. */
   sortDescriptor?: SortDescriptor;
-
-  /**
-   * Define a custom grid-template-columns.
-   * Defaults to taking up an even amount of space.
-   *
-   * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-columns Template columns MDN reference}
-   */
-  templateColumns?: string;
 };
 
 type MenuRowAction = {

--- a/easy-ui-react/src/DataGrid/ActionsCellContent.module.scss
+++ b/easy-ui-react/src/DataGrid/ActionsCellContent.module.scss
@@ -4,3 +4,13 @@
   display: inline-flex;
   gap: design-token("space.1.5");
 }
+
+.MenuButton {
+  display: inline-flex;
+  border-radius: design-token("shape.border_radius.sm");
+}
+
+.open {
+  background: design-token("color.primary.700");
+  color: design-token("color.neutral.000");
+}

--- a/easy-ui-react/src/DataGrid/ActionsCellContent.tsx
+++ b/easy-ui-react/src/DataGrid/ActionsCellContent.tsx
@@ -1,8 +1,9 @@
 import MoreVertIcon from "@easypost/easy-ui-icons/MoreVert";
-import React, { useCallback } from "react";
+import React, { useCallback, useState } from "react";
 import { Icon } from "../Icon";
 import { Menu } from "../Menu";
 import { Text } from "../Text";
+import { classNames } from "../utilities/css";
 import { UnstyledPressButton } from "./UnstyledPressButton";
 import { useDataGridRow } from "./context";
 import {
@@ -34,13 +35,21 @@ export function ActionsCellContent({ rowActions }: ActionsCellContentProps) {
 function MenuRowAction({ rowAction }: { rowAction: MenuRowActionType }) {
   const { accessibilityLabel = "Actions" } = rowAction;
   const { removeHover } = useDataGridRow();
+  const [isOpen, setIsOpen] = useState(false);
+
   const handleClick = useCallback(() => {
     removeHover();
   }, [removeHover]);
+
+  const handleOpenChange = useCallback((isOpen: boolean) => {
+    setIsOpen(isOpen);
+  }, []);
+
+  const className = classNames(styles.MenuButton, isOpen && styles.open);
   return (
-    <Menu>
+    <Menu isOpen={isOpen} onOpenChange={handleOpenChange}>
       <Menu.Trigger>
-        <UnstyledPressButton onPress={handleClick}>
+        <UnstyledPressButton onPress={handleClick} className={className}>
           <Text visuallyHidden>{accessibilityLabel}</Text>
           <Icon symbol={MoreVertIcon} />
         </UnstyledPressButton>

--- a/easy-ui-react/src/DataGrid/Cell.module.scss
+++ b/easy-ui-react/src/DataGrid/Cell.module.scss
@@ -2,27 +2,37 @@
 @use "mixins" as DataGrid;
 
 .Cell {
-  @include font-style("body1");
-
-  display: inline-flex;
-  align-items: center;
-  padding: 0 design-token("space.2");
-
   background: component-token("data-grid", "cell-bg");
   border-bottom: design-token("shape.border_width.1") solid
     component-token("data-grid", "cell-border-color");
   color: component-token("data-grid", "cell-text");
-  height: component-token("data-grid", "body-row-height");
+  padding: 0 design-token("space.2");
   z-index: component-token("data-grid", "cell-z-index");
+  outline: none;
+}
+
+.content {
+  @include font-style("body1");
+  display: inline-flex;
+  align-items: center;
+  height: calc(
+    component-token("data-grid", "body-row-height") - design-token(
+        "shape.border_width.1"
+      )
+  );
 }
 
 .lastRow {
   border-bottom: 0;
 }
 
-.focused {
-  outline-offset: -1px;
-  @include native-focus-ring;
+.focused,
+.rowFocused {
+  @include component-token(
+    "data-grid",
+    "cell-bg",
+    design-token("color.neutral.050")
+  );
 }
 
 .expanded {

--- a/easy-ui-react/src/DataGrid/Cell.module.scss
+++ b/easy-ui-react/src/DataGrid/Cell.module.scss
@@ -9,9 +9,15 @@
   padding: 0 design-token("space.2");
 
   background: component-token("data-grid", "cell-bg");
+  border-bottom: design-token("shape.border_width.1") solid
+    component-token("data-grid", "cell-border-color");
   color: component-token("data-grid", "cell-text");
   height: component-token("data-grid", "body-row-height");
   z-index: component-token("data-grid", "cell-z-index");
+}
+
+.lastRow {
+  border-bottom: 0;
 }
 
 .focused {

--- a/easy-ui-react/src/DataGrid/Cell.tsx
+++ b/easy-ui-react/src/DataGrid/Cell.tsx
@@ -52,6 +52,8 @@ export function Cell({ cell, state }: CellProps) {
     hasActionsAtEnd &&
       cell.index === state.collection.columnCount - 2 &&
       styles.secondToLastWithActions,
+    row.index === 0 && styles.firstRow,
+    row.index === state.collection.size - 1 && styles.lastRow,
   );
 
   const CellContentComponent = cell.props.isSelectionCell

--- a/easy-ui-react/src/DataGrid/Cell.tsx
+++ b/easy-ui-react/src/DataGrid/Cell.tsx
@@ -40,6 +40,7 @@ export function Cell({ cell, state }: CellProps) {
     styles.Cell,
     isFocusVisible && styles.focused,
     row.isExpanded && styles.expanded,
+    row.isFocusVisible && styles.rowFocused,
     hasRightShadow && styles[variationName("shadow", "right")],
     hasLeftShadow && styles[variationName("shadow", "left")],
     cell.index === 0 && styles.first,
@@ -61,14 +62,16 @@ export function Cell({ cell, state }: CellProps) {
     : DefaultCellContent;
 
   return (
-    <div
+    <td
       {...mergeProps(gridCellProps, focusProps)}
       ref={ref}
       className={className}
     >
-      <CellContentComponent cell={cell} state={state} />
-      <div data-ezui-data-grid-shadow />
-    </div>
+      <div className={styles.content}>
+        <CellContentComponent cell={cell} state={state} />
+        <div data-ezui-data-grid-shadow />
+      </div>
+    </td>
   );
 }
 

--- a/easy-ui-react/src/DataGrid/ColumnHeader.module.scss
+++ b/easy-ui-react/src/DataGrid/ColumnHeader.module.scss
@@ -2,7 +2,7 @@
 @use "mixins" as DataGrid;
 
 .ColumnHeader {
-  @include font-style("subtitle2");
+  @include font-style("subtitle1");
 
   display: inline-flex;
   align-items: center;

--- a/easy-ui-react/src/DataGrid/ColumnHeader.module.scss
+++ b/easy-ui-react/src/DataGrid/ColumnHeader.module.scss
@@ -2,19 +2,20 @@
 @use "mixins" as DataGrid;
 
 .ColumnHeader {
-  @include font-style("subtitle1");
-
-  display: inline-flex;
-  align-items: center;
-  padding: 0 design-token("space.2");
-
   position: sticky;
   top: 0;
   background: component-token("data-grid", "header-bg");
   color: component-token("data-grid", "header-text");
-  height: component-token("data-grid", "header-row-height");
-  z-index: component-token("data-grid", "column-z-index");
   outline: none;
+  padding: 0 design-token("space.2");
+  z-index: component-token("data-grid", "column-z-index");
+}
+
+.content {
+  @include font-style("subtitle1");
+  display: inline-flex;
+  align-items: center;
+  height: component-token("data-grid", "header-row-height");
 }
 
 .allowsSorting {

--- a/easy-ui-react/src/DataGrid/ColumnHeader.tsx
+++ b/easy-ui-react/src/DataGrid/ColumnHeader.tsx
@@ -59,21 +59,28 @@ export function ColumnHeader({ column, state }: ColumnHeaderProps) {
       styles.secondToLastWithActions,
   );
 
+  const contentClassName = classNames(
+    styles.content,
+    column.props.allowsSorting && styles.allowsSorting,
+  );
+
   const ColumnHeaderContentComponent = column.props.isSelectionCell
     ? SelectAllColumnHeaderContent
     : DefaultColumnHeaderContent;
 
   return (
-    <div
+    <td
       ref={ref}
       {...mergeProps(columnHeaderProps, focusProps)}
       className={className}
       data-ezui-data-grid-column-header="true"
     >
-      <ColumnHeaderContentComponent column={column} state={state} />
-      <div data-ezui-data-grid-shadow="bottom" />
-      <div data-ezui-data-grid-shadow="side" />
-    </div>
+      <div className={contentClassName}>
+        <ColumnHeaderContentComponent column={column} state={state} />
+        <div data-ezui-data-grid-shadow="bottom" />
+        <div data-ezui-data-grid-shadow="side" />
+      </div>
+    </td>
   );
 }
 

--- a/easy-ui-react/src/DataGrid/DataGrid.mdx
+++ b/easy-ui-react/src/DataGrid/DataGrid.mdx
@@ -80,8 +80,8 @@ const rows = [
     // update row order
   }}
   columnKeysAllowingSort={["name"]}
-  // Provide a custom grid-template-columns value
-  templateColumns="repeat(2, 1fr)"
+  // "sm", "md" (default), or "lg"
+  size="lg"
 />;
 ```
 

--- a/easy-ui-react/src/DataGrid/DataGrid.mdx
+++ b/easy-ui-react/src/DataGrid/DataGrid.mdx
@@ -44,6 +44,10 @@ const rows = [
   rows={rows}
   renderColumnCell={(column) => <span>{String(column.name)}</span>}
   renderRowCell={(item, columnKey, row) => <span>{String(item)}</span>}
+  // Handler that is called when a user performs an action on the cell
+  onCellAction={(key) => {}}
+  // Handler that is called when a user performs an action on the row
+  onRowAction={(key: Key) => {}}
   // Enable row expansion
   renderExpandedRow={(rowKey: Key) => <div>Expanded row content</div>}
   defaultExpandedKey={1}

--- a/easy-ui-react/src/DataGrid/DataGrid.mdx
+++ b/easy-ui-react/src/DataGrid/DataGrid.mdx
@@ -222,7 +222,7 @@ In the example below, to make the status text green or red depending on whether 
 
 ## Header Variant
 
-`DataGrid` supports an alternate header color through the `headerVariant` prop. Pass `secondary` as the alternate color for the header.
+`DataGrid` supports alternate header styles through the `headerVariant` prop. Pass `secondary` or `emphasized` as alternate versions of the header.
 
 <Canvas of={DataGridStories.WithHeaderVariant} />
 

--- a/easy-ui-react/src/DataGrid/DataGrid.mdx
+++ b/easy-ui-react/src/DataGrid/DataGrid.mdx
@@ -195,6 +195,14 @@ function SortableDataGrid(args: DataGridProps) {
 
 <Canvas of={DataGridStories.WithSort} />
 
+## With Custom Size
+
+`DataGrid` supports `sm`, `md`, and `lg` row heights with the `size` prop.
+
+<Canvas of={DataGridStories.WithCustomSize} />
+
+<Controls of={DataGridStories.WithCustomSize} />
+
 ## With Custom Rendering
 
 `DataGrid` supports custom rendering of content for row and column cells using the `renderRowCell` and `renderColumnCell` props.

--- a/easy-ui-react/src/DataGrid/DataGrid.module.scss
+++ b/easy-ui-react/src/DataGrid/DataGrid.module.scss
@@ -91,6 +91,11 @@
   @include component-token("data-grid", "body-row-height", 80px);
 }
 
+.innerContainer {
+  position: relative;
+  min-width: min-content;
+}
+
 .contents {
   display: contents;
 }

--- a/easy-ui-react/src/DataGrid/DataGrid.module.scss
+++ b/easy-ui-react/src/DataGrid/DataGrid.module.scss
@@ -53,9 +53,9 @@
   );
   @include component-token("data-grid", "cell-z-index", 1);
   @include component-token("data-grid", "cell-stuck-z-index", 2);
-  @include component-token("data-grid", "column-z-index", 3);
-  @include component-token("data-grid", "column-stuck-z-index", 4);
-  @include component-token("data-grid", "expanded-row-z-index", 5);
+  @include component-token("data-grid", "expanded-row-z-index", 3);
+  @include component-token("data-grid", "column-z-index", 4);
+  @include component-token("data-grid", "column-stuck-z-index", 5);
   @include component-token("data-grid", "sticky-left-offset", -16px);
   @include component-token("data-grid", "sticky-right-offset", -12px);
   @include component-token("data-grid", "action-cell-width", 44px);

--- a/easy-ui-react/src/DataGrid/DataGrid.module.scss
+++ b/easy-ui-react/src/DataGrid/DataGrid.module.scss
@@ -12,7 +12,7 @@
     design-token("color.neutral.000")
   );
   @include component-token("data-grid", "header-row-height", 48px);
-  @include component-token("data-grid", "body-row-height", 56px);
+  @include component-token("data-grid", "body-row-height", 48px);
   @include component-token("data-grid", "expand-btn-size", 24px);
   @include component-token(
     "data-grid",
@@ -27,7 +27,12 @@
   @include component-token(
     "data-grid",
     "border-color",
-    design-token("color.neutral.300")
+    design-token("color.neutral.200")
+  );
+  @include component-token(
+    "data-grid",
+    "cell-border-color",
+    design-token("color.neutral.100")
   );
   @include component-token("data-grid", "sticky-shadow-size", 8px);
   @include component-token("data-grid", "sticky-shadow-opacity", 0.5);
@@ -44,7 +49,7 @@
   @include component-token(
     "data-grid",
     "cell-text",
-    design-token("color.primary.800")
+    design-token("color.primary.900")
   );
   @include component-token("data-grid", "cell-z-index", 1);
   @include component-token("data-grid", "cell-stuck-z-index", 2);
@@ -56,7 +61,7 @@
 
   border: component-token("data-grid", "border-width") solid
     component-token("data-grid", "border-color");
-  border-radius: design-token("shape.border_radius.md");
+  border-radius: design-token("shape.border_radius.lg");
   /* stylelint-disable scss/operator-no-newline-after */
   max-height: calc(
     (component-token("data-grid", "border-width") * 2) +
@@ -86,6 +91,15 @@
   grid-template-rows: auto;
   grid-template-areas: component-token("data-grid", "template-areas");
   grid-template-columns: component-token("data-grid", "template-columns");
+}
+
+.sizeSm {
+  @include component-token("data-grid", "header-row-height", 32px);
+  @include component-token("data-grid", "body-row-height", 32px);
+}
+
+.sizeLg {
+  @include component-token("data-grid", "body-row-height", 80px);
 }
 
 .headerSecondary {

--- a/easy-ui-react/src/DataGrid/DataGrid.module.scss
+++ b/easy-ui-react/src/DataGrid/DataGrid.module.scss
@@ -55,6 +55,7 @@
   @include component-token("data-grid", "cell-stuck-z-index", 2);
   @include component-token("data-grid", "column-z-index", 3);
   @include component-token("data-grid", "column-stuck-z-index", 4);
+  @include component-token("data-grid", "expanded-row-z-index", 5);
   @include component-token("data-grid", "sticky-left-offset", -16px);
   @include component-token("data-grid", "sticky-right-offset", -12px);
   @include component-token("data-grid", "action-cell-width", 44px);
@@ -74,23 +75,11 @@
   /* stylelint-enable scss/operator-no-newline-after */
   overflow: auto;
   position: relative;
+  line-height: 0;
 
   [data-ezui-data-grid-shadow] {
     position: absolute;
   }
-}
-
-.contents {
-  display: contents;
-}
-
-.table {
-  position: relative;
-  min-width: min-content;
-  display: grid;
-  grid-template-rows: auto;
-  grid-template-areas: component-token("data-grid", "template-areas");
-  grid-template-columns: component-token("data-grid", "template-columns");
 }
 
 .sizeSm {
@@ -100,6 +89,18 @@
 
 .sizeLg {
   @include component-token("data-grid", "body-row-height", 80px);
+}
+
+.contents {
+  display: contents;
+}
+
+.table {
+  position: relative;
+  min-width: min-content;
+  display: table;
+  border-collapse: collapse;
+  width: 100%;
 }
 
 .headerSecondary {

--- a/easy-ui-react/src/DataGrid/DataGrid.module.scss
+++ b/easy-ui-react/src/DataGrid/DataGrid.module.scss
@@ -100,3 +100,11 @@
     design-token("color.primary.800")
   );
 }
+
+.headerEmphasized {
+  @include component-token(
+    "data-grid",
+    "header-bg",
+    design-token("color.primary.900")
+  );
+}

--- a/easy-ui-react/src/DataGrid/DataGrid.module.scss
+++ b/easy-ui-react/src/DataGrid/DataGrid.module.scss
@@ -59,6 +59,7 @@
   @include component-token("data-grid", "sticky-left-offset", -16px);
   @include component-token("data-grid", "sticky-right-offset", -12px);
   @include component-token("data-grid", "action-cell-width", 44px);
+  @include component-token("data-grid", "expanded-row-opacity", 0);
 
   border: component-token("data-grid", "border-width") solid
     component-token("data-grid", "border-color");

--- a/easy-ui-react/src/DataGrid/DataGrid.module.scss
+++ b/easy-ui-react/src/DataGrid/DataGrid.module.scss
@@ -4,12 +4,12 @@
   @include component-token(
     "data-grid",
     "header-bg",
-    design-token("color.blue.800")
+    design-token("color.primary.700")
   );
   @include component-token(
     "data-grid",
     "header-text",
-    design-token("color.white")
+    design-token("color.neutral.000")
   );
   @include component-token("data-grid", "header-row-height", 48px);
   @include component-token("data-grid", "body-row-height", 56px);
@@ -17,7 +17,7 @@
   @include component-token(
     "data-grid",
     "sort-icon-color",
-    design-token("color.gray.500")
+    design-token("color.neutral.500")
   );
   @include component-token(
     "data-grid",
@@ -27,20 +27,24 @@
   @include component-token(
     "data-grid",
     "border-color",
-    design-token("color.gray.300")
+    design-token("color.neutral.300")
   );
   @include component-token("data-grid", "sticky-shadow-size", 8px);
   @include component-token("data-grid", "sticky-shadow-opacity", 0.5);
   @include component-token(
     "data-grid",
     "sticky-shadow-color",
-    design-token("color.gray.500")
+    design-token("color.neutral.500")
   );
-  @include component-token("data-grid", "cell-bg", design-token("color.white"));
+  @include component-token(
+    "data-grid",
+    "cell-bg",
+    design-token("color.neutral.000")
+  );
   @include component-token(
     "data-grid",
     "cell-text",
-    design-token("color.blue.800")
+    design-token("color.primary.800")
   );
   @include component-token("data-grid", "cell-z-index", 1);
   @include component-token("data-grid", "cell-stuck-z-index", 2);
@@ -88,11 +92,11 @@
   @include component-token(
     "data-grid",
     "header-bg",
-    design-token("color.gray.050")
+    design-token("color.neutral.050")
   );
   @include component-token(
     "data-grid",
     "header-text",
-    design-token("color.blue.800")
+    design-token("color.primary.800")
   );
 }

--- a/easy-ui-react/src/DataGrid/DataGrid.stories.tsx
+++ b/easy-ui-react/src/DataGrid/DataGrid.stories.tsx
@@ -170,7 +170,7 @@ export const WithKebabMenu: Story = {
 };
 
 export const WithHeaderVariant: Story = {
-  render: Template.bind({}),
+  render: WithSortTemplate.bind({}),
   args: {
     "aria-label": "Example data grid with header variant",
     headerVariant: "secondary",

--- a/easy-ui-react/src/DataGrid/DataGrid.stories.tsx
+++ b/easy-ui-react/src/DataGrid/DataGrid.stories.tsx
@@ -196,7 +196,6 @@ export const WithCustomSize: Story = {
   render: WithSortTemplate.bind({}),
   args: {
     "aria-label": "Example data grid with custom size",
-    onRowAction: action("Row action!"),
     selectionMode: "multiple",
     size: "lg",
   },

--- a/easy-ui-react/src/DataGrid/DataGrid.stories.tsx
+++ b/easy-ui-react/src/DataGrid/DataGrid.stories.tsx
@@ -189,6 +189,20 @@ export const WithSort: Story = {
   },
 };
 
+export const WithCustomSize: Story = {
+  render: WithSortTemplate.bind({}),
+  args: {
+    "aria-label": "Example data grid with custom size",
+    selectionMode: "multiple",
+    size: "lg",
+  },
+  parameters: {
+    controls: {
+      include: ["size"],
+    },
+  },
+};
+
 export const WithCustomRendering: Story = {
   render: Template.bind({}),
   args: {

--- a/easy-ui-react/src/DataGrid/DataGrid.stories.tsx
+++ b/easy-ui-react/src/DataGrid/DataGrid.stories.tsx
@@ -111,6 +111,7 @@ export const Default: Story = {
   render: Template.bind({}),
   args: {
     "aria-label": "Example data grid",
+    onRowAction: action("Row action!"),
   },
   parameters: {
     controls: {
@@ -142,6 +143,7 @@ export const WithRowExpansion: Story = {
   render: Template.bind({}),
   args: {
     "aria-label": "Example data grid with row expansion",
+    onRowAction: action("Row action!"),
     renderExpandedRow: (rowKey: Key) => (
       <PlaceholderBox width="100%" height="140px">
         Space for row {rowKey} content
@@ -154,6 +156,7 @@ export const WithKebabMenu: Story = {
   render: Template.bind({}),
   args: {
     "aria-label": "Example data grid with kebab menu",
+    onRowAction: action("Row action!"),
     rowActions: () => [
       {
         type: "menu",
@@ -172,6 +175,7 @@ export const WithHeaderVariant: Story = {
   render: WithSortTemplate.bind({}),
   args: {
     "aria-label": "Example data grid with header variant",
+    onRowAction: action("Row action!"),
     headerVariant: "secondary",
   },
   parameters: {
@@ -192,6 +196,7 @@ export const WithCustomSize: Story = {
   render: WithSortTemplate.bind({}),
   args: {
     "aria-label": "Example data grid with custom size",
+    onRowAction: action("Row action!"),
     selectionMode: "multiple",
     size: "lg",
   },
@@ -206,6 +211,7 @@ export const WithCustomRendering: Story = {
   render: Template.bind({}),
   args: {
     "aria-label": "Example data grid with custom rendering",
+    onRowAction: action("Row action!"),
     renderRowCell(cell, columnKey) {
       if (columnKey === "status") {
         return (
@@ -228,6 +234,7 @@ export const WithIcons: Story = {
   render: Template.bind({}),
   args: {
     "aria-label": "Example data grid with icons",
+    onRowAction: action("Row action!"),
     renderRowCell(cell, columnKey) {
       if (columnKey === "status") {
         return (
@@ -246,6 +253,7 @@ export const WithRowExpansionAndKebabMenu: Story = {
   args: {
     "aria-label": "Example data grid with row expansion and kebab menu",
     rows,
+    onRowAction: action("Row action!"),
     renderExpandedRow: (rowKey: Key) => (
       <PlaceholderBox width="100%" height="140px">
         Space for row {rowKey} content

--- a/easy-ui-react/src/DataGrid/DataGrid.stories.tsx
+++ b/easy-ui-react/src/DataGrid/DataGrid.stories.tsx
@@ -263,6 +263,35 @@ export const WithRowExpansionAndKebabMenu: Story = {
       },
     ],
   },
+  parameters: {
+    controls: {
+      include: ["size", "maxRows"],
+    },
+  },
+};
+
+export const WithSelectionAndSortAndKebabMenu: Story = {
+  render: WithSortTemplate.bind({}),
+  args: {
+    "aria-label": "Example data grid with selection and sort and kebab menu",
+    selectionMode: "multiple",
+    rowActions: () => [
+      {
+        type: "menu",
+        renderMenuOverlay: () => (
+          <Menu.Overlay onAction={action("Menu item clicked!")}>
+            <Menu.Item>Action 1</Menu.Item>
+            <Menu.Item>Action 2</Menu.Item>
+          </Menu.Overlay>
+        ),
+      },
+    ],
+  },
+  parameters: {
+    controls: {
+      include: ["size", "maxRows"],
+    },
+  },
 };
 
 function WithSortTemplate(args: Partial<DataGridProps>) {

--- a/easy-ui-react/src/DataGrid/DataGrid.stories.tsx
+++ b/easy-ui-react/src/DataGrid/DataGrid.stories.tsx
@@ -97,7 +97,6 @@ const meta: Meta<typeof DataGrid> = {
   args: {
     headerVariant: "primary",
     selectionMode: "none",
-    templateColumns: "min-content 1fr min-content min-content min-content",
   },
   parameters: {
     controls: {

--- a/easy-ui-react/src/DataGrid/DataGrid.test.tsx
+++ b/easy-ui-react/src/DataGrid/DataGrid.test.tsx
@@ -43,7 +43,7 @@ describe("<DataGrid />", () => {
 
   it("should support max rows", () => {
     render(createDataGrid({ maxRows: 8 }));
-    expect(getContainer()).toHaveStyle(
+    expect(getOuterContainer()).toHaveStyle(
       getComponentToken("data-grid", "max-rows", "8"),
     );
   });
@@ -58,7 +58,7 @@ describe("<DataGrid />", () => {
 
   it("should support custom size", () => {
     render(createDataGrid({ size: "lg" }));
-    expect(screen.getByRole("grid").parentElement).toHaveAttribute(
+    expect(getOuterContainer()).toHaveAttribute(
       "class",
       expect.stringContaining("sizeLg"),
     );
@@ -246,7 +246,11 @@ function createDataGrid(props: Partial<DataGridProps> = {}) {
   );
 }
 
-function getContainer() {
+function getOuterContainer() {
+  return getInnerContainer().parentElement as HTMLElement;
+}
+
+function getInnerContainer() {
   return screen.getByRole("grid").parentElement as HTMLElement;
 }
 

--- a/easy-ui-react/src/DataGrid/DataGrid.test.tsx
+++ b/easy-ui-react/src/DataGrid/DataGrid.test.tsx
@@ -48,13 +48,6 @@ describe("<DataGrid />", () => {
     );
   });
 
-  it("should support custom template columns", () => {
-    render(createDataGrid({ templateColumns: "1fr 2fr" }));
-    expect(getContainer()).toHaveStyle(
-      getComponentToken("data-grid", "template-columns", "1fr 2fr"),
-    );
-  });
-
   it("should support a header variant", () => {
     render(createDataGrid({ headerVariant: "secondary" }));
     expect(screen.getByRole("grid")).toHaveAttribute(
@@ -65,7 +58,7 @@ describe("<DataGrid />", () => {
 
   it("should support custom size", () => {
     render(createDataGrid({ size: "lg" }));
-    expect(screen.getByRole("grid")).toHaveAttribute(
+    expect(screen.getByRole("grid").parentElement).toHaveAttribute(
       "class",
       expect.stringContaining("sizeLg"),
     );

--- a/easy-ui-react/src/DataGrid/DataGrid.test.tsx
+++ b/easy-ui-react/src/DataGrid/DataGrid.test.tsx
@@ -63,6 +63,14 @@ describe("<DataGrid />", () => {
     );
   });
 
+  it("should support custom size", () => {
+    render(createDataGrid({ size: "lg" }));
+    expect(screen.getByRole("grid")).toHaveAttribute(
+      "class",
+      expect.stringContaining("sizeLg"),
+    );
+  });
+
   it("should support multiple selection", async () => {
     const handleSelectionChange = vi.fn();
     const { user } = render(

--- a/easy-ui-react/src/DataGrid/ExpandedRowContent.module.scss
+++ b/easy-ui-react/src/DataGrid/ExpandedRowContent.module.scss
@@ -5,7 +5,13 @@
   left: 0;
   right: 0;
   top: component-token("data-grid", "expanded-row-position");
+  margin-top: component-token("data-grid", "body-row-height");
   opacity: component-token("data-grid", "expanded-row-opacity");
   padding: design-token("space.1") design-token("space.5");
+  pointer-events: none;
   z-index: component-token("data-grid", "expanded-row-z-index");
+}
+
+.inner {
+  pointer-events: auto;
 }

--- a/easy-ui-react/src/DataGrid/ExpandedRowContent.module.scss
+++ b/easy-ui-react/src/DataGrid/ExpandedRowContent.module.scss
@@ -7,4 +7,5 @@
   top: component-token("data-grid", "expanded-row-position");
   opacity: component-token("data-grid", "expanded-row-opacity");
   padding: design-token("space.1") design-token("space.5");
+  z-index: component-token("data-grid", "expanded-row-z-index");
 }

--- a/easy-ui-react/src/DataGrid/ExpandedRowContent.tsx
+++ b/easy-ui-react/src/DataGrid/ExpandedRowContent.tsx
@@ -13,7 +13,7 @@ export function ExpandedRowContent({ children }: ExpandedRowContentProps) {
       className={classNames(styles.ExpandedRowContent)}
       data-ezui-data-grid-expanded-row-content="active"
     >
-      <div>{children}</div>
+      <div className={classNames(styles.inner)}>{children}</div>
     </div>
   );
 }

--- a/easy-ui-react/src/DataGrid/HeaderRow.tsx
+++ b/easy-ui-react/src/DataGrid/HeaderRow.tsx
@@ -3,7 +3,7 @@ import React, { ReactNode, useRef } from "react";
 import { useTableHeaderRow } from "react-aria";
 import { TableState } from "react-stately";
 
-import styles from "./DataGrid.module.scss";
+import styles from "./Row.module.scss";
 
 type HeaderRowProps<T = unknown> = {
   item: Node<T>;
@@ -15,8 +15,8 @@ export function HeaderRow({ item, state, children }: HeaderRowProps) {
   const ref = useRef(null);
   const { rowProps } = useTableHeaderRow({ node: item }, state, ref);
   return (
-    <div {...rowProps} ref={ref} className={styles.contents}>
+    <tr {...rowProps} ref={ref} className={styles.Row}>
       {children}
-    </div>
+    </tr>
   );
 }

--- a/easy-ui-react/src/DataGrid/Row.module.scss
+++ b/easy-ui-react/src/DataGrid/Row.module.scss
@@ -3,6 +3,8 @@
 .Row {
   vertical-align: top;
   outline: none;
+  user-select: none;
+  cursor: default;
 }
 
 .expanded {

--- a/easy-ui-react/src/DataGrid/Row.module.scss
+++ b/easy-ui-react/src/DataGrid/Row.module.scss
@@ -1,7 +1,17 @@
 @use "../styles/common" as *;
 
 .Row {
-  display: contents;
+  vertical-align: top;
+  outline: none;
+}
+
+.expanded {
+  /* stylelint-disable scss/operator-no-newline-after */
+  height: calc(
+    component-token("data-grid", "body-row-height") +
+      component-token("data-grid", "expanded-row-height")
+  );
+  /* stylelint-enable scss/operator-no-newline-after */
 }
 
 .hovered {

--- a/easy-ui-react/src/DataGrid/Row.module.scss
+++ b/easy-ui-react/src/DataGrid/Row.module.scss
@@ -8,11 +8,11 @@
   @include component-token(
     "data-grid",
     "cell-bg",
-    design-token("color.gray.050")
+    design-token("color.neutral.025")
   );
   @include component-token(
     "data-grid",
     "cell-text",
-    design-token("color.blue.700")
+    design-token("color.primary.700")
   );
 }

--- a/easy-ui-react/src/DataGrid/Row.module.scss
+++ b/easy-ui-react/src/DataGrid/Row.module.scss
@@ -8,11 +8,22 @@
   @include component-token(
     "data-grid",
     "cell-bg",
-    design-token("color.neutral.025")
+    design-token("color.neutral.050")
   );
+}
+
+.selected {
   @include component-token(
     "data-grid",
-    "cell-text",
-    design-token("color.primary.700")
+    "cell-bg",
+    design-token("color.primary.050")
+  );
+}
+
+.selected.hovered {
+  @include component-token(
+    "data-grid",
+    "cell-bg",
+    design-token("color.primary.100")
   );
 }

--- a/easy-ui-react/src/DataGrid/Row.tsx
+++ b/easy-ui-react/src/DataGrid/Row.tsx
@@ -27,6 +27,7 @@ export function Row({ item, children, state, isExpanded }: RowProps) {
   const isPendingExpanded = item.value
     ? item.value[EXPAND_COLUMN_KEY as keyof typeof item.value] === true
     : false;
+  const rowIndex = item.index;
 
   const ref = useRef(null);
   const { rowProps, isPressed } = useTableRow({ node: item }, state, ref);
@@ -49,8 +50,8 @@ export function Row({ item, children, state, isExpanded }: RowProps) {
   }, [hoverProps]);
 
   const context = useMemo(() => {
-    return { isExpanded, removeHover };
-  }, [isExpanded, removeHover]);
+    return { isExpanded, removeHover, index: rowIndex };
+  }, [isExpanded, removeHover, rowIndex]);
 
   const className = classNames(
     styles.Row,

--- a/easy-ui-react/src/DataGrid/Row.tsx
+++ b/easy-ui-react/src/DataGrid/Row.tsx
@@ -50,8 +50,8 @@ export function Row({ item, children, state, isExpanded }: RowProps) {
   }, [hoverProps]);
 
   const context = useMemo(() => {
-    return { isExpanded, removeHover, index: rowIndex };
-  }, [isExpanded, removeHover, rowIndex]);
+    return { isExpanded, isFocusVisible, removeHover, index: rowIndex };
+  }, [isExpanded, isFocusVisible, removeHover, rowIndex]);
 
   const className = classNames(
     styles.Row,
@@ -65,7 +65,7 @@ export function Row({ item, children, state, isExpanded }: RowProps) {
 
   return (
     <DataGridRowContext.Provider value={context}>
-      <div
+      <tr
         ref={ref}
         {...mergeProps(rowProps, focusProps, hoverProps)}
         className={className}
@@ -73,7 +73,7 @@ export function Row({ item, children, state, isExpanded }: RowProps) {
         data-ezui-data-grid-row="true"
       >
         {children}
-      </div>
+      </tr>
     </DataGridRowContext.Provider>
   );
 }

--- a/easy-ui-react/src/DataGrid/SortIndicator.module.scss
+++ b/easy-ui-react/src/DataGrid/SortIndicator.module.scss
@@ -15,7 +15,7 @@
   @include component-token(
     "data-grid",
     "sort-icon-color",
-    design-token("color.white")
+    design-token("color.neutral.000")
   );
 }
 
@@ -23,13 +23,13 @@
   @include component-token(
     "data-grid",
     "sort-icon-color",
-    design-token("color.gray.400")
+    design-token("color.neutral.400")
   );
   &.sorted {
     @include component-token(
       "data-grid",
       "sort-icon-color",
-      design-token("color.blue.800")
+      design-token("color.primary.800")
     );
   }
 }

--- a/easy-ui-react/src/DataGrid/Table.tsx
+++ b/easy-ui-react/src/DataGrid/Table.tsx
@@ -11,6 +11,7 @@ import { RowGroup } from "./RowGroup";
 import {
   ACTIONS_COLUMN_KEY,
   DEFAULT_MAX_ROWS,
+  DEFAULT_SIZE,
   EXPAND_COLUMN_KEY,
 } from "./constants";
 import { DataGridTableContext } from "./context";
@@ -31,6 +32,7 @@ export function Table<C extends Column>(props: TableProps<C>) {
     maxRows = DEFAULT_MAX_ROWS,
     renderExpandedRow = (r) => r,
     selectionMode,
+    size = DEFAULT_SIZE,
     templateColumns,
   } = props;
 
@@ -42,11 +44,7 @@ export function Table<C extends Column>(props: TableProps<C>) {
     selectionBehavior: "toggle",
     showSelectionCheckboxes: selectionMode !== "none",
   });
-  const { gridProps } = useTable(
-    { ...props, focusMode: "cell" },
-    state,
-    tableRef,
-  );
+  const { gridProps } = useTable(props, state, tableRef);
 
   const { expandedRow, expandedRowStyle } = useExpandedRow({ tableRef, state });
   const { gridTemplateStyle } = useGridTemplate({ templateColumns, state });
@@ -64,6 +62,7 @@ export function Table<C extends Column>(props: TableProps<C>) {
 
   const className = classNames(
     styles.table,
+    styles[variationName("size", size)],
     headerVariant && styles[variationName("header", headerVariant)],
     hasSelection && styles.hasSelection,
     hasExpansion && styles.hasExpansion,

--- a/easy-ui-react/src/DataGrid/Table.tsx
+++ b/easy-ui-react/src/DataGrid/Table.tsx
@@ -37,7 +37,7 @@ export function Table<C extends Column>(props: TableProps<C>) {
   } = props;
 
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const tableRef = useRef<HTMLDivElement | null>(null);
+  const tableRef = useRef<HTMLTableElement | null>(null);
   const state = useTableState({
     ...props,
     selectionMode,
@@ -60,9 +60,13 @@ export function Table<C extends Column>(props: TableProps<C>) {
   const hasExpansion = columns.some((c) => c.key === EXPAND_COLUMN_KEY);
   const hasRowActions = columns.some((c) => c.key === ACTIONS_COLUMN_KEY);
 
-  const className = classNames(
-    styles.table,
+  const dataGridClassName = classNames(
+    styles.DataGrid,
     styles[variationName("size", size)],
+  );
+
+  const tableClassName = classNames(
+    styles.table,
     headerVariant && styles[variationName("header", headerVariant)],
     hasSelection && styles.hasSelection,
     hasExpansion && styles.hasExpansion,
@@ -100,9 +104,9 @@ export function Table<C extends Column>(props: TableProps<C>) {
 
   return (
     <DataGridTableContext.Provider value={context}>
-      <div ref={containerRef} className={styles.DataGrid} style={style}>
-        <div {...gridProps} ref={tableRef} className={className}>
-          <RowGroup>
+      <div ref={containerRef} className={dataGridClassName} style={style}>
+        <table {...gridProps} ref={tableRef} className={tableClassName}>
+          <RowGroup as="thead">
             {collection.headerRows.map((headerRow) => (
               <HeaderRow key={headerRow.key} item={headerRow} state={state}>
                 {[...headerRow.childNodes].map((column) => (
@@ -115,7 +119,7 @@ export function Table<C extends Column>(props: TableProps<C>) {
               </HeaderRow>
             ))}
           </RowGroup>
-          <RowGroup>
+          <RowGroup as="tbody">
             {[...collection.body.childNodes].map((row) => (
               <Row
                 key={row.key}
@@ -135,7 +139,7 @@ export function Table<C extends Column>(props: TableProps<C>) {
             </ExpandedRowContent>
           )}
           {renderInterceptors()}
-        </div>
+        </table>
       </div>
     </DataGridTableContext.Provider>
   );

--- a/easy-ui-react/src/DataGrid/Table.tsx
+++ b/easy-ui-react/src/DataGrid/Table.tsx
@@ -18,7 +18,6 @@ import { DataGridTableContext } from "./context";
 import { Column, DataGridProps } from "./types";
 import { useEdgeInterceptors } from "./useEdgeInterceptors";
 import { useExpandedRow } from "./useExpandedRow";
-import { useGridTemplate } from "./useGridTemplate";
 
 import styles from "./DataGrid.module.scss";
 
@@ -33,7 +32,6 @@ export function Table<C extends Column>(props: TableProps<C>) {
     renderExpandedRow = (r) => r,
     selectionMode,
     size = DEFAULT_SIZE,
-    templateColumns,
   } = props;
 
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -46,8 +44,10 @@ export function Table<C extends Column>(props: TableProps<C>) {
   });
   const { gridProps } = useTable(props, state, tableRef);
 
-  const { expandedRow, expandedRowStyle } = useExpandedRow({ tableRef, state });
-  const { gridTemplateStyle } = useGridTemplate({ templateColumns, state });
+  const { expandedRow, expandedRowStyle } = useExpandedRow({
+    containerRef,
+    state,
+  });
   const [
     renderInterceptors,
     { isTopEdgeUnderScroll, isLeftEdgeUnderScroll, isRightEdgeUnderScroll },
@@ -78,7 +78,6 @@ export function Table<C extends Column>(props: TableProps<C>) {
 
   const style = {
     ...getComponentToken("data-grid", "max-rows", String(maxRows)),
-    ...gridTemplateStyle,
     ...expandedRowStyle,
   } as CSSProperties;
 
@@ -133,13 +132,13 @@ export function Table<C extends Column>(props: TableProps<C>) {
               </Row>
             ))}
           </RowGroup>
-          {expandedRow && (
-            <ExpandedRowContent>
-              {renderExpandedRow(expandedRow.key)}
-            </ExpandedRowContent>
-          )}
-          {renderInterceptors()}
         </table>
+        {expandedRow && (
+          <ExpandedRowContent>
+            {renderExpandedRow(expandedRow.key)}
+          </ExpandedRowContent>
+        )}
+        {renderInterceptors()}
       </div>
     </DataGridTableContext.Provider>
   );

--- a/easy-ui-react/src/DataGrid/Table.tsx
+++ b/easy-ui-react/src/DataGrid/Table.tsx
@@ -34,7 +34,8 @@ export function Table<C extends Column>(props: TableProps<C>) {
     size = DEFAULT_SIZE,
   } = props;
 
-  const containerRef = useRef<HTMLDivElement | null>(null);
+  const outerContainerRef = useRef<HTMLDivElement | null>(null);
+  const innerContainerRef = useRef<HTMLDivElement | null>(null);
   const tableRef = useRef<HTMLTableElement | null>(null);
   const state = useTableState({
     ...props,
@@ -45,13 +46,13 @@ export function Table<C extends Column>(props: TableProps<C>) {
   const { gridProps } = useTable(props, state, tableRef);
 
   const { expandedRow, expandedRowStyle } = useExpandedRow({
-    containerRef,
+    containerRef: innerContainerRef,
     state,
   });
   const [
     renderInterceptors,
     { isTopEdgeUnderScroll, isLeftEdgeUnderScroll, isRightEdgeUnderScroll },
-  ] = useEdgeInterceptors(containerRef);
+  ] = useEdgeInterceptors(outerContainerRef);
 
   const { collection } = state;
   const { columns } = collection;
@@ -103,42 +104,44 @@ export function Table<C extends Column>(props: TableProps<C>) {
 
   return (
     <DataGridTableContext.Provider value={context}>
-      <div ref={containerRef} className={dataGridClassName} style={style}>
-        <table {...gridProps} ref={tableRef} className={tableClassName}>
-          <RowGroup as="thead">
-            {collection.headerRows.map((headerRow) => (
-              <HeaderRow key={headerRow.key} item={headerRow} state={state}>
-                {[...headerRow.childNodes].map((column) => (
-                  <ColumnHeader
-                    key={column.key}
-                    column={column}
-                    state={state}
-                  />
-                ))}
-              </HeaderRow>
-            ))}
-          </RowGroup>
-          <RowGroup as="tbody">
-            {[...collection.body.childNodes].map((row) => (
-              <Row
-                key={row.key}
-                item={row}
-                state={state}
-                isExpanded={expandedRow ? expandedRow.key === row.key : false}
-              >
-                {[...row.childNodes].map((cell) => (
-                  <Cell key={cell.key} cell={cell} state={state} />
-                ))}
-              </Row>
-            ))}
-          </RowGroup>
-        </table>
-        {expandedRow && (
-          <ExpandedRowContent>
-            {renderExpandedRow(expandedRow.key)}
-          </ExpandedRowContent>
-        )}
-        {renderInterceptors()}
+      <div ref={outerContainerRef} className={dataGridClassName} style={style}>
+        <div ref={innerContainerRef} className={styles.innerContainer}>
+          <table {...gridProps} ref={tableRef} className={tableClassName}>
+            <RowGroup as="thead">
+              {collection.headerRows.map((headerRow) => (
+                <HeaderRow key={headerRow.key} item={headerRow} state={state}>
+                  {[...headerRow.childNodes].map((column) => (
+                    <ColumnHeader
+                      key={column.key}
+                      column={column}
+                      state={state}
+                    />
+                  ))}
+                </HeaderRow>
+              ))}
+            </RowGroup>
+            <RowGroup as="tbody">
+              {[...collection.body.childNodes].map((row) => (
+                <Row
+                  key={row.key}
+                  item={row}
+                  state={state}
+                  isExpanded={expandedRow ? expandedRow.key === row.key : false}
+                >
+                  {[...row.childNodes].map((cell) => (
+                    <Cell key={cell.key} cell={cell} state={state} />
+                  ))}
+                </Row>
+              ))}
+            </RowGroup>
+          </table>
+          {expandedRow && (
+            <ExpandedRowContent>
+              {renderExpandedRow(expandedRow.key)}
+            </ExpandedRowContent>
+          )}
+          {renderInterceptors()}
+        </div>
       </div>
     </DataGridTableContext.Provider>
   );

--- a/easy-ui-react/src/DataGrid/UnstyledPressButton.tsx
+++ b/easy-ui-react/src/DataGrid/UnstyledPressButton.tsx
@@ -1,5 +1,6 @@
 import React, { ComponentProps, forwardRef } from "react";
 import { AriaButtonProps, PressHookProps, usePress } from "react-aria";
+import { classNames } from "../utilities/css";
 
 import styles from "./UnstyledPressButton.module.scss";
 
@@ -15,7 +16,11 @@ export const UnstyledPressButton = forwardRef<
 >((props, ref) => {
   const { pressProps } = usePress(props as PressHookProps);
   return (
-    <button className={styles.UnstyledPressButton} ref={ref} {...pressProps} />
+    <button
+      {...pressProps}
+      ref={ref}
+      className={classNames(styles.UnstyledPressButton, pressProps.className)}
+    />
   );
 });
 

--- a/easy-ui-react/src/DataGrid/constants.ts
+++ b/easy-ui-react/src/DataGrid/constants.ts
@@ -1,3 +1,4 @@
 export const EXPAND_COLUMN_KEY = "__ezui-column-key-expand__";
 export const ACTIONS_COLUMN_KEY = "__ezui-column-key-actions__";
 export const DEFAULT_MAX_ROWS = 999;
+export const DEFAULT_SIZE = "md";

--- a/easy-ui-react/src/DataGrid/context.ts
+++ b/easy-ui-react/src/DataGrid/context.ts
@@ -41,6 +41,7 @@ export const useDataGridTable = () => {
 type DataGridRowContextType = {
   isExpanded: boolean;
   removeHover: () => void;
+  index?: number;
 };
 
 export const DataGridRowContext = createContext<DataGridRowContextType | null>(

--- a/easy-ui-react/src/DataGrid/context.ts
+++ b/easy-ui-react/src/DataGrid/context.ts
@@ -40,6 +40,7 @@ export const useDataGridTable = () => {
 
 type DataGridRowContextType = {
   isExpanded: boolean;
+  isFocusVisible: boolean;
   removeHover: () => void;
   index?: number;
 };

--- a/easy-ui-react/src/DataGrid/types.d.ts
+++ b/easy-ui-react/src/DataGrid/types.d.ts
@@ -74,7 +74,7 @@ export type DataGridProps<C extends Column = Column> = AriaLabelingProps & {
    * Variant of the data grid header to use.
    * @default primary
    */
-  headerVariant?: "primary" | "secondary";
+  headerVariant?: "primary" | "secondary" | "emphasized";
 
   /** Constrains the height of the data grid to a set number of rows. */
   maxRows?: number;

--- a/easy-ui-react/src/DataGrid/types.d.ts
+++ b/easy-ui-react/src/DataGrid/types.d.ts
@@ -123,12 +123,4 @@ export type DataGridProps<C extends Column = Column> = AriaLabelingProps & {
 
   /** The current sorted column and direction. */
   sortDescriptor?: SortDescriptor;
-
-  /**
-   * Define a custom grid-template-columns.
-   * Defaults to taking up an even amount of space.
-   *
-   * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-columns Template columns MDN reference}
-   */
-  templateColumns?: string;
 };

--- a/easy-ui-react/src/DataGrid/types.d.ts
+++ b/easy-ui-react/src/DataGrid/types.d.ts
@@ -115,6 +115,12 @@ export type DataGridProps<C extends Column = Column> = AriaLabelingProps & {
   /** The type of selection that is allowed in the collection. */
   selectionMode?: SelectionMode;
 
+  /**
+   * Visual compactness of the DataGrid.
+   * @default md
+   */
+  size?: "sm" | "md" | "lg";
+
   /** The current sorted column and direction. */
   sortDescriptor?: SortDescriptor;
 

--- a/easy-ui-react/src/DataGrid/useExpandedRow.ts
+++ b/easy-ui-react/src/DataGrid/useExpandedRow.ts
@@ -97,11 +97,7 @@ function getExpandedRowContentRect($container: HTMLElement) {
     .map((r) => r.childNodes[0] as HTMLElement)
     .filter((_, i) => i < expandedIndex)
     .reduce((acc, c) => acc + c.offsetHeight, 0);
-  const y =
-    heightOfPreviousRows +
-    $firstColumnHeader.offsetHeight +
-    $expandedRowCells[0].offsetHeight -
-    $expandedRowContent.offsetHeight;
+  const y = heightOfPreviousRows + $firstColumnHeader.offsetHeight;
   const width =
     $expandedRowCells.reduce((acc, c) => acc + c.offsetWidth, 0) - 1;
   const height = $expandedRowContent.offsetHeight;

--- a/easy-ui-react/src/DataGrid/useExpandedRow.ts
+++ b/easy-ui-react/src/DataGrid/useExpandedRow.ts
@@ -15,10 +15,10 @@ import { EXPAND_COLUMN_KEY } from "./constants";
  * and height of the expanded row box to manage its positioning in the grid.
  */
 export function useExpandedRow({
-  tableRef,
+  containerRef,
   state,
 }: {
-  tableRef: MutableRefObject<HTMLDivElement | null>;
+  containerRef: MutableRefObject<HTMLDivElement | null>;
   state: TableState<unknown>;
 }) {
   const [expandedRowRect, setExpandedRowRect] = useState<DOMRect | null>(null);
@@ -30,16 +30,16 @@ export function useExpandedRow({
   });
 
   useLayoutEffect(() => {
-    if (tableRef.current && expandedRow) {
-      setExpandedRowRect(getExpandedRowContentRect(tableRef.current));
+    if (containerRef.current && expandedRow) {
+      setExpandedRowRect(getExpandedRowContentRect(containerRef.current));
     }
-  }, [tableRef, expandedRow]);
+  }, [containerRef, expandedRow]);
 
   useResizeObserver({
-    ref: tableRef,
+    ref: containerRef,
     onResize() {
-      if (tableRef.current && expandedRow) {
-        const rect = getExpandedRowContentRect(tableRef.current);
+      if (containerRef.current && expandedRow) {
+        const rect = getExpandedRowContentRect(containerRef.current);
         if (
           !expandedRowRect ||
           rect.height !== expandedRowRect.height ||
@@ -80,17 +80,17 @@ export function useExpandedRow({
 /**
  * Calculates a DOMRect (bounding client rectangle) for the expanded row
  * content box. This is used to position the expanded row content absolutely
- * within the table.
+ * within the container.
  *
- * @param $table Table element
+ * @param $container Containerlement
  * @param isPending whether or not to compute the pending expanded row or the active one
  * @returns a DOMRect of the expanded row content
  */
-function getExpandedRowContentRect($table: HTMLElement) {
-  const $rows = getDataGridRowEls($table);
-  const $firstColumnHeader = getFirstColumnHeaderEl($table);
-  const $expandedRowContent = getExpandedRowContentEl($table);
-  const $expandedRow = getExpandedRowEl($table);
+function getExpandedRowContentRect($container: HTMLElement) {
+  const $rows = getDataGridRowEls($container);
+  const $firstColumnHeader = getFirstColumnHeaderEl($container);
+  const $expandedRowContent = getExpandedRowContentEl($container);
+  const $expandedRow = getExpandedRowEl($container);
   const expandedIndex = $rows.findIndex((r) => r === $expandedRow);
   const $expandedRowCells = [...$expandedRow.childNodes] as HTMLElement[];
   const heightOfPreviousRows = $rows
@@ -108,26 +108,26 @@ function getExpandedRowContentRect($table: HTMLElement) {
   return new DOMRect(0, y, width, height);
 }
 
-function getFirstColumnHeaderEl($table: HTMLElement) {
-  return $table.querySelector(
+function getFirstColumnHeaderEl($container: HTMLElement) {
+  return $container.querySelector(
     `[data-ezui-data-grid-column-header="true"]`,
   ) as HTMLElement;
 }
 
-function getDataGridRowEls($table: HTMLElement) {
+function getDataGridRowEls($container: HTMLElement) {
   return [
-    ...$table.querySelectorAll(`[data-ezui-data-grid-row="true"]`),
+    ...$container.querySelectorAll(`[data-ezui-data-grid-row="true"]`),
   ] as HTMLElement[];
 }
 
-function getExpandedRowContentEl($table: HTMLElement) {
-  return $table.querySelector(
+function getExpandedRowContentEl($container: HTMLElement) {
+  return $container.querySelector(
     `[data-ezui-data-grid-expanded-row-content="active"]`,
   ) as HTMLElement;
 }
 
-function getExpandedRowEl($table: HTMLElement) {
-  return $table.querySelector(
+function getExpandedRowEl($container: HTMLElement) {
+  return $container.querySelector(
     `[data-ezui-data-grid-expanded-row='true']`,
   ) as HTMLElement;
 }

--- a/easy-ui-react/src/DataGrid/useExpandedRow.ts
+++ b/easy-ui-react/src/DataGrid/useExpandedRow.ts
@@ -100,7 +100,8 @@ function getExpandedRowContentRect($table: HTMLElement) {
   const y =
     heightOfPreviousRows +
     $firstColumnHeader.offsetHeight +
-    $expandedRowCells[0].offsetHeight;
+    $expandedRowCells[0].offsetHeight -
+    $expandedRowContent.offsetHeight;
   const width =
     $expandedRowCells.reduce((acc, c) => acc + c.offsetWidth, 0) - 1;
   const height = $expandedRowContent.offsetHeight;


### PR DESCRIPTION
## 📝 Changes

- Adds new header variant and changes primary variant color
- Refactors to `table` HTML to support React Aria's clicking rows
- Removes `templateColumns` with move to built-in `table` layout
- Adds `size` prop—supporting `sm`, `md` (default), `lg`
- Various style and bug fixes

[Link to story](https://update-datagrid-header-color--63f50c7c86f6514d2e0ef4be.chromatic.com/?path=/docs/components-datagrid--docs).

## ✅ Checklist

Easy UI has certain UX standards that must be met. In general, non-trivial changes should meet the following criteria:

- [x] Visuals match Design Specs in Figma
- [x] Stories accompany any component changes
- [x] Code is in accordance with our style guide
- [x] Design tokens are utilized
- [x] Unit tests accompany any component changes
- [x] TSDoc is written for any API surface area
- [x] Specs are up-to-date
- [x] Console is free from warnings
- [x] No accessibility violations are reported
- [x] Cross-browser check is performed (Chrome, Safari, Firefox)
- [x] Changeset is added

~Strikethrough~ any items that are not applicable to this pull request.
