### PR TITLE
feat(Card): support box shadow

### DIFF
--- a/.changeset/quick-bobcats-wait.md
+++ b/.changeset/quick-bobcats-wait.md
@@ -1,0 +1,6 @@
+---
+"@easypost/easy-ui-tokens": minor
+"@easypost/easy-ui": minor
+---
+
+feat(Card): support shadow variant

--- a/documentation/specs/Card.md
+++ b/documentation/specs/Card.md
@@ -62,6 +62,12 @@ type CardContainerProps = {
    * @default outlined
    */
   variant?: CardVariant;
+
+  /**
+   * Card shadow level.
+   * @default 1
+   */
+  shadowLevel?: ShadowLevel;
 } & AllHTMLAttributes<ElementType>;
 
 type CardAreaProps = {

--- a/documentation/specs/Card.md
+++ b/documentation/specs/Card.md
@@ -36,7 +36,7 @@ Architecture proposed is to surface a basic `<Card />` component with `variety` 
 
 ```ts
 type CardBackground = "primary" | "secondary";
-type CardVariant = "solid" | "outlined" | "flagged";
+type CardVariant = "solid" | "outlined" | "flagged" | "shadow";
 type CardStatus = "danger" | "warning" | "success";
 
 type CardContainerProps = {

--- a/documentation/specs/Card.md
+++ b/documentation/specs/Card.md
@@ -36,7 +36,7 @@ Architecture proposed is to surface a basic `<Card />` component with `variety` 
 
 ```ts
 type CardBackground = "primary" | "secondary";
-type CardVariant = "solid" | "outlined" | "flagged" | "shadow";
+type CardVariant = "solid" | "outlined" | "flagged";
 type CardStatus = "danger" | "warning" | "success";
 
 type CardContainerProps = {
@@ -64,10 +64,9 @@ type CardContainerProps = {
   variant?: CardVariant;
 
   /**
-   * Card shadow level.
-   * @default 1
+   * Card shadow.
    */
-  shadowLevel?: ShadowLevel;
+  boxShadow?: ShadowLevel;
 } & AllHTMLAttributes<ElementType>;
 
 type CardAreaProps = {

--- a/easy-ui-react/src/Card/Card.mdx
+++ b/easy-ui-react/src/Card/Card.mdx
@@ -33,6 +33,14 @@ Cards can be flagged using `variant="flagged"`. Use the `status` prop to adjust 
 
 <Controls of={CardStories.Flagged} />
 
+## Shadow
+
+Cards can have a shadow with `variant="shadow"`.
+
+<Canvas of={CardStories.Shadow} />
+
+<Controls of={CardStories.Shadow} />
+
 ## Composition
 
 Cards are composable. Use `<Card.Container />` and `<Card.Area />` to create cards with complex content.

--- a/easy-ui-react/src/Card/Card.mdx
+++ b/easy-ui-react/src/Card/Card.mdx
@@ -35,7 +35,7 @@ Cards can be flagged using `variant="flagged"`. Use the `status` prop to adjust 
 
 ## Shadow
 
-Cards can have a shadow using the `boxShadow` prop. Use any numeric value in the `shadow.level` token namespace.
+Cards can have a shadow using the `boxShadow` prop. Use any value in the `shadow.level` token namespace.
 
 <Canvas of={CardStories.Shadow} />
 

--- a/easy-ui-react/src/Card/Card.mdx
+++ b/easy-ui-react/src/Card/Card.mdx
@@ -35,7 +35,7 @@ Cards can be flagged using `variant="flagged"`. Use the `status` prop to adjust 
 
 ## Shadow
 
-Cards can have a shadow with `variant="shadow"`.
+Cards can have a shadow with `variant="shadow"`. Use the `shadowLevel` prop to adjust the depth of the shadow.
 
 <Canvas of={CardStories.Shadow} />
 

--- a/easy-ui-react/src/Card/Card.mdx
+++ b/easy-ui-react/src/Card/Card.mdx
@@ -35,7 +35,7 @@ Cards can be flagged using `variant="flagged"`. Use the `status` prop to adjust 
 
 ## Shadow
 
-Cards can have a shadow with `variant="shadow"`. Use the `shadowLevel` prop to adjust the depth of the shadow.
+Cards can have a shadow using the `boxShadow` prop. Use any numeric value in the `shadow.level` token namespace.
 
 <Canvas of={CardStories.Shadow} />
 

--- a/easy-ui-react/src/Card/Card.module.scss
+++ b/easy-ui-react/src/Card/Card.module.scss
@@ -42,7 +42,7 @@ button.container:not([disabled]) {
 }
 
 .variantShadow {
-  box-shadow: design-token("shadow.card");
+  box-shadow: component-token("card-container", "box-shadow");
 }
 
 .selected {

--- a/easy-ui-react/src/Card/Card.module.scss
+++ b/easy-ui-react/src/Card/Card.module.scss
@@ -4,7 +4,9 @@
 .container {
   @include unstyled.button;
   @include unstyled.link;
+  @include component-token("card", "box-shadow", "none");
   border-radius: design-token("shape.border_radius.md");
+  box-shadow: component-token("card", "box-shadow");
   overflow: hidden;
 }
 
@@ -39,10 +41,6 @@ button.container:not([disabled]) {
     "color.border",
     theme-token("color.neutral.400")
   );
-}
-
-.variantShadow {
-  box-shadow: component-token("card-container", "box-shadow");
 }
 
 .selected {

--- a/easy-ui-react/src/Card/Card.module.scss
+++ b/easy-ui-react/src/Card/Card.module.scss
@@ -41,6 +41,10 @@ button.container:not([disabled]) {
   );
 }
 
+.variantShadow {
+  box-shadow: design-token("shadow.card");
+}
+
 .selected {
   @include component-token(
     "card",

--- a/easy-ui-react/src/Card/Card.stories.tsx
+++ b/easy-ui-react/src/Card/Card.stories.tsx
@@ -8,6 +8,7 @@ import { Icon } from "../Icon";
 import { Text } from "../Text";
 import { VerticalStack } from "../VerticalStack";
 import {
+  createColorTokensControl,
   createShadowTokensControl,
   InlineStoryDecorator,
   PlaceholderBox,
@@ -27,6 +28,7 @@ const meta: Meta<typeof Card> = {
   component: Card,
   decorators: [InlineStoryDecorator],
   argTypes: {
+    background: createColorTokensControl(),
     boxShadow: createShadowTokensControl(),
   },
   parameters: {

--- a/easy-ui-react/src/Card/Card.stories.tsx
+++ b/easy-ui-react/src/Card/Card.stories.tsx
@@ -55,6 +55,13 @@ export const Flagged: Story = {
   },
 };
 
+export const Shadow: Story = {
+  render: Template.bind({}),
+  args: {
+    variant: "shadow",
+  },
+};
+
 export const Composition: Story = {
   render: () => (
     <Card.Container variant="outlined">

--- a/easy-ui-react/src/Card/Card.stories.tsx
+++ b/easy-ui-react/src/Card/Card.stories.tsx
@@ -1,14 +1,18 @@
+import AccountBalanceIcon from "@easypost/easy-ui-icons/AccountBalance";
 import { action } from "@storybook/addon-actions";
 import { Meta, StoryObj } from "@storybook/react";
-import AccountBalanceIcon from "@easypost/easy-ui-icons/AccountBalance";
 import React, { useState } from "react";
 import { HorizontalGrid } from "../HorizontalGrid";
 import { HorizontalStack } from "../HorizontalStack";
+import { Icon } from "../Icon";
 import { Text } from "../Text";
 import { VerticalStack } from "../VerticalStack";
-import { InlineStoryDecorator, PlaceholderBox } from "../utilities/storybook";
+import {
+  createShadowTokensControl,
+  InlineStoryDecorator,
+  PlaceholderBox,
+} from "../utilities/storybook";
 import { Card, CardProps } from "./Card";
-import { Icon } from "../Icon";
 
 type Story = StoryObj<typeof Card>;
 
@@ -22,6 +26,9 @@ const meta: Meta<typeof Card> = {
   title: "Components/Card",
   component: Card,
   decorators: [InlineStoryDecorator],
+  argTypes: {
+    shadowLevel: createShadowTokensControl(),
+  },
   parameters: {
     controls: {
       include: ["background"],
@@ -59,6 +66,11 @@ export const Shadow: Story = {
   render: Template.bind({}),
   args: {
     variant: "shadow",
+  },
+  parameters: {
+    controls: {
+      include: ["shadowLevel"],
+    },
   },
 };
 

--- a/easy-ui-react/src/Card/Card.stories.tsx
+++ b/easy-ui-react/src/Card/Card.stories.tsx
@@ -27,7 +27,7 @@ const meta: Meta<typeof Card> = {
   component: Card,
   decorators: [InlineStoryDecorator],
   argTypes: {
-    shadowLevel: createShadowTokensControl(),
+    boxShadow: createShadowTokensControl(),
   },
   parameters: {
     controls: {
@@ -65,11 +65,12 @@ export const Flagged: Story = {
 export const Shadow: Story = {
   render: Template.bind({}),
   args: {
-    variant: "shadow",
+    variant: "solid",
+    boxShadow: "1",
   },
   parameters: {
     controls: {
-      include: ["shadowLevel"],
+      include: ["variant", "status", "boxShadow"],
     },
   },
 };

--- a/easy-ui-react/src/Card/Card.test.tsx
+++ b/easy-ui-react/src/Card/Card.test.tsx
@@ -72,6 +72,14 @@ describe("<Card />", () => {
     );
   });
 
+  it("should render shadow card", () => {
+    render(<Card variant="shadow">Content</Card>);
+    expect(screen.getByTestId("container")).toHaveAttribute(
+      "class",
+      expect.stringContaining("variantShadow"),
+    );
+  });
+
   it("should render custom background", () => {
     render(<Card background="primary">Content</Card>);
     expect(screen.getByTestId("area")).toHaveStyle(

--- a/easy-ui-react/src/Card/Card.test.tsx
+++ b/easy-ui-react/src/Card/Card.test.tsx
@@ -72,11 +72,23 @@ describe("<Card />", () => {
     );
   });
 
-  it("should render shadow card", () => {
-    render(<Card variant="shadow">Content</Card>);
+  it("should render shadow card with level", () => {
+    render(
+      <Card variant="shadow" shadowLevel="2">
+        Content
+      </Card>,
+    );
     expect(screen.getByTestId("container")).toHaveAttribute(
       "class",
       expect.stringContaining("variantShadow"),
+    );
+    expect(screen.getByTestId("container")).toHaveStyle(
+      getComponentThemeToken(
+        "card-container",
+        "box-shadow",
+        "shadow.level",
+        "2",
+      ),
     );
   });
 

--- a/easy-ui-react/src/Card/Card.test.tsx
+++ b/easy-ui-react/src/Card/Card.test.tsx
@@ -79,10 +79,17 @@ describe("<Card />", () => {
     );
   });
 
-  it("should render custom background", () => {
+  it("should render custom background keyword", () => {
     render(<Card background="primary">Content</Card>);
     expect(screen.getByTestId("area")).toHaveStyle(
       getComponentThemeToken("card-area", "background", "color", "neutral.000"),
+    );
+  });
+
+  it("should render custom background token", () => {
+    render(<Card background="neutral.100">Content</Card>);
+    expect(screen.getByTestId("area")).toHaveStyle(
+      getComponentThemeToken("card-area", "background", "color", "neutral.100"),
     );
   });
 

--- a/easy-ui-react/src/Card/Card.test.tsx
+++ b/easy-ui-react/src/Card/Card.test.tsx
@@ -72,23 +72,10 @@ describe("<Card />", () => {
     );
   });
 
-  it("should render shadow card with level", () => {
-    render(
-      <Card variant="shadow" shadowLevel="2">
-        Content
-      </Card>,
-    );
-    expect(screen.getByTestId("container")).toHaveAttribute(
-      "class",
-      expect.stringContaining("variantShadow"),
-    );
+  it("should render shadow", () => {
+    render(<Card boxShadow="2">Content</Card>);
     expect(screen.getByTestId("container")).toHaveStyle(
-      getComponentThemeToken(
-        "card-container",
-        "box-shadow",
-        "shadow.level",
-        "2",
-      ),
+      getComponentThemeToken("card", "box-shadow", "shadow.level", "2"),
     );
   });
 

--- a/easy-ui-react/src/Card/Card.tsx
+++ b/easy-ui-react/src/Card/Card.tsx
@@ -17,7 +17,7 @@ const DEFAULT_VARIANT = "outlined";
 type SpaceScale = DesignTokenNamespace<"space">;
 
 export type CardBackground = "primary" | "secondary";
-export type CardVariant = "solid" | "outlined" | "flagged";
+export type CardVariant = "solid" | "outlined" | "flagged" | "shadow";
 export type CardStatus = "danger" | "warning" | "success" | "neutral";
 export type CardPadding = ResponsiveProp<SpaceScale>;
 
@@ -157,6 +157,12 @@ function getBackgroundToken(background: CardAreaProps["background"]) {
  * _Flagged:_
  * ```tsx
  * <Card variant="flagged" status="danger">Content</Card>
+ * ```
+ *
+ * @example
+ * _Shadow:_
+ * ```tsx
+ * <Card variant="shadow">Content</Card>
  * ```
  *
  * @example

--- a/easy-ui-react/src/Card/Card.tsx
+++ b/easy-ui-react/src/Card/Card.tsx
@@ -1,6 +1,6 @@
 import omit from "lodash/omit";
 import React, { AllHTMLAttributes, ElementType, ReactNode } from "react";
-import { DesignTokenNamespace } from "../types";
+import { DesignTokenNamespace, ShadowLevel } from "../types";
 import {
   ResponsiveProp,
   classNames,
@@ -13,6 +13,7 @@ import styles from "./Card.module.scss";
 
 const DEFAULT_ELEMENT_TYPE = "div";
 const DEFAULT_VARIANT = "outlined";
+const DEFAULT_SHADOW_LEVEL = "1";
 
 type SpaceScale = DesignTokenNamespace<"space">;
 
@@ -44,6 +45,12 @@ export type CardContainerProps = {
    * @default outlined
    */
   variant?: CardVariant;
+
+  /**
+   * Card shadow level.
+   * @default 1
+   */
+  shadowLevel?: ShadowLevel;
 } & AllHTMLAttributes<ElementType>;
 
 export type CardAreaProps = {
@@ -74,6 +81,7 @@ function CardContainer(props: CardContainerProps) {
     isSelected,
     status,
     variant = DEFAULT_VARIANT,
+    shadowLevel = DEFAULT_SHADOW_LEVEL,
     ...restProps
   } = props;
 
@@ -85,6 +93,15 @@ function CardContainer(props: CardContainerProps) {
     variant === "outlined" && isSelected && styles.selected,
   );
 
+  const style = {
+    ...getComponentThemeToken(
+      "card-container",
+      "box-shadow",
+      "shadow.level",
+      shadowLevel,
+    ),
+  };
+
   if (variant !== "flagged" && status) {
     console.warn("status is only applicable for flagged cards");
   }
@@ -93,12 +110,17 @@ function CardContainer(props: CardContainerProps) {
     console.warn("isSelected is only applicable for outlined cards");
   }
 
+  if (variant !== "shadow" && props.shadowLevel) {
+    console.warn("shadowLevel is only applicable for shadow cards");
+  }
+
   return (
     <As
       className={className}
+      style={style}
       data-testid="container"
       disabled={isDisabled}
-      {...omit(restProps, ["className"])}
+      {...omit(restProps, ["className", "style"])}
     >
       {children}
     </As>

--- a/easy-ui-react/src/Card/Card.tsx
+++ b/easy-ui-react/src/Card/Card.tsx
@@ -13,12 +13,11 @@ import styles from "./Card.module.scss";
 
 const DEFAULT_ELEMENT_TYPE = "div";
 const DEFAULT_VARIANT = "outlined";
-const DEFAULT_SHADOW_LEVEL = "1";
 
 type SpaceScale = DesignTokenNamespace<"space">;
 
 export type CardBackground = "primary" | "secondary";
-export type CardVariant = "solid" | "outlined" | "flagged" | "shadow";
+export type CardVariant = "solid" | "outlined" | "flagged";
 export type CardStatus = "danger" | "warning" | "success" | "neutral";
 export type CardPadding = ResponsiveProp<SpaceScale>;
 
@@ -47,10 +46,9 @@ export type CardContainerProps = {
   variant?: CardVariant;
 
   /**
-   * Card shadow level.
-   * @default 1
+   * Card shadow.
    */
-  shadowLevel?: ShadowLevel;
+  boxShadow?: ShadowLevel;
 } & AllHTMLAttributes<ElementType>;
 
 export type CardAreaProps = {
@@ -81,7 +79,7 @@ function CardContainer(props: CardContainerProps) {
     isSelected,
     status,
     variant = DEFAULT_VARIANT,
-    shadowLevel = DEFAULT_SHADOW_LEVEL,
+    boxShadow,
     ...restProps
   } = props;
 
@@ -94,12 +92,7 @@ function CardContainer(props: CardContainerProps) {
   );
 
   const style = {
-    ...getComponentThemeToken(
-      "card-container",
-      "box-shadow",
-      "shadow.level",
-      shadowLevel,
-    ),
+    ...getComponentThemeToken("card", "box-shadow", "shadow.level", boxShadow),
   };
 
   if (variant !== "flagged" && status) {
@@ -108,10 +101,6 @@ function CardContainer(props: CardContainerProps) {
 
   if (variant !== "outlined" && isSelected) {
     console.warn("isSelected is only applicable for outlined cards");
-  }
-
-  if (variant !== "shadow" && props.shadowLevel) {
-    console.warn("shadowLevel is only applicable for shadow cards");
   }
 
   return (
@@ -184,7 +173,7 @@ function getBackgroundToken(background: CardAreaProps["background"]) {
  * @example
  * _Shadow:_
  * ```tsx
- * <Card variant="shadow">Content</Card>
+ * <Card boxShadow="1">Content</Card>
  * ```
  *
  * @example

--- a/easy-ui-react/src/Card/Card.tsx
+++ b/easy-ui-react/src/Card/Card.tsx
@@ -1,6 +1,10 @@
 import omit from "lodash/omit";
 import React, { AllHTMLAttributes, ElementType, ReactNode } from "react";
-import { DesignTokenNamespace, ShadowLevel } from "../types";
+import {
+  DesignTokenNamespace,
+  ShadowLevel,
+  ThemeTokenNamespace,
+} from "../types";
 import {
   ResponsiveProp,
   classNames,
@@ -16,7 +20,10 @@ const DEFAULT_VARIANT = "outlined";
 
 type SpaceScale = DesignTokenNamespace<"space">;
 
-export type CardBackground = "primary" | "secondary";
+export type CardBackground =
+  | "primary"
+  | "secondary"
+  | ThemeTokenNamespace<"color">;
 export type CardVariant = "solid" | "outlined" | "flagged";
 export type CardStatus = "danger" | "warning" | "success" | "neutral";
 export type CardPadding = ResponsiveProp<SpaceScale>;

--- a/easy-ui-react/src/types.ts
+++ b/easy-ui-react/src/types.ts
@@ -66,3 +66,5 @@ export type IconSymbol = React.FunctionComponent<IconSymbolProps>;
 
 export type SpaceScale = DesignTokenNamespace<"space">;
 export type ResponsiveSpaceScale = ResponsiveProp<SpaceScale>;
+
+export type ShadowLevel = DesignTokenNamespace<"shadow.level">;

--- a/easy-ui-react/src/utilities/storybook.tsx
+++ b/easy-ui-react/src/utilities/storybook.tsx
@@ -30,6 +30,10 @@ export function createColorTokensControl() {
   return getThemeTokensControl("color.{alias}");
 }
 
+export function createShadowTokensControl() {
+  return getDesignTokensControl("shadow.level.{alias}");
+}
+
 export function getDesignTokensControl(pattern: string) {
   return getTokensControl(getTokenAliases(tokens, pattern));
 }

--- a/easy-ui-tokens/src/shadow/base.json
+++ b/easy-ui-tokens/src/shadow/base.json
@@ -21,8 +21,14 @@
     "stuck-from-bottom": {
       "value": "0px -4px 4px 0px hsla(221, 30%, 74%, 0.25)"
     },
-    "card": {
-      "value": "0px 1px 8px 0px hsla(226, 84%, 27%, 0.3)"
+    "level.1": {
+      "value": "0px 1px 8px 0px hsla(226, 28%, 39%, 0.25)"
+    },
+    "level.2": {
+      "value": "0px 1px 10px 0px hsla(226, 28%, 39%, 0.4)"
+    },
+    "level.3": {
+      "value": "0px 1px 12px 0px hsla(226, 28%, 39%, 0.6)"
     }
   }
 }

--- a/easy-ui-tokens/src/shadow/base.json
+++ b/easy-ui-tokens/src/shadow/base.json
@@ -20,6 +20,9 @@
     },
     "stuck-from-bottom": {
       "value": "0px -4px 4px 0px hsla(221, 30%, 74%, 0.25)"
+    },
+    "card": {
+      "value": "0px 1px 8px 0px hsla(226, 84%, 27%, 0.3)"
     }
   }
 }


### PR DESCRIPTION
## 📝 Changes

- Add support for box shadows with `<Card boxShadow="1" />` per the shadow levels outlined in Figma design spec
- Fix `background` types

[Link to Story](https://63f50c7c86f6514d2e0ef4be-edphtsadgo.chromatic.com/?path=/story/components-card--shadow).

## ✅ Checklist

Easy UI has certain UX standards that must be met. In general, non-trivial changes should meet the following criteria:

- [x] Visuals match Design Specs in Figma
- [x] Stories accompany any component changes
- [x] Code is in accordance with our style guide
- [x] Design tokens are utilized
- [x] Unit tests accompany any component changes
- [x] TSDoc is written for any API surface area
- [x] Specs are up-to-date
- [x] Console is free from warnings
- [x] No accessibility violations are reported
- [x] Cross-browser check is performed (Chrome, Safari, Firefox)
- [x] Changeset is added

~Strikethrough~ any items that are not applicable to this pull request.
