### PR TITLE
feat: support new `Card` props and update `ToggleCard` to use new props

### DIFF
--- a/.changeset/loud-penguins-kiss.md
+++ b/.changeset/loud-penguins-kiss.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": minor
+---
+
+feat: add borderRadius prop to `Card`, allow non-uniform padding for `Card`, and updates `ToggleCard` to use new Card props

--- a/.changeset/loud-penguins-kiss.md
+++ b/.changeset/loud-penguins-kiss.md
@@ -2,4 +2,4 @@
 "@easypost/easy-ui": minor
 ---
 
-feat: support border radius and non-uniform padding for `Card`, and update `ToggleCard` to use new `Card` props
+feat: support border radius, paddingX, and paddingY for `Card` and update `ToggleCard` to use new `Card` props

--- a/.changeset/loud-penguins-kiss.md
+++ b/.changeset/loud-penguins-kiss.md
@@ -2,4 +2,4 @@
 "@easypost/easy-ui": minor
 ---
 
-feat: add borderRadius prop to `Card`, allow non-uniform padding for `Card`, and updates `ToggleCard` to use new Card props
+feat: support border radius and non-uniform padding for `Card`, and update `ToggleCard` to use new `Card` props

--- a/documentation/specs/Card.md
+++ b/documentation/specs/Card.md
@@ -66,7 +66,12 @@ type CardContainerProps = {
   /**
    * Card shadow.
    */
+
   boxShadow?: ShadowLevel;
+  /**
+   * Card border radius.
+   */
+  borderRadius?: BorderRadius;
 } & AllHTMLAttributes<ElementType>;
 
 type CardAreaProps = {

--- a/documentation/specs/Card.md
+++ b/documentation/specs/Card.md
@@ -38,6 +38,7 @@ Architecture proposed is to surface a basic `<Card />` component with `variety` 
 type CardBackground = "primary" | "secondary";
 type CardVariant = "solid" | "outlined" | "flagged";
 type CardStatus = "danger" | "warning" | "success";
+type CardPadding = ResponsiveProp<SpaceScale>;
 
 type CardContainerProps = {
   /** Custom element for the card container. */
@@ -80,6 +81,33 @@ type CardAreaProps = {
 
   /** Content of the card area. */
   children: ReactNode;
+
+  /**
+   * The spacing around the content area. Accepts a spacing token or an object of spacing tokens for different screen sizes.
+   *
+   * @example
+   * padding='2'
+   * padding={{ xs: '2', sm: '3', md: '4', lg: '5', xl: '6' }}
+   */
+  padding?: CardPadding;
+
+  /**
+   * The horizontal spacing around the content area. Accepts a spacing token or an object of spacing tokens for different screen sizes.
+   *
+   * @example
+   * paddingX='2'
+   * paddingX={{ xs: '2', sm: '3', md: '4', lg: '5', xl: '6' }}
+   */
+  paddingX?: CardPadding;
+
+  /**
+   * The vertical spacing around the content area. Accepts a spacing token or an object of spacing tokens for different screen sizes.
+   *
+   * @example
+   * paddingY='2'
+   * paddingY={{ xs: '2', sm: '3', md: '4', lg: '5', xl: '6' }}
+   */
+  paddingY?: CardPadding;
 };
 
 type CardProps = CardContainerProps & CardAreaProps;

--- a/documentation/specs/Card.md
+++ b/documentation/specs/Card.md
@@ -66,8 +66,8 @@ type CardContainerProps = {
   /**
    * Card shadow.
    */
-
   boxShadow?: ShadowLevel;
+
   /**
    * Card border radius.
    */

--- a/easy-ui-react/src/Card/Card.mdx
+++ b/easy-ui-react/src/Card/Card.mdx
@@ -41,6 +41,14 @@ Cards can have a shadow using the `boxShadow` prop. Use any value in the `shadow
 
 <Controls of={CardStories.Shadow} />
 
+## Border Radius
+
+Cards can have a border radius using the `borderRadius` prop. Use any value in the `shape.border_radius` token namespace.
+
+<Canvas of={CardStories.BorderRadius} />
+
+<Controls of={CardStories.BorderRadius} />
+
 ## Composition
 
 Cards are composable. Use `<Card.Container />` and `<Card.Area />` to create cards with complex content.

--- a/easy-ui-react/src/Card/Card.mdx
+++ b/easy-ui-react/src/Card/Card.mdx
@@ -91,6 +91,10 @@ To create a card with two columns, for instance, use `<Card.Container />` and `<
 
 <Canvas of={CardStories.ExampleCallout} />
 
+### Non-uniform padding
+
+<Canvas of={CardStories.ExamplePadding} />
+
 ### Layouts
 
 Card content behavior should follow the rules of their parent layouts.

--- a/easy-ui-react/src/Card/Card.mdx
+++ b/easy-ui-react/src/Card/Card.mdx
@@ -49,6 +49,18 @@ Cards can have a border radius using the `borderRadius` prop. Use any value in t
 
 <Controls of={CardStories.BorderRadius} />
 
+## Padding
+
+By default, Cards have a uniform padding of `space.2`.
+
+The `padding` prop accepts a spacing token or an object of spacing tokens for different screen sizes as a value, and it can be used to define custom **uniform** padding.
+
+<Canvas of={CardStories.Padding} />
+
+Similarly, the `paddingX` and `paddingY` props accept a spacing token or an object of spacing tokens for different screen sizes as values, they can be used together to define custom **non-uniform** padding.
+
+<Canvas of={CardStories.PaddingXAndPaddingY} />
+
 ## Composition
 
 Cards are composable. Use `<Card.Container />` and `<Card.Area />` to create cards with complex content.
@@ -98,10 +110,6 @@ To create a card with two columns, for instance, use `<Card.Container />` and `<
 ### Callout
 
 <Canvas of={CardStories.ExampleCallout} />
-
-### Non-uniform padding
-
-<Canvas of={CardStories.ExamplePadding} />
 
 ### Layouts
 

--- a/easy-ui-react/src/Card/Card.module.scss
+++ b/easy-ui-react/src/Card/Card.module.scss
@@ -5,7 +5,7 @@
   @include unstyled.button;
   @include unstyled.link;
   @include component-token("card", "box-shadow", "none");
-  border-radius: design-token("shape.border_radius.md");
+  border-radius: component-token("card", "border-radius");
   box-shadow: component-token("card", "box-shadow");
   overflow: hidden;
 }
@@ -19,7 +19,11 @@ button.container:not([disabled]) {
   display: flex;
   flex-direction: column;
   min-height: 100%;
-  @include responsive-prop("card-area", "padding", padding);
+
+  @include responsive-prop("card-area", "padding-top", "padding-top");
+  @include responsive-prop("card-area", "padding-bottom", "padding-bottom");
+  @include responsive-prop("card-area", "padding-left", "padding-left");
+  @include responsive-prop("card-area", "padding-right", "padding-right");
   > * {
     flex: 1 0 auto;
   }

--- a/easy-ui-react/src/Card/Card.stories.tsx
+++ b/easy-ui-react/src/Card/Card.stories.tsx
@@ -283,6 +283,19 @@ export const ExampleCallout: Story = {
   ),
 };
 
+export const ExamplePadding: Story = {
+  render: () => (
+    <Card.Container variant="outlined">
+      <Card.Area
+        background="primary.800"
+        padding={{ paddingX: "1", paddingY: { xs: "2", sm: "3", md: "5" } }}
+      >
+        <PlaceholderBox width={250} />
+      </Card.Area>
+    </Card.Container>
+  ),
+};
+
 export const ExampleStretch: Story = {
   render: () => (
     <HorizontalGrid columns={2} gap="2">

--- a/easy-ui-react/src/Card/Card.stories.tsx
+++ b/easy-ui-react/src/Card/Card.stories.tsx
@@ -10,6 +10,7 @@ import { VerticalStack } from "../VerticalStack";
 import {
   createColorTokensControl,
   createShadowTokensControl,
+  createBorderRadiusTokensControl,
   InlineStoryDecorator,
   PlaceholderBox,
 } from "../utilities/storybook";
@@ -30,6 +31,7 @@ const meta: Meta<typeof Card> = {
   argTypes: {
     background: createColorTokensControl(),
     boxShadow: createShadowTokensControl(),
+    borderRadius: createBorderRadiusTokensControl(),
   },
   parameters: {
     controls: {
@@ -73,6 +75,19 @@ export const Shadow: Story = {
   parameters: {
     controls: {
       include: ["variant", "status", "boxShadow"],
+    },
+  },
+};
+
+export const BorderRadius: Story = {
+  render: Template.bind({}),
+  args: {
+    variant: "outlined",
+    borderRadius: "md",
+  },
+  parameters: {
+    controls: {
+      include: ["variant", "status", "borderRadius"],
     },
   },
 };

--- a/easy-ui-react/src/Card/Card.stories.tsx
+++ b/easy-ui-react/src/Card/Card.stories.tsx
@@ -92,6 +92,33 @@ export const BorderRadius: Story = {
   },
 };
 
+export const Padding: Story = {
+  render: () => (
+    <Card.Container variant="outlined">
+      <Card.Area
+        background="primary.800"
+        padding={{ xs: "2", sm: "3", md: "4", lg: "5" }}
+      >
+        <PlaceholderBox width={250} />
+      </Card.Area>
+    </Card.Container>
+  ),
+};
+
+export const PaddingXAndPaddingY: Story = {
+  render: () => (
+    <Card.Container variant="outlined">
+      <Card.Area
+        background="primary.800"
+        paddingX="1"
+        paddingY={{ xs: "2", sm: "3", md: "4", lg: "5" }}
+      >
+        <PlaceholderBox width={250} />
+      </Card.Area>
+    </Card.Container>
+  ),
+};
+
 export const Composition: Story = {
   render: () => (
     <Card.Container variant="outlined">
@@ -295,19 +322,6 @@ export const ExampleCallout: Story = {
         </Text>
       </Card>
     </div>
-  ),
-};
-
-export const ExamplePadding: Story = {
-  render: () => (
-    <Card.Container variant="outlined">
-      <Card.Area
-        background="primary.800"
-        padding={{ paddingX: "1", paddingY: { xs: "2", sm: "3", md: "5" } }}
-      >
-        <PlaceholderBox width={250} />
-      </Card.Area>
-    </Card.Container>
   ),
 };
 

--- a/easy-ui-react/src/Card/Card.test.tsx
+++ b/easy-ui-react/src/Card/Card.test.tsx
@@ -93,6 +93,18 @@ describe("<Card />", () => {
     );
   });
 
+  it("should render border radius", () => {
+    render(<Card borderRadius="lg">Content</Card>);
+    expect(screen.getByTestId("container")).toHaveStyle(
+      getComponentThemeToken(
+        "card",
+        "border-radius",
+        "shape.border_radius",
+        "lg",
+      ),
+    );
+  });
+
   it("should render custom padding", () => {
     render(<Card padding="1">Content</Card>);
     expect(screen.getByTestId("area")).toHaveStyle(

--- a/easy-ui-react/src/Card/Card.test.tsx
+++ b/easy-ui-react/src/Card/Card.test.tsx
@@ -121,6 +121,22 @@ describe("<Card />", () => {
     );
   });
 
+  it("should render custom paddingX", () => {
+    render(<Card paddingX="2">Content</Card>);
+    expect(screen.getByTestId("area")).toHaveStyle(
+      getResponsiveDesignToken("card-area", "padding-top", "space", "0"),
+    );
+    expect(screen.getByTestId("area")).toHaveStyle(
+      getResponsiveDesignToken("card-area", "padding-right", "space", "2"),
+    );
+    expect(screen.getByTestId("area")).toHaveStyle(
+      getResponsiveDesignToken("card-area", "padding-bottom", "space", "0"),
+    );
+    expect(screen.getByTestId("area")).toHaveStyle(
+      getResponsiveDesignToken("card-area", "padding-left", "space", "2"),
+    );
+  });
+
   it("should render composable card", () => {
     render(
       <Card.Container variant="outlined">

--- a/easy-ui-react/src/Card/Card.test.tsx
+++ b/easy-ui-react/src/Card/Card.test.tsx
@@ -96,7 +96,16 @@ describe("<Card />", () => {
   it("should render custom padding", () => {
     render(<Card padding="1">Content</Card>);
     expect(screen.getByTestId("area")).toHaveStyle(
-      getResponsiveDesignToken("card-area", "padding", "space", "1"),
+      getResponsiveDesignToken("card-area", "padding-top", "space", "1"),
+    );
+    expect(screen.getByTestId("area")).toHaveStyle(
+      getResponsiveDesignToken("card-area", "padding-right", "space", "1"),
+    );
+    expect(screen.getByTestId("area")).toHaveStyle(
+      getResponsiveDesignToken("card-area", "padding-bottom", "space", "1"),
+    );
+    expect(screen.getByTestId("area")).toHaveStyle(
+      getResponsiveDesignToken("card-area", "padding-left", "space", "1"),
     );
   });
 

--- a/easy-ui-react/src/Card/Card.test.tsx
+++ b/easy-ui-react/src/Card/Card.test.tsx
@@ -123,15 +123,11 @@ describe("<Card />", () => {
 
   it("should render custom paddingX", () => {
     render(<Card paddingX="2">Content</Card>);
-    expect(screen.getByTestId("area")).toHaveStyle(
-      getResponsiveDesignToken("card-area", "padding-top", "space", "0"),
-    );
+
     expect(screen.getByTestId("area")).toHaveStyle(
       getResponsiveDesignToken("card-area", "padding-right", "space", "2"),
     );
-    expect(screen.getByTestId("area")).toHaveStyle(
-      getResponsiveDesignToken("card-area", "padding-bottom", "space", "0"),
-    );
+
     expect(screen.getByTestId("area")).toHaveStyle(
       getResponsiveDesignToken("card-area", "padding-left", "space", "2"),
     );

--- a/easy-ui-react/src/Card/Card.tsx
+++ b/easy-ui-react/src/Card/Card.tsx
@@ -64,6 +64,7 @@ export type CardContainerProps = {
    * Card shadow.
    */
   boxShadow?: ShadowLevel;
+
   /**
    * Card border radius.
    */
@@ -273,6 +274,11 @@ function getBackgroundToken(background: CardAreaProps["background"]) {
  * _Shadow:_
  * ```tsx
  * <Card boxShadow="1">Content</Card>
+ * ```
+ * @example
+ * _Border radius:_
+ * ```tsx
+ * <Card borderRadius="sm">Content</Card>
  * ```
  *
  * @example

--- a/easy-ui-react/src/Card/Card.tsx
+++ b/easy-ui-react/src/Card/Card.tsx
@@ -176,25 +176,25 @@ function CardArea({
       "card-area",
       "padding-top",
       "space",
-      paddingTop as ResponsiveProp<SpaceScale>,
+      paddingTop,
     ),
     ...getResponsiveDesignToken(
       "card-area",
       "padding-bottom",
       "space",
-      paddingBottom as ResponsiveProp<SpaceScale>,
+      paddingBottom,
     ),
     ...getResponsiveDesignToken(
       "card-area",
       "padding-left",
       "space",
-      paddingLeft as ResponsiveProp<SpaceScale>,
+      paddingLeft,
     ),
     ...getResponsiveDesignToken(
       "card-area",
       "padding-right",
       "space",
-      paddingRight as ResponsiveProp<SpaceScale>,
+      paddingRight,
     ),
   } as React.CSSProperties;
 

--- a/easy-ui-react/src/Card/Card.tsx
+++ b/easy-ui-react/src/Card/Card.tsx
@@ -3,6 +3,7 @@ import React, { AllHTMLAttributes, ElementType, ReactNode } from "react";
 import {
   DesignTokenNamespace,
   ShadowLevel,
+  BorderRadius,
   ThemeTokenNamespace,
 } from "../types";
 import {
@@ -17,6 +18,8 @@ import styles from "./Card.module.scss";
 
 const DEFAULT_ELEMENT_TYPE = "div";
 const DEFAULT_VARIANT = "outlined";
+const DEFAULT_PADDING = "2";
+const DEFAULT_BORDER_RADIUS = "md";
 
 type SpaceScale = DesignTokenNamespace<"space">;
 
@@ -26,7 +29,12 @@ export type CardBackground =
   | ThemeTokenNamespace<"color">;
 export type CardVariant = "solid" | "outlined" | "flagged";
 export type CardStatus = "danger" | "warning" | "success" | "neutral";
-export type CardPadding = ResponsiveProp<SpaceScale>;
+export type CardPadding =
+  | {
+      paddingY?: ResponsiveProp<SpaceScale>;
+      paddingX?: ResponsiveProp<SpaceScale>;
+    }
+  | ResponsiveProp<SpaceScale>;
 
 export type CardContainerProps = {
   /** Custom element for the card container. */
@@ -56,6 +64,10 @@ export type CardContainerProps = {
    * Card shadow.
    */
   boxShadow?: ShadowLevel;
+  /**
+   * Card border radius.
+   */
+  borderRadius?: BorderRadius;
 } & AllHTMLAttributes<ElementType>;
 
 export type CardAreaProps = {
@@ -72,6 +84,7 @@ export type CardAreaProps = {
    * @example
    * padding='2'
    * padding={{ xs: '2', sm: '3', md: '4', lg: '5', xl: '6' }}
+   * padding={{ paddingX: '4', paddingY: { sm: '1', md: '3' }}}
    */
   padding?: CardPadding;
 };
@@ -87,6 +100,7 @@ function CardContainer(props: CardContainerProps) {
     status,
     variant = DEFAULT_VARIANT,
     boxShadow,
+    borderRadius = DEFAULT_BORDER_RADIUS,
     ...restProps
   } = props;
 
@@ -100,6 +114,12 @@ function CardContainer(props: CardContainerProps) {
 
   const style = {
     ...getComponentThemeToken("card", "box-shadow", "shadow.level", boxShadow),
+    ...getComponentThemeToken(
+      "card",
+      "border-radius",
+      "shape.border_radius",
+      borderRadius,
+    ),
   };
 
   if (variant !== "flagged" && status) {
@@ -124,6 +144,9 @@ function CardContainer(props: CardContainerProps) {
 }
 
 function CardArea({ background, children, padding = "2" }: CardAreaProps) {
+  const { paddingTop, paddingBottom, paddingLeft, paddingRight } =
+    getPaddingValues(padding);
+
   const style = {
     ...getComponentThemeToken(
       "card-area",
@@ -131,13 +154,82 @@ function CardArea({ background, children, padding = "2" }: CardAreaProps) {
       "color",
       getBackgroundToken(background),
     ),
-    ...getResponsiveDesignToken("card-area", "padding", "space", padding),
+    ...getResponsiveDesignToken(
+      "card-area",
+      "padding-top",
+      "space",
+      paddingTop as ResponsiveProp<SpaceScale>,
+    ),
+    ...getResponsiveDesignToken(
+      "card-area",
+      "padding-bottom",
+      "space",
+      paddingBottom as ResponsiveProp<SpaceScale>,
+    ),
+    ...getResponsiveDesignToken(
+      "card-area",
+      "padding-left",
+      "space",
+      paddingLeft as ResponsiveProp<SpaceScale>,
+    ),
+    ...getResponsiveDesignToken(
+      "card-area",
+      "padding-right",
+      "space",
+      paddingRight as ResponsiveProp<SpaceScale>,
+    ),
   } as React.CSSProperties;
+
   return (
     <div className={styles.area} style={style} data-testid="area">
       {children}
     </div>
   );
+}
+
+/**
+ * Extracts padding passed by consumer into top,
+ * right, bottom, and left values
+ *
+ * @param padding card padding
+ * @returns extracted padding values
+ */
+function getPaddingValues(padding: CardPadding) {
+  // handles padding='2' and padding={{ sm: '3', md: '4', lg: '5' }}
+  if (
+    typeof padding === "string" ||
+    (typeof padding === "object" &&
+      !("paddingX" in padding) &&
+      !("paddingY" in padding))
+  ) {
+    return {
+      paddingTop: padding,
+      paddingBottom: padding,
+      paddingLeft: padding,
+      paddingRight: padding,
+    };
+  }
+
+  // handles padding={{ paddingX: '4', paddingY: { sm: '1', md: '3' }}}
+  if (
+    typeof padding === "object" &&
+    ("paddingX" in padding || "paddingY" in padding)
+  ) {
+    const { paddingX = 0, paddingY = 0 } = padding;
+    return {
+      paddingTop: paddingY,
+      paddingBottom: paddingY,
+      paddingLeft: paddingX,
+      paddingRight: paddingX,
+    };
+  }
+
+  return {
+    paddingTop: DEFAULT_PADDING,
+    paddingBottom: DEFAULT_PADDING,
+    paddingLeft: DEFAULT_PADDING,
+    paddingRight: DEFAULT_PADDING,
+  };
 }
 
 function getBackgroundToken(background: CardAreaProps["background"]) {

--- a/easy-ui-react/src/Card/Card.tsx
+++ b/easy-ui-react/src/Card/Card.tsx
@@ -29,12 +29,7 @@ export type CardBackground =
   | ThemeTokenNamespace<"color">;
 export type CardVariant = "solid" | "outlined" | "flagged";
 export type CardStatus = "danger" | "warning" | "success" | "neutral";
-export type CardPadding =
-  | {
-      paddingY?: ResponsiveProp<SpaceScale>;
-      paddingX?: ResponsiveProp<SpaceScale>;
-    }
-  | ResponsiveProp<SpaceScale>;
+export type CardPadding = ResponsiveProp<SpaceScale>;
 
 export type CardContainerProps = {
   /** Custom element for the card container. */
@@ -81,13 +76,29 @@ export type CardAreaProps = {
   /**
    * The spacing around the content area. Accepts a spacing token or an object of spacing tokens for different screen sizes.
    *
-   * @default '2'
    * @example
    * padding='2'
    * padding={{ xs: '2', sm: '3', md: '4', lg: '5', xl: '6' }}
-   * padding={{ paddingX: '4', paddingY: { sm: '1', md: '3' }}}
    */
   padding?: CardPadding;
+
+  /**
+   * The horizontal spacing around the content area. Accepts a spacing token or an object of spacing tokens for different screen sizes.
+   *
+   * @example
+   * paddingX='2'
+   * paddingX={{ xs: '2', sm: '3', md: '4', lg: '5', xl: '6' }}
+   */
+  paddingX?: CardPadding;
+
+  /**
+   * The vertical spacing around the content area. Accepts a spacing token or an object of spacing tokens for different screen sizes.
+   *
+   * @example
+   * paddingY='2'
+   * paddingY={{ xs: '2', sm: '3', md: '4', lg: '5', xl: '6' }}
+   */
+  paddingY?: CardPadding;
 };
 
 export type CardProps = CardContainerProps & CardAreaProps;
@@ -144,9 +155,15 @@ function CardContainer(props: CardContainerProps) {
   );
 }
 
-function CardArea({ background, children, padding = "2" }: CardAreaProps) {
+function CardArea({
+  background,
+  children,
+  padding,
+  paddingX,
+  paddingY,
+}: CardAreaProps) {
   const { paddingTop, paddingBottom, paddingLeft, paddingRight } =
-    getPaddingValues(padding);
+    getPaddingValues(padding, paddingX, paddingY);
 
   const style = {
     ...getComponentThemeToken(
@@ -193,16 +210,16 @@ function CardArea({ background, children, padding = "2" }: CardAreaProps) {
  * right, bottom, and left values
  *
  * @param padding card padding
+ * @param paddingX horizontal card padding
+ * @param paddingY vertical card padding
  * @returns extracted padding values
  */
-function getPaddingValues(padding: CardPadding) {
-  // handles padding='2' and padding={{ sm: '3', md: '4', lg: '5' }}
-  if (
-    typeof padding === "string" ||
-    (typeof padding === "object" &&
-      !("paddingX" in padding) &&
-      !("paddingY" in padding))
-  ) {
+function getPaddingValues(
+  padding?: CardPadding,
+  paddingX?: CardPadding,
+  paddingY?: CardPadding,
+) {
+  if (padding) {
     return {
       paddingTop: padding,
       paddingBottom: padding,
@@ -211,12 +228,7 @@ function getPaddingValues(padding: CardPadding) {
     };
   }
 
-  // handles padding={{ paddingX: '4', paddingY: { sm: '1', md: '3' }}}
-  if (
-    typeof padding === "object" &&
-    ("paddingX" in padding || "paddingY" in padding)
-  ) {
-    const { paddingX = 0, paddingY = 0 } = padding;
+  if (paddingX && paddingY) {
     return {
       paddingTop: paddingY,
       paddingBottom: paddingY,
@@ -225,6 +237,16 @@ function getPaddingValues(padding: CardPadding) {
     };
   }
 
+  if (paddingX || paddingY) {
+    return {
+      paddingTop: paddingY || 0,
+      paddingBottom: paddingY || 0,
+      paddingLeft: paddingX || 0,
+      paddingRight: paddingX || 0,
+    };
+  }
+
+  // default
   return {
     paddingTop: DEFAULT_PADDING,
     paddingBottom: DEFAULT_PADDING,
@@ -275,10 +297,29 @@ function getBackgroundToken(background: CardAreaProps["background"]) {
  * ```tsx
  * <Card boxShadow="1">Content</Card>
  * ```
+ *
  * @example
  * _Border radius:_
  * ```tsx
  * <Card borderRadius="sm">Content</Card>
+ * ```
+ *
+ * @example
+ * _Padding:_
+ * ```tsx
+ * <Card padding={{ xs: '2', sm: '3', md: '4', lg: '5', xl: '6' }}>Content</Card>
+ * ```
+ *
+ * @example
+ * _PaddingX:_
+ * ```tsx
+ * <Card paddingX="3">Content</Card>
+ * ```
+ *
+ * @example
+ * _PaddingY:_
+ * ```tsx
+ * <Card paddingY={{ xs: '1', sm: '2', md: '3'}}>Content</Card>
  * ```
  *
  * @example

--- a/easy-ui-react/src/Card/Card.tsx
+++ b/easy-ui-react/src/Card/Card.tsx
@@ -212,7 +212,7 @@ function CardArea({
  * @param padding card padding
  * @param paddingX horizontal card padding
  * @param paddingY vertical card padding
- * @returns extracted padding values
+ * @returns extracted directional padding values
  */
 function getPaddingValues(
   padding?: CardPadding,
@@ -228,21 +228,12 @@ function getPaddingValues(
     };
   }
 
-  if (paddingX && paddingY) {
+  if (paddingX || paddingY) {
     return {
       paddingTop: paddingY,
       paddingBottom: paddingY,
       paddingLeft: paddingX,
       paddingRight: paddingX,
-    };
-  }
-
-  if (paddingX || paddingY) {
-    return {
-      paddingTop: paddingY || 0,
-      paddingBottom: paddingY || 0,
-      paddingLeft: paddingX || 0,
-      paddingRight: paddingX || 0,
     };
   }
 
@@ -338,10 +329,22 @@ function getBackgroundToken(background: CardAreaProps["background"]) {
  * ```
  */
 export function Card(props: CardProps) {
-  const { background, children, padding, ...containerProps } = props;
+  const {
+    background,
+    children,
+    padding,
+    paddingX,
+    paddingY,
+    ...containerProps
+  } = props;
   return (
     <CardContainer {...containerProps}>
-      <CardArea background={background} padding={padding}>
+      <CardArea
+        background={background}
+        padding={padding}
+        paddingX={paddingX}
+        paddingY={paddingY}
+      >
         {children}
       </CardArea>
     </CardContainer>

--- a/easy-ui-react/src/ToggleCard/ToggleCard.module.scss
+++ b/easy-ui-react/src/ToggleCard/ToggleCard.module.scss
@@ -1,5 +1,0 @@
-@use "../styles/common" as *;
-
-.body {
-  padding: design-token("space.1") design-token("space.0");
-}

--- a/easy-ui-react/src/ToggleCard/ToggleCard.tsx
+++ b/easy-ui-react/src/ToggleCard/ToggleCard.tsx
@@ -103,7 +103,7 @@ function ToggleCardHeader(props: ToggleCardHeaderProps) {
   }, [children]);
 
   return (
-    <Card.Area background="neutral.050" padding="0.5">
+    <Card.Area background="neutral.050" paddingY="0.5" paddingX="1">
       <HorizontalStack gap="2" align="space-between" blockAlign="center">
         {children}
       </HorizontalStack>

--- a/easy-ui-react/src/ToggleCard/ToggleCard.tsx
+++ b/easy-ui-react/src/ToggleCard/ToggleCard.tsx
@@ -6,8 +6,6 @@ import {
   getDisplayNameFromReactNode,
 } from "../utilities/react";
 
-import styles from "./ToggleCard.module.scss";
-
 export type ToggleCardProps = {
   /**
    * The children of the <ToggleCard> element. Should render
@@ -78,7 +76,7 @@ export type ToggleCardProps = {
 export function ToggleCard(props: ToggleCardProps) {
   const { children } = props;
 
-  return <Card.Container>{children}</Card.Container>;
+  return <Card.Container borderRadius="lg">{children}</Card.Container>;
 }
 export type ToggleCardHeaderProps = {
   /**
@@ -124,8 +122,8 @@ function ToggleCardBody(props: ToggleCardBodyProps) {
   const { children } = props;
 
   return (
-    <Card.Area padding="0.5">
-      <div className={styles.body}>{children}</div>
+    <Card.Area padding={{ paddingX: "0.5", paddingY: "1" }}>
+      {children}
     </Card.Area>
   );
 }

--- a/easy-ui-react/src/ToggleCard/ToggleCard.tsx
+++ b/easy-ui-react/src/ToggleCard/ToggleCard.tsx
@@ -122,7 +122,7 @@ function ToggleCardBody(props: ToggleCardBodyProps) {
   const { children } = props;
 
   return (
-    <Card.Area padding={{ paddingX: "0.5", paddingY: "1" }}>
+    <Card.Area paddingX="0.5" paddingY="1">
       {children}
     </Card.Area>
   );

--- a/easy-ui-react/src/types.ts
+++ b/easy-ui-react/src/types.ts
@@ -70,3 +70,5 @@ export type SpaceScale = DesignTokenNamespace<"space">;
 export type ResponsiveSpaceScale = ResponsiveProp<SpaceScale>;
 
 export type ShadowLevel = DesignTokenNamespace<"shadow.level">;
+
+export type BorderRadius = DesignTokenNamespace<"shape.border_radius">;

--- a/easy-ui-react/src/utilities/storybook.tsx
+++ b/easy-ui-react/src/utilities/storybook.tsx
@@ -34,6 +34,10 @@ export function createShadowTokensControl() {
   return getDesignTokensControl("shadow.level.{alias}");
 }
 
+export function createBorderRadiusTokensControl() {
+  return getDesignTokensControl("shape.border_radius.{alias}");
+}
+
 export function getDesignTokensControl(pattern: string) {
   return getTokensControl(getTokenAliases(tokens, pattern));
 }


### PR DESCRIPTION
## 📝 Changes

`<Card />`:
  - Add support for `borderRadius` that maps to `shape.border_radius` values
  - Add support for `paddingY` and `paddingX`; values map to spacing tokens or an object of spacing tokens for different screen sizes
 
`<ToggleCard />`:
  - Uses new `<Card />` props to update component to match Figma designs

## ✅ Checklist

Easy UI has certain UX standards that must be met. In general, non-trivial changes should meet the following criteria:

- [x] Visuals match Design Specs in Figma
- [x] Stories accompany any component changes
- [x] Code is in accordance with our style guide
- [x] Design tokens are utilized
- [x] Unit tests accompany any component changes
- [x] TSDoc is written for any API surface area
- [x] Specs are up-to-date
- [x] Console is free from warnings
- [x] No accessibility violations are reported
- [x] Cross-browser check is performed (Chrome, Safari, Firefox)
- [x] Changeset is added

~Strikethrough~ any items that are not applicable to this pull request.
