### PR TITLE
T82577: update workflow permissions

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -4,6 +4,9 @@ jobs:
   deployment:
     runs-on: ubuntu-latest
     if: ${{ github.triggering_actor != 'dependabot[bot]' }}
+    permissions:
+      contents: write
+      statuses: write
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js v18

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      packages: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3


### PR DESCRIPTION
## 📝 Changes

**context:**

https://github.com/EasyPost/easy-ui/actions/runs/11845921295/job/33012393926?pr=1467

![Screenshot 2024-11-15 at 8 57 10 AM](https://github.com/user-attachments/assets/7b4aed04-cd51-46d0-9366-9f1ad1829098)

starting yesterday a couple of our workflows (chromatic and release) started failing and it looks to be due to permission issues. i reached out to dev tools on slack to ask if anything changed recently in the easypost github org settings / permissions that could prevent `github-actions[bot]` from doing things, but havent heard back yet.

