### PR TITLE
fix: EmptyStateCard use solid variant

### DIFF
--- a/.changeset/heavy-yaks-destroy.md
+++ b/.changeset/heavy-yaks-destroy.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+fix: EmptyStateCard use solid variant

--- a/easy-ui-react/src/EmptyStateCard/EmptyStateCard.tsx
+++ b/easy-ui-react/src/EmptyStateCard/EmptyStateCard.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from "react";
 import { Text, TextProps } from "../Text";
-import { Card } from "../Card";
+import { Card, CardProps } from "../Card";
 import { VerticalStack, VerticalStackProps } from "../VerticalStack";
 import { HorizontalStack, HorizontalStackProps } from "../HorizontalStack";
 import { classNames } from "../utilities/css";
@@ -8,7 +8,7 @@ import { classNames } from "../utilities/css";
 import { BASE_64_BLUE_BOX, BASE_64_CLAPPING_BENJAMIN } from "./utilities";
 import styles from "./EmptyStateCard.module.scss";
 
-export type EmptyStateCardProps = {
+export type EmptyStateCardProps = CardProps & {
   /**
    * The children of the <EmptyStateCard> element.
    */
@@ -67,10 +67,17 @@ export type EmptyStateCardProps = {
  * ```
  */
 export function EmptyStateCard(props: EmptyStateCardProps) {
-  const { children } = props;
+  const { children, ...cardProps } = props;
 
   return (
-    <Card background="primary.800" borderRadius="lg" padding="0" boxShadow="1">
+    <Card
+      variant="solid"
+      background="primary.800"
+      borderRadius="lg"
+      padding="0"
+      boxShadow="1"
+      {...cardProps}
+    >
       {children}
     </Card>
   );


### PR DESCRIPTION
## 📝 Changes

- Updates EmptyStateCard to use `solid` variant by default
- Support custom extension via `cardProps`

This matches the Figma which doesn't have a border:

<img width="568" alt="image" src="https://github.com/user-attachments/assets/c0d90ce2-ccab-43b8-bab4-b1f0119df8d6">

## ✅ Checklist

Easy UI has certain UX standards that must be met. In general, non-trivial changes should meet the following criteria:

- [x] Visuals match Design Specs in Figma
- [ ] ~Stories accompany any component changes~
- [ ] ~Code is in accordance with our style guide~
- [ ] ~Design tokens are utilized~
- [ ] ~Unit tests accompany any component changes~
- [ ] ~TSDoc is written for any API surface area~
- [ ] ~Specs are up-to-date~
- [ ] ~Console is free from warnings~
- [ ] ~No accessibility violations are reported~
- [ ] ~Cross-browser check is performed (Chrome, Safari, Firefox)~
- [x] Changeset is added

~Strikethrough~ any items that are not applicable to this pull request.
