### PR TITLE
fix: css output filename

### DIFF
--- a/.changeset/unlucky-grapes-joke.md
+++ b/.changeset/unlucky-grapes-joke.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+fix: css output filename

--- a/easy-ui-react/vite.config.mts
+++ b/easy-ui-react/vite.config.mts
@@ -48,6 +48,7 @@ export default defineConfig({
           ignore: ["**/test.ts", "**/*.test.ts"],
         }),
       ]),
+      cssFileName: "style",
     },
     rollupOptions: {
       external: ["react", "react-dom"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,10 +100,10 @@
     },
     "easy-ui-react": {
       "name": "@easypost/easy-ui",
-      "version": "1.0.0-alpha.48",
+      "version": "1.0.0-alpha.49",
       "dependencies": {
         "@easypost/easy-ui-icons": "1.0.0-alpha.28",
-        "@easypost/easy-ui-tokens": "1.0.0-alpha.13",
+        "@easypost/easy-ui-tokens": "1.0.0-alpha.14",
         "@react-aria/toast": "^3.0.0-beta.18",
         "@react-aria/utils": "^3.26.0",
         "@react-stately/toast": "^3.0.0-beta.7",
@@ -187,7 +187,7 @@
     },
     "easy-ui-tokens": {
       "name": "@easypost/easy-ui-tokens",
-      "version": "1.0.0-alpha.13",
+      "version": "1.0.0-alpha.14",
       "devDependencies": {
         "nodemon": "^3.1.7",
         "style-dictionary": "^3.9.2"
@@ -24893,7 +24893,7 @@
       "version": "file:easy-ui-react",
       "requires": {
         "@easypost/easy-ui-icons": "1.0.0-alpha.28",
-        "@easypost/easy-ui-tokens": "1.0.0-alpha.13",
+        "@easypost/easy-ui-tokens": "1.0.0-alpha.14",
         "@react-aria/toast": "^3.0.0-beta.18",
         "@react-aria/utils": "^3.26.0",
         "@react-stately/toast": "^3.0.0-beta.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,10 +100,10 @@
     },
     "easy-ui-react": {
       "name": "@easypost/easy-ui",
-      "version": "1.0.0-alpha.49",
+      "version": "1.0.0-alpha.48",
       "dependencies": {
         "@easypost/easy-ui-icons": "1.0.0-alpha.28",
-        "@easypost/easy-ui-tokens": "1.0.0-alpha.14",
+        "@easypost/easy-ui-tokens": "1.0.0-alpha.13",
         "@react-aria/toast": "^3.0.0-beta.18",
         "@react-aria/utils": "^3.26.0",
         "@react-stately/toast": "^3.0.0-beta.7",
@@ -187,7 +187,7 @@
     },
     "easy-ui-tokens": {
       "name": "@easypost/easy-ui-tokens",
-      "version": "1.0.0-alpha.14",
+      "version": "1.0.0-alpha.13",
       "devDependencies": {
         "nodemon": "^3.1.7",
         "style-dictionary": "^3.9.2"
@@ -24893,7 +24893,7 @@
       "version": "file:easy-ui-react",
       "requires": {
         "@easypost/easy-ui-icons": "1.0.0-alpha.28",
-        "@easypost/easy-ui-tokens": "1.0.0-alpha.14",
+        "@easypost/easy-ui-tokens": "1.0.0-alpha.13",
         "@react-aria/toast": "^3.0.0-beta.18",
         "@react-aria/utils": "^3.26.0",
         "@react-stately/toast": "^3.0.0-beta.7",


### PR DESCRIPTION
## 📝 Changes

- upgrading Vite renamed the default filename for the CSS file. this fixes it
