### PR TITLE
react aria compatible menu selection

### DIFF
--- a/easy-ui-react/src/Menu/Menu.module.scss
+++ b/easy-ui-react/src/Menu/Menu.module.scss
@@ -20,8 +20,9 @@
 }
 
 .sectionTitle {
-  @include font-style("subtitle1");
-  color: theme-token("color.primary.900");
+  display: inline-flex;
+  align-items: center;
+  min-height: design-token("space.4");
   padding: 0 component-token("menu", "padding.x");
 }
 

--- a/easy-ui-react/src/Menu/Menu.stories.tsx
+++ b/easy-ui-react/src/Menu/Menu.stories.tsx
@@ -40,7 +40,10 @@ export const SimpleMenu: Story = {
   render: Template.bind({}),
   args: {
     children: (
-      <Menu.Overlay onAction={action("Selected")}>
+      <Menu.Overlay
+        onAction={action("onAction")}
+        onSelectionChange={selectionChangeAction("onSelectionChange")}
+      >
         <Menu.Item key="copy">Copy</Menu.Item>
         <Menu.Item key="cut">Cut</Menu.Item>
         <Menu.Item key="paste">Paste</Menu.Item>
@@ -53,7 +56,10 @@ export const WithSeparator: Story = {
   render: Template.bind({}),
   args: {
     children: (
-      <Menu.Overlay onAction={action("Selected")}>
+      <Menu.Overlay
+        onAction={action("onAction")}
+        onSelectionChange={selectionChangeAction("onSelectionChange")}
+      >
         <Menu.Section aria-label="Edit commands">
           <Menu.Item key="edit">Edit</Menu.Item>
           <Menu.Item key="duplicate">Duplicate</Menu.Item>
@@ -71,7 +77,10 @@ export const WithTitle: Story = {
   render: Template.bind({}),
   args: {
     children: (
-      <Menu.Overlay onAction={action("Selected")}>
+      <Menu.Overlay
+        onAction={action("onAction")}
+        onSelectionChange={selectionChangeAction("onSelectionChange")}
+      >
         <Menu.Section aria-label="Edit commands" title="Title option">
           <Menu.Item key="edit">Edit</Menu.Item>
           <Menu.Item key="duplicate">Duplicate</Menu.Item>
@@ -92,7 +101,8 @@ export const ScrollsOnMaxItems: StoryObj<MenuOverlayProps<unknown>> = {
         <DropdownButton>Click me</DropdownButton>
       </Menu.Trigger>
       <Menu.Overlay
-        onAction={action("Selected")}
+        onAction={action("onAction")}
+        onSelectionChange={selectionChangeAction("onSelectionChange")}
         maxItemsUntilScroll={maxItemsUntilScroll}
       >
         <Menu.Item key="edit">Edit</Menu.Item>
@@ -119,7 +129,10 @@ export const WithLongItems: Story = {
   render: Template.bind({}),
   args: {
     children: (
-      <Menu.Overlay onAction={action("Selected")}>
+      <Menu.Overlay
+        onAction={action("onAction")}
+        onSelectionChange={selectionChangeAction("onSelectionChange")}
+      >
         <Menu.Item key="download-carriers">Download carriers report</Menu.Item>
         <Menu.Item key="download-shipping">Download shipping report</Menu.Item>
       </Menu.Overlay>
@@ -131,7 +144,11 @@ export const MatchContentWidth: Story = {
   render: Template.bind({}),
   args: {
     children: (
-      <Menu.Overlay onAction={action("Selected")} width="fit-content">
+      <Menu.Overlay
+        onAction={action("onAction")}
+        onSelectionChange={selectionChangeAction("onSelectionChange")}
+        width="fit-content"
+      >
         <Menu.Item key="copy">Copy</Menu.Item>
         <Menu.Item key="cut">Cut</Menu.Item>
         <Menu.Item key="paste">Paste</Menu.Item>
@@ -144,7 +161,11 @@ export const DefinedWidth: Story = {
   render: Template.bind({}),
   args: {
     children: (
-      <Menu.Overlay onAction={action("Selected")} width={300}>
+      <Menu.Overlay
+        onAction={action("onAction")}
+        onSelectionChange={selectionChangeAction("onSelectionChange")}
+        width={300}
+      >
         <Menu.Item key="copy">Copy</Menu.Item>
         <Menu.Item key="cut">Cut</Menu.Item>
         <Menu.Item key="paste">Paste</Menu.Item>
@@ -157,7 +178,11 @@ export const DefinedResponsiveWidth: Story = {
   render: Template.bind({}),
   args: {
     children: (
-      <Menu.Overlay onAction={action("Selected")} width={{ xs: 150, lg: 250 }}>
+      <Menu.Overlay
+        onAction={action("onAction")}
+        onSelectionChange={selectionChangeAction("onSelectionChange")}
+        width={{ xs: 150, lg: 250 }}
+      >
         <Menu.Item key="copy">Copy</Menu.Item>
         <Menu.Item key="cut">Cut</Menu.Item>
         <Menu.Item key="paste">Paste</Menu.Item>
@@ -178,7 +203,11 @@ export const MixedItemTypes: Story = {
   render: Template.bind({}),
   args: {
     children: (
-      <Menu.Overlay onAction={action("Selected")} disabledKeys={["no-results"]}>
+      <Menu.Overlay
+        onAction={action("onAction")}
+        onSelectionChange={selectionChangeAction("onSelectionChange")}
+        disabledKeys={["no-results"]}
+      >
         <Menu.Item key="no-results">Nothing to click here</Menu.Item>
         <Menu.Item key="link" href="https://easypost.com" target="_blank">
           I am a link
@@ -205,7 +234,8 @@ export const CustomPlacement: StoryObj<MenuOverlayProps<unknown>> = {
         <DropdownButton>Click me</DropdownButton>
       </Menu.Trigger>
       <Menu.Overlay
-        onAction={action("Selected")}
+        onAction={action("onAction")}
+        onSelectionChange={selectionChangeAction("onSelectionChange")}
         placement={placement}
         width="fit-content"
       >
@@ -237,17 +267,19 @@ export const MultipleSelection: Story = {
     const [selectedKeys, setSelectedKeys] = React.useState<Selection>(
       new Set([]),
     );
-
     return (
       <Menu>
         <Menu.Trigger>
           <DropdownButton>Click me</DropdownButton>
         </Menu.Trigger>
         <Menu.Overlay
-          onSelectionChange={setSelectedKeys}
           selectionMode="multiple"
           selectedKeys={selectedKeys}
-          onAction={action("Selected")}
+          onSelectionChange={(keys) => {
+            setSelectedKeys(keys);
+            selectionChangeAction("onSelectionChange")(keys);
+          }}
+          onAction={action("onAction")}
         >
           <Menu.Item key="transit">In Transit</Menu.Item>
           <Menu.Item key="delivery">Out for Delivery</Menu.Item>
@@ -263,7 +295,6 @@ export const MultipleSelectionWithSelectAll: Story = {
     const [selectedKeys, setSelectedKeys] = React.useState<Selection>(
       new Set([]),
     );
-
     return (
       <Menu>
         <Menu.Trigger>
@@ -271,9 +302,12 @@ export const MultipleSelectionWithSelectAll: Story = {
         </Menu.Trigger>
         <Menu.Overlay
           selectionMode="multiple"
-          onSelectionChange={setSelectedKeys}
           selectedKeys={selectedKeys}
-          onAction={action("Selected")}
+          onSelectionChange={(keys) => {
+            setSelectedKeys(keys);
+            selectionChangeAction("onSelectionChange")(keys);
+          }}
+          onAction={action("onAction")}
         >
           <Menu.Section aria-label="All Status">
             <Menu.Item key="all">All Statues</Menu.Item>
@@ -288,3 +322,40 @@ export const MultipleSelectionWithSelectAll: Story = {
     );
   },
 };
+
+export const UncontrolledMultipleSelectionWithSelectAll: Story = {
+  render: () => {
+    return (
+      <Menu>
+        <Menu.Trigger>
+          <DropdownButton>Click me</DropdownButton>
+        </Menu.Trigger>
+        <Menu.Overlay
+          selectionMode="multiple"
+          defaultSelectedKeys={["transit", "usps"]}
+          onAction={action("onAction")}
+          onSelectionChange={selectionChangeAction("onSelectionChange")}
+          maxItemsUntilScroll={8}
+        >
+          <Menu.Section aria-label="All Status">
+            <Menu.Item key="all">All Statues</Menu.Item>
+          </Menu.Section>
+          <Menu.Section aria-label="Status" title="Status">
+            <Menu.Item key="transit">In Transit</Menu.Item>
+            <Menu.Item key="delivery">Out for Delivery</Menu.Item>
+            <Menu.Item key="delivered">Delivered</Menu.Item>
+          </Menu.Section>
+          <Menu.Section aria-label="Carrier" title="Carrier">
+            <Menu.Item key="usps">USPS</Menu.Item>
+            <Menu.Item key="ups">UPS</Menu.Item>
+            <Menu.Item key="fedex">FedEx</Menu.Item>
+          </Menu.Section>
+        </Menu.Overlay>
+      </Menu>
+    );
+  },
+};
+
+function selectionChangeAction(name: string) {
+  return (keys: Selection) => action(name)(keys === "all" ? keys : [...keys]);
+}

--- a/easy-ui-react/src/Menu/Menu.test.tsx
+++ b/easy-ui-react/src/Menu/Menu.test.tsx
@@ -297,6 +297,28 @@ describe("<Menu />", () => {
     await clickMenuItem(user, checkboxes[0]);
     checkboxes.forEach((checkbox) => expect(checkbox).toBeChecked());
   });
+
+  // TODO: userKeyboard is not registering onSelectionChange in React Aria
+  //       figure out how to get working with react aria
+  it.skip("should select all options when cmd + a keyboard shortcut is used", async () => {
+    const { user } = render(
+      getMenu({
+        menuProps: { defaultOpen: true },
+        menuOverlayProps: {
+          selectionMode: "multiple",
+        },
+        items: [
+          <Menu.Item key="all">Select All</Menu.Item>,
+          <Menu.Item key="1">1</Menu.Item>,
+          <Menu.Item key="2">2</Menu.Item>,
+          <Menu.Item key="3">3</Menu.Item>,
+        ],
+      }),
+    );
+    await userKeyboard(user, "{Meta>}{a}{/Meta}");
+    const checkboxes = screen.getAllByRole("menuitemcheckbox");
+    checkboxes.forEach((checkbox) => expect(checkbox).toBeChecked());
+  });
 });
 
 function getMenu({

--- a/easy-ui-react/src/Menu/MenuItem.tsx
+++ b/easy-ui-react/src/Menu/MenuItem.tsx
@@ -7,10 +7,14 @@ import React, {
 } from "react";
 import { mergeProps, useMenuItem } from "react-aria";
 import { Item, Node, TreeState } from "react-stately";
-import { Text } from "../Text";
 import { Checkbox } from "../Checkbox";
+import { Text } from "../Text";
 import { NoInfer } from "../types";
-import { SELECT_ALL_KEY, useSelectAllState } from "./utilities";
+import {
+  isSelectAllIndeterminate,
+  isSelectAllSelected,
+  SELECT_ALL_KEY,
+} from "./utilities";
 
 import styles from "./Menu.module.scss";
 
@@ -74,19 +78,19 @@ export function MenuItemContent<T>({ item, state }: MenuItemContentProps<T>) {
     state,
     ref,
   );
-  const { selectAllItemProps, isSelectAllSelected, isSelectAllIndeterminate } =
-    useSelectAllState(state, item.key);
 
   const MenuItemContainer = href
     ? LinkMenuItemContainer
     : StandardMenuItemContainer;
 
-  const props = href
-    ? mergeProps(
-        menuItemProps,
-        omit(item.props, ["aria-label", "as", "children", "closeOnSelect"]),
-      )
-    : mergeProps(menuItemProps, selectAllItemProps);
+  const props = mergeProps(
+    menuItemProps,
+    href
+      ? omit(item.props, ["aria-label", "as", "children", "closeOnSelect"])
+      : item.key === SELECT_ALL_KEY
+        ? { "aria-checked": isSelectAllSelected(state) }
+        : {},
+  );
 
   return (
     <MenuItemContainer
@@ -96,7 +100,7 @@ export function MenuItemContent<T>({ item, state }: MenuItemContentProps<T>) {
       data-is-disabled={isDisabled}
       data-is-focused={isFocused}
       data-is-selected={
-        item.key === SELECT_ALL_KEY ? isSelectAllSelected : isSelected
+        item.key === SELECT_ALL_KEY ? isSelectAllSelected(state) : isSelected
       }
     >
       <div className={styles.itemContent}>
@@ -106,12 +110,16 @@ export function MenuItemContent<T>({ item, state }: MenuItemContentProps<T>) {
           </Text>
         ) : (
           <Checkbox
-            isSelected={
-              item.key === SELECT_ALL_KEY ? isSelectAllSelected : isSelected
-            }
             isDisabled={isDisabled}
             isIndeterminate={
-              item.key === SELECT_ALL_KEY ? isSelectAllIndeterminate : undefined
+              item.key === SELECT_ALL_KEY
+                ? isSelectAllIndeterminate(state)
+                : undefined
+            }
+            isSelected={
+              item.key === SELECT_ALL_KEY
+                ? isSelectAllSelected(state)
+                : isSelected
             }
           >
             {item.rendered}

--- a/easy-ui-react/src/Menu/MenuOverlay.tsx
+++ b/easy-ui-react/src/Menu/MenuOverlay.tsx
@@ -1,10 +1,11 @@
 import {
   CollectionChildren,
   Key,
-  SelectionMode,
   Selection,
+  SelectionMode,
 } from "@react-types/shared";
-import React from "react";
+import noop from "lodash/noop";
+import React, { useCallback } from "react";
 import {
   DismissButton,
   Overlay,
@@ -28,8 +29,9 @@ import {
   OVERLAY_PADDING_FROM_CONTAINER,
   SELECT_ALL_KEY,
   Y_PADDING_INSIDE_OVERLAY,
+  filterSelectedKeys,
   getUnmergedPopoverStyles,
-  getItems,
+  isSelectAllSelected,
 } from "./utilities";
 
 import styles from "./Menu.module.scss";
@@ -42,6 +44,11 @@ export type MenuOverlayWidth =
 export type MenuOverlayProps<T> = {
   /** The contents of the menu. */
   children: CollectionChildren<T>;
+
+  /**
+   * The initial selected keys in the collection (uncontrolled).
+   */
+  defaultSelectedKeys?: "all" | Iterable<Key>;
 
   /** The item keys that are disabled. These items cannot be selected, focused, or otherwise interacted with. */
   disabledKeys?: Iterable<Key>;
@@ -94,27 +101,21 @@ export function MenuOverlay<T extends object>(props: MenuOverlayProps<T>) {
 function MenuOverlayContent<T extends object>(props: MenuOverlayProps<T>) {
   const {
     children,
+    defaultSelectedKeys,
     disabledKeys,
     maxItemsUntilScroll = DEFAULT_MAX_ITEMS_UNTIL_SCROLL,
-    onAction,
+    onAction = noop,
     onClose,
     placement = DEFAULT_PLACEMENT,
     width = DEFAULT_WIDTH,
     selectionMode,
-    onSelectionChange,
+    onSelectionChange = noop,
     selectedKeys,
   } = props;
 
   const popoverRef = React.useRef(null);
   const menuRef = React.useRef(null);
-
-  const menuTreeState = useTreeState({
-    children,
-    disabledKeys,
-    selectionMode,
-    selectedKeys,
-    onSelectionChange,
-  });
+  const selectionPendingRef = React.useRef(false);
 
   const { menuTriggerState, triggerRef, triggerWidth, menuPropsFromTrigger } =
     useInternalMenuContext();
@@ -133,30 +134,47 @@ function MenuOverlayContent<T extends object>(props: MenuOverlayProps<T>) {
     menuTriggerState,
   );
 
-  const { selectionManager } = menuTreeState;
-  const handleMultiSelectAll = (key: Key) => {
-    const { itemSize, items } = getItems(menuTreeState);
-    if (key === SELECT_ALL_KEY) {
-      if (selectionManager.selectedKeys.size === itemSize) {
-        selectionManager.clearSelection();
-      } else {
-        selectionManager.setSelectedKeys(items);
+  // Override the onSelectionChange handler to handle custom
+  // "Select all" behavior.
+  const handleSelectionChange = useCallback(
+    (keys: Selection) => {
+      if (!selectionPendingRef.current) {
+        return;
       }
-    }
-    if (onAction) {
-      onAction(key);
-    }
-  };
+      onSelectionChange(keys === "all" ? keys : filterSelectedKeys(keys));
+      selectionPendingRef.current = false;
+    },
+    [onSelectionChange],
+  );
 
-  const handleOnAction =
-    selectionMode === "multiple" &&
-    !!menuTreeState.collection.getItem(SELECT_ALL_KEY)
-      ? handleMultiSelectAll
-      : onAction;
+  const menuTreeState = useTreeState({
+    children,
+    defaultSelectedKeys,
+    disabledKeys,
+    selectionMode,
+    selectedKeys,
+    onSelectionChange: handleSelectionChange,
+  });
+
+  // Override the onAction handler to handle custom "Select all" behavior.
+  const handleAction = useCallback(
+    (key: Key) => {
+      selectionPendingRef.current = true;
+      if (key === SELECT_ALL_KEY && isSelectAllSelected(menuTreeState)) {
+        menuTreeState.selectionManager.clearSelection();
+      } else if (key === SELECT_ALL_KEY) {
+        menuTreeState.selectionManager.selectAll();
+      } else {
+        menuTreeState.selectionManager.toggleSelection(key);
+      }
+      onAction(key);
+    },
+    [menuTreeState, onAction],
+  );
 
   const { menuProps } = useMenu(
     mergeProps(
-      { disabledKeys, onAction: handleOnAction, onClose },
+      { disabledKeys, onAction: handleAction, onClose },
       menuPropsFromTrigger,
     ),
     menuTreeState,

--- a/easy-ui-react/src/Menu/MenuSection.tsx
+++ b/easy-ui-react/src/Menu/MenuSection.tsx
@@ -4,6 +4,7 @@ import { Node, Section, TreeState } from "react-stately";
 
 import styles from "./Menu.module.scss";
 import { MenuItemContent } from "./MenuItem";
+import { Text } from "../Text";
 
 export type MenuSectionProps = {
   /** Rendered contents of the item or child items. */
@@ -61,7 +62,9 @@ export function MenuSectionContent<T>({
             <>
               {section.rendered && (
                 <span {...headingProps} className={styles.sectionTitle}>
-                  {section.rendered}
+                  <Text variant="subtitle1" color="primary.900">
+                    {section.rendered}
+                  </Text>
                 </span>
               )}
               <ul {...groupProps} className={styles.sectionList}>

--- a/easy-ui-react/src/Menu/utilities.ts
+++ b/easy-ui-react/src/Menu/utilities.ts
@@ -1,11 +1,11 @@
-import React from "react";
 import { Key } from "@react-types/shared";
+import React from "react";
+import { TreeState } from "react-stately";
 import {
   getComponentToken,
   getResponsiveValue,
   pxToRem,
 } from "../utilities/css";
-import { TreeState } from "react-stately";
 import { MenuOverlayWidth } from "./MenuOverlay";
 
 export const DEFAULT_MAX_ITEMS_UNTIL_SCROLL = 5;
@@ -41,48 +41,41 @@ export function getUnmergedPopoverStyles(
   };
 }
 
-type Items = {
-  itemSize: number;
-  items: Set<Key>;
-};
-export function getItems<T>(state: TreeState<T>): Items {
-  return [...state.collection].reduce(
-    (acc, item) => {
-      if (item.type === "section") {
-        [...item.childNodes].forEach((child) => {
-          if (
-            child.key !== SELECT_ALL_KEY &&
-            !state.disabledKeys.has(child.key)
-          ) {
-            acc.itemSize += 1;
-            acc.items.add(child.key);
-          }
-        });
-      } else {
-        if (item.key !== SELECT_ALL_KEY) {
-          acc.itemSize += 1;
-          acc.items.add(item.key);
+export function getAllSelectableItems<T>(state: TreeState<T>): Set<Key> {
+  return [...state.collection].reduce((acc, item) => {
+    if (item.type === "section") {
+      [...item.childNodes].forEach((child) => {
+        if (
+          child.key !== SELECT_ALL_KEY &&
+          !state.disabledKeys.has(child.key)
+        ) {
+          acc.add(child.key);
         }
+      });
+    } else {
+      if (item.key !== SELECT_ALL_KEY && !state.disabledKeys.has(item.key)) {
+        acc.add(item.key);
       }
-      return acc;
-    },
-    { itemSize: 0, items: new Set<Key>() },
+    }
+    return acc;
+  }, new Set<Key>());
+}
+
+export function filterSelectedKeys(keys: Set<Key>) {
+  return new Set([...keys].filter((v) => v !== SELECT_ALL_KEY));
+}
+
+export function getFilteredSelectedKeys<T>(state: TreeState<T>) {
+  return filterSelectedKeys(state.selectionManager.selectedKeys);
+}
+
+export function isSelectAllSelected<T>(state: TreeState<T>) {
+  return (
+    state.selectionManager.isSelectAll ||
+    getFilteredSelectedKeys(state).size === getAllSelectableItems(state).size
   );
 }
 
-export function useSelectAllState<T>(state: TreeState<T>, key: Key) {
-  const { selectedKeys } = state.selectionManager;
-  const { itemSize } = getItems(state);
-  const isSelectAllCheckbox = key === SELECT_ALL_KEY;
-  const isSelectAllSelected =
-    !selectedKeys.has(SELECT_ALL_KEY) && selectedKeys.size === itemSize;
-  const isSelectAllIndeterminate =
-    selectedKeys.size > 0 && !isSelectAllSelected;
-  const selectAllItemProps = isSelectAllCheckbox
-    ? {
-        "aria-checked": isSelectAllSelected,
-      }
-    : {};
-
-  return { selectAllItemProps, isSelectAllSelected, isSelectAllIndeterminate };
+export function isSelectAllIndeterminate<T>(state: TreeState<T>) {
+  return !isSelectAllSelected(state) && getFilteredSelectedKeys(state).size > 0;
 }


### PR DESCRIPTION
- example of react aria menu compatible selection
- other menu fixes

Link to Story:
https://menu-adjustment--63f50c7c86f6514d2e0ef4be.chromatic.com/?path=/story/components-menu--multiple-selection-with-select-all

View "Actions" panel to see how behavior reflects what is expected for React Aria selection. When selecting a list of items the returned keys are an array of items. When selecting "Select all" directly, the key returned is "all". This matches what is outlined here: https://react-spectrum.adobe.com/react-aria/selection.html#select-all

We'll also want to update the docs to note this.
