### PR TITLE
feat(Menu,Select): use proper Overlay primitive

### DIFF
--- a/.changeset/selfish-mice-reflect.md
+++ b/.changeset/selfish-mice-reflect.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+fix(Select,Tooltip): use proper Overlay primitive

--- a/easy-ui-react/src/Select/SelectOverlay.tsx
+++ b/easy-ui-react/src/Select/SelectOverlay.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import {
   DismissButton,
-  OverlayContainer,
+  Overlay,
   mergeProps,
   useListBox,
   usePopover,
@@ -68,7 +68,7 @@ function SelectOverlayContent() {
   } as React.CSSProperties;
 
   return (
-    <OverlayContainer>
+    <Overlay>
       <div {...underlayProps} className={styles.underlay} />
       <div
         {...mergeProps(popoverProps, { style })}
@@ -104,6 +104,6 @@ function SelectOverlayContent() {
         </div>
         <DismissButton onDismiss={selectState.close} />
       </div>
-    </OverlayContainer>
+    </Overlay>
   );
 }

--- a/easy-ui-react/src/Tooltip/Tooltip.tsx
+++ b/easy-ui-react/src/Tooltip/Tooltip.tsx
@@ -6,7 +6,7 @@ import React, {
   useLayoutEffect,
 } from "react";
 import {
-  OverlayContainer,
+  Overlay,
   Placement,
   mergeProps,
   useOverlayPosition,
@@ -129,14 +129,14 @@ export function Tooltip(props: TooltipProps) {
         ref: triggerRef,
       })}
       {tooltipTriggerState.isOpen && (
-        <OverlayContainer>
+        <Overlay>
           <TooltipInner
             {...props}
             triggerRef={triggerRef}
             tooltipPropsFromTrigger={tooltipPropsFromTrigger}
             tooltipTriggerState={tooltipTriggerState}
           />
-        </OverlayContainer>
+        </Overlay>
       )}
     </>
   );


### PR DESCRIPTION
## 📝 Changes

- Tooltips and Selects were using OverlayContainer instead of Overlay which was causing them not to work right in modals and drawers

## ✅ Checklist

Easy UI has certain UX standards that must be met. In general, non-trivial changes should meet the following criteria:

- [ ] ~Visuals match Design Specs in Figma~
- [ ] ~Stories accompany any component changes~
- [x] Code is in accordance with our style guide
- [ ] ~Design tokens are utilized~
- [ ] ~Unit tests accompany any component changes~
- [ ] ~TSDoc is written for any API surface area~
- [ ] ~Specs are up-to-date~
- [x] Console is free from warnings
- [x] No accessibility violations are reported
- [x] Cross-browser check is performed (Chrome, Safari, Firefox)
- [x] Changeset is added

~Strikethrough~ any items that are not applicable to this pull request.
