### PR TITLE
fix(DataGrid): align actions menu to end

### DIFF
--- a/.changeset/rotten-tips-divide.md
+++ b/.changeset/rotten-tips-divide.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+fix(DataGrid): align actions menu to end

--- a/easy-ui-react/src/DataGrid/Cell.module.scss
+++ b/easy-ui-react/src/DataGrid/Cell.module.scss
@@ -64,6 +64,7 @@
 }
 
 .lastWithActions {
+  text-align: end;
   padding-left: design-token("space.0.5");
   padding-right: design-token("space.2");
   position: sticky;

--- a/easy-ui-react/src/DataGrid/Cell.module.scss
+++ b/easy-ui-react/src/DataGrid/Cell.module.scss
@@ -64,11 +64,11 @@
 }
 
 .lastWithActions {
-  text-align: end;
   padding-left: design-token("space.0.5");
   padding-right: design-token("space.2");
   position: sticky;
   right: component-token("data-grid", "sticky-right-offset");
+  text-align: end;
   z-index: component-token("data-grid", "cell-stuck-z-index");
 }
 


### PR DESCRIPTION
## 📝 Changes

- In cases where the actions cell is expanded beyond its content width, align it toward the end 

before:

<img width="1045" alt="image" src="https://github.com/user-attachments/assets/851bb0a7-b450-45eb-bf1c-ce868167e9b0" />

after:

<img width="1030" alt="image" src="https://github.com/user-attachments/assets/bcb9e32b-05c8-4394-bf60-a7034be644fa" />

