### PR TITLE
fix(Select,TextField): click through icon

### DIFF
--- a/.changeset/short-shrimps-beg.md
+++ b/.changeset/short-shrimps-beg.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+fix(Select,TextField): click through icon

--- a/easy-ui-react/src/InputField/InputField.module.scss
+++ b/easy-ui-react/src/InputField/InputField.module.scss
@@ -126,6 +126,7 @@
   color: component-token("inputfield", "color.text.gray.resting");
   border: 0;
   display: inline-block;
+  pointer-events: none;
   position: absolute;
   top: design-token("space.1.5");
   z-index: component-token("inputfield", "z-index");


### PR DESCRIPTION
## 📝 Changes

- support clicking through icons that overlay Select and TextField

this fixes the bug particularly noticeable on Select components where users can't open the dropdown when their mouse is over the arrow icon. preserves actionable icon such as in password textfield

## ✅ Checklist

Easy UI has certain UX standards that must be met. In general, non-trivial changes should meet the following criteria:

- [ ] ~Visuals match Design Specs in Figma~
- [ ] ~Stories accompany any component changes~
- [ ] ~Code is in accordance with our style guide~
- [ ] ~Design tokens are utilized~
- [ ] ~Unit tests accompany any component changes~
- [ ] ~TSDoc is written for any API surface area~
- [ ] ~Specs are up-to-date~
- [x] Console is free from warnings
- [x] No accessibility violations are reported
- [x] Cross-browser check is performed (Chrome, Safari, Firefox)
- [x] Changeset is added

~Strikethrough~ any items that are not applicable to this pull request.
