### PR TITLE
fix(DataGrid): support user selection and unbreak line-height

### DIFF
--- a/.changeset/short-lizards-promise.md
+++ b/.changeset/short-lizards-promise.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+fix(DataGrid): support user selection and unbreak line-height

--- a/easy-ui-react/src/DataGrid/DataGrid.module.scss
+++ b/easy-ui-react/src/DataGrid/DataGrid.module.scss
@@ -76,7 +76,6 @@
   /* stylelint-enable scss/operator-no-newline-after */
   overflow: auto;
   position: relative;
-  line-height: 0;
 
   [data-ezui-data-grid-shadow] {
     position: absolute;
@@ -128,4 +127,10 @@
     "header-bg",
     design-token("color.primary.900")
   );
+}
+
+// Table layout renders extra height on visuallyHidden text elements
+// when display is set to usual `inline`
+.visuallyHiddenCellContainer {
+  display: inline-flex;
 }

--- a/easy-ui-react/src/DataGrid/Row.module.scss
+++ b/easy-ui-react/src/DataGrid/Row.module.scss
@@ -3,6 +3,9 @@
 .Row {
   vertical-align: top;
   outline: none;
+}
+
+.noUserSelection {
   user-select: none;
   cursor: default;
 }

--- a/easy-ui-react/src/DataGrid/Row.tsx
+++ b/easy-ui-react/src/DataGrid/Row.tsx
@@ -10,7 +10,7 @@ import { mergeProps, useFocusRing, useHover, useTableRow } from "react-aria";
 import { TableState } from "react-stately";
 import { classNames } from "../utilities/css";
 import { EXPAND_COLUMN_KEY } from "./constants";
-import { DataGridRowContext } from "./context";
+import { DataGridRowContext, useDataGridTable } from "./context";
 
 import styles from "./Row.module.scss";
 
@@ -34,6 +34,7 @@ export function Row({ item, children, state, isExpanded }: RowProps) {
   const rowIndex = item.index;
 
   const ref = useRef(null);
+  const { hasSelection, hasOnRowAction } = useDataGridTable();
   const { rowProps, isPressed } = useTableRow({ node: item }, state, ref);
   const { isFocusVisible, focusProps } = useFocusRing();
   const { isHovered, hoverProps } = useHover({});
@@ -65,6 +66,7 @@ export function Row({ item, children, state, isExpanded }: RowProps) {
     isSelected && styles.selected,
     isPressed && styles.pressed,
     isDisabled && styles.disabled,
+    (hasSelection || hasOnRowAction) && styles.noUserSelection,
   );
 
   return (

--- a/easy-ui-react/src/DataGrid/Table.tsx
+++ b/easy-ui-react/src/DataGrid/Table.tsx
@@ -33,7 +33,7 @@ export function Table<C extends Column>(props: TableProps<C>) {
     renderExpandedRow = (r) => r,
     selectionMode,
     size = DEFAULT_SIZE,
-    renderEmptyState = () => "No Data!",
+    renderEmptyState = () => "No Data",
     isLoading = false,
   } = props;
 
@@ -63,6 +63,7 @@ export function Table<C extends Column>(props: TableProps<C>) {
   const hasSelection = columns.some((c) => c.props.isSelectionCell);
   const hasExpansion = columns.some((c) => c.key === EXPAND_COLUMN_KEY);
   const hasRowActions = columns.some((c) => c.key === ACTIONS_COLUMN_KEY);
+  const hasOnRowAction = !!props.onRowAction;
 
   const dataGridClassName = classNames(
     styles.DataGrid,
@@ -91,6 +92,7 @@ export function Table<C extends Column>(props: TableProps<C>) {
       hasSelection,
       hasExpansion,
       hasRowActions,
+      hasOnRowAction,
       isTopEdgeUnderScroll,
       isLeftEdgeUnderScroll,
       isRightEdgeUnderScroll,
@@ -100,6 +102,7 @@ export function Table<C extends Column>(props: TableProps<C>) {
     hasSelection,
     hasExpansion,
     hasRowActions,
+    hasOnRowAction,
     isTopEdgeUnderScroll,
     isLeftEdgeUnderScroll,
     isRightEdgeUnderScroll,

--- a/easy-ui-react/src/DataGrid/VisuallyHiddenCellContent.tsx
+++ b/easy-ui-react/src/DataGrid/VisuallyHiddenCellContent.tsx
@@ -1,6 +1,8 @@
 import React, { ReactNode } from "react";
 import { Text } from "../Text";
 
+import styles from "./DataGrid.module.scss";
+
 type VisuallyHiddenCellContentProps = {
   children: ReactNode;
 };
@@ -8,5 +10,9 @@ type VisuallyHiddenCellContentProps = {
 export function VisuallyHiddenCellContent({
   children,
 }: VisuallyHiddenCellContentProps) {
-  return <Text visuallyHidden>{children}</Text>;
+  return (
+    <span className={styles.visuallyHiddenCellContainer}>
+      <Text visuallyHidden>{children}</Text>
+    </span>
+  );
 }

--- a/easy-ui-react/src/DataGrid/context.ts
+++ b/easy-ui-react/src/DataGrid/context.ts
@@ -22,6 +22,7 @@ type DataGridTableContextType = {
   hasSelection: boolean;
   hasExpansion: boolean;
   hasRowActions: boolean;
+  hasOnRowAction: boolean;
   isTopEdgeUnderScroll: boolean;
   isLeftEdgeUnderScroll: boolean;
   isRightEdgeUnderScroll: boolean;


### PR DESCRIPTION
## 📝 Changes

- supports user selection when possible. still can't select text when DataGrid is in selection mode or if a row can be clicked. this is because React Aria intercepts events for each
- unbreaks line-height by removing the line-height declaration on the parent and solving the height issue elsewhere

## ✅ Checklist

Easy UI has certain UX standards that must be met. In general, non-trivial changes should meet the following criteria:

- [x] Visuals match Design Specs in Figma
- [x] Stories accompany any component changes
- [x] Code is in accordance with our style guide
- [x] Design tokens are utilized
- [x] Unit tests accompany any component changes
- [x] TSDoc is written for any API surface area
- [x] Specs are up-to-date
- [x] Console is free from warnings
- [x] No accessibility violations are reported
- [x] Cross-browser check is performed (Chrome, Safari, Firefox)
- [x] Changeset is added

~Strikethrough~ any items that are not applicable to this pull request.
