### PR TITLE
fix(Button): remove support for className

### DIFF
--- a/.changeset/brown-buckets-whisper.md
+++ b/.changeset/brown-buckets-whisper.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+fix(Button): extend className instead of overwriting

--- a/.changeset/brown-buckets-whisper.md
+++ b/.changeset/brown-buckets-whisper.md
@@ -2,4 +2,4 @@
 "@easypost/easy-ui": patch
 ---
 
-fix(Button): extend className instead of overwriting
+fix(Button): remove support for className

--- a/easy-ui-react/src/Button/Button.test.tsx
+++ b/easy-ui-react/src/Button/Button.test.tsx
@@ -68,4 +68,17 @@ describe("<Button />", () => {
     render(<Button isDisabled />);
     expect(screen.getByRole("button")).toBeDisabled();
   });
+
+  it("should extend the className", () => {
+    render(<Button className="extend" />);
+    expect(screen.getByRole("button")).toHaveAttribute(
+      "class",
+      expect.stringContaining("extend"),
+    );
+    // keep existing button class
+    expect(screen.getByRole("button")).toHaveAttribute(
+      "class",
+      expect.stringContaining("_Button_"),
+    );
+  });
 });

--- a/easy-ui-react/src/Button/Button.test.tsx
+++ b/easy-ui-react/src/Button/Button.test.tsx
@@ -69,9 +69,10 @@ describe("<Button />", () => {
     expect(screen.getByRole("button")).toBeDisabled();
   });
 
-  it("should extend the className", () => {
+  it("should not support className", () => {
+    // @ts-expect-error testing className omission
     render(<Button className="extend" />);
-    expect(screen.getByRole("button")).toHaveAttribute(
+    expect(screen.getByRole("button")).not.toHaveAttribute(
       "class",
       expect.stringContaining("extend"),
     );

--- a/easy-ui-react/src/Button/Button.tsx
+++ b/easy-ui-react/src/Button/Button.tsx
@@ -39,6 +39,8 @@ export type ButtonProps = AriaButtonProps & {
   children?: ReactNode;
   /** Link's destination */
   href?: string;
+  /** Button's className */
+  className?: string;
 };
 
 /**
@@ -115,6 +117,7 @@ export const Button = forwardRef<null, ButtonProps>((props, inRef) => {
     iconAtEnd,
     children = "Button",
     href = "",
+    className,
     ...restProps
   } = props;
 
@@ -142,6 +145,7 @@ export const Button = forwardRef<null, ButtonProps>((props, inRef) => {
         styles[variationName("variant", variant)],
         styles[variationName("size", size)],
         isBlock && styles.block,
+        className,
       )}
       href={href}
       {...restProps}

--- a/easy-ui-react/src/Button/Button.tsx
+++ b/easy-ui-react/src/Button/Button.tsx
@@ -39,8 +39,6 @@ export type ButtonProps = AriaButtonProps & {
   children?: ReactNode;
   /** Link's destination */
   href?: string;
-  /** Button's className */
-  className?: string;
 };
 
 /**
@@ -117,7 +115,6 @@ export const Button = forwardRef<null, ButtonProps>((props, inRef) => {
     iconAtEnd,
     children = "Button",
     href = "",
-    className,
     ...restProps
   } = props;
 
@@ -139,16 +136,15 @@ export const Button = forwardRef<null, ButtonProps>((props, inRef) => {
     <UnstyledButton
       isDisabled={isDisabled}
       ref={inRef}
+      href={href}
+      {...restProps}
       className={classNames(
         styles.Button,
         styles[variationName("color", color)],
         styles[variationName("variant", variant)],
         styles[variationName("size", size)],
         isBlock && styles.block,
-        className,
       )}
-      href={href}
-      {...restProps}
     >
       {iconAtStart && canUseIcon && <Icon symbol={iconAtStart} />}
       <span


### PR DESCRIPTION
## 📝 Changes

- remove support for overwriting `className` on `Button`

`<Button className="extend" />` overwrites button styles by accidentally spreading props at the end. this is a pretty big departure from Easy UI's current expectations that presentational components contain their styles and provide extensions only through props, and can cause further breaking changes later with a harder upgrade path

🚨 this is technically a breaking change but due to being in pre-release mode, it's better served as a patch. we will need to update 4 instances in our products. these can be found with this `<Button([\s\n\r]+|[^>]+)className` regex 🚨 

## ✅ Checklist

Easy UI has certain UX standards that must be met. In general, non-trivial changes should meet the following criteria:

- [x] Visuals match Design Specs in Figma
- [x] Stories accompany any component changes
- [x] Code is in accordance with our style guide
- [x] Design tokens are utilized
- [x] Unit tests accompany any component changes
- [x] TSDoc is written for any API surface area
- [x] Specs are up-to-date
- [x] Console is free from warnings
- [x] No accessibility violations are reported
- [x] Cross-browser check is performed (Chrome, Safari, Firefox)
- [x] Changeset is added

~Strikethrough~ any items that are not applicable to this pull request.
