### PR TITLE
fix(Checkbox,RadioGroupItem,Toggle): support clickable elements in text

### DIFF
--- a/.changeset/brown-cheetahs-design.md
+++ b/.changeset/brown-cheetahs-design.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+fix(Checkbox,RadioGroupItem,Toggle): support clickable elements in text

--- a/easy-ui-react/src/Checkbox/Checkbox.stories.tsx
+++ b/easy-ui-react/src/Checkbox/Checkbox.stories.tsx
@@ -134,3 +134,41 @@ export const Multiline: Story = {
       "Multi line option for mobile use. Note how the box is at the top not centered",
   },
 };
+
+export const WithLink: Story = {
+  render: (args) => (
+    <span
+      style={{
+        display: "inline-flex",
+        flexDirection: "column",
+        width: "100%",
+        maxWidth: 320,
+        gap: 48,
+      }}
+    >
+      <Checkbox {...args} />
+    </span>
+  ),
+  args: {
+    children: (
+      <>
+        I agree to the EasyPost{" "}
+        <a
+          href="https://www.easypost.com/legal/terms"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Terms of Service
+        </a>{" "}
+        and{" "}
+        <a
+          href="https://www.easypost.com/privacy"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Privacy Policy
+        </a>
+      </>
+    ),
+  },
+};

--- a/easy-ui-react/src/styles/_accessibility.scss
+++ b/easy-ui-react/src/styles/_accessibility.scss
@@ -34,6 +34,12 @@
     opacity: 0.0001;
     z-index: 1;
   }
+
+  a,
+  button {
+    position: relative;
+    z-index: 2;
+  }
 }
 
 @mixin native-focus-ring {


### PR DESCRIPTION
## 📝 Changes

- fixes our checkboxes, radios, and toggles to allow links and buttons to be clickable inside of their labels. this would support our use case on the sign up page, for instance, that includes terms and privacy links

## ✅ Checklist

Easy UI has certain UX standards that must be met. In general, non-trivial changes should meet the following criteria:

- [x] Visuals match Design Specs in Figma
- [x] Stories accompany any component changes
- [x] Code is in accordance with our style guide
- [x] Design tokens are utilized
- [x] Unit tests accompany any component changes
- [x] TSDoc is written for any API surface area
- [x] Specs are up-to-date
- [x] Console is free from warnings
- [x] No accessibility violations are reported
- [x] Cross-browser check is performed (Chrome, Safari, Firefox)
- [x] Changeset is added

~Strikethrough~ any items that are not applicable to this pull request.
