### PR TITLE
fix(DataGrid): extra spacing inside rows

### DIFF
--- a/.changeset/thirty-cougars-warn.md
+++ b/.changeset/thirty-cougars-warn.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+fix(DataGrid): extra spacing inside row

--- a/easy-ui-react/src/DataGrid/Row.module.scss
+++ b/easy-ui-react/src/DataGrid/Row.module.scss
@@ -3,6 +3,7 @@
 .Row {
   vertical-align: top;
   outline: none;
+  line-height: 0;
 }
 
 .noUserSelection {


### PR DESCRIPTION
## 📝 Changes

- set row line-height to 0 to fix extra spacing bleeding around cells in a row

previously we had `line-height: 0` set on the `DataGrid` element which caused problems with content in the expanded row. to correct this, we removed `line-height`, but this introduced a nonobvious bug with cell content that didn't contain inline elements (including empty cells).

this sets `line-height` back on the row to fix extra space bleeding out of the cells while not reintroducing the previous bug. content cells also have line height specified so this won't break wrapping text inside of a cell.

before:

<img width="1013" alt="image" src="https://github.com/user-attachments/assets/b866ab95-0384-486d-96b2-a44ff9a10556" />

after:

<img width="1010" alt="image" src="https://github.com/user-attachments/assets/499aa5bd-5da7-4fc0-a4b0-dce81f89eb48" />

## ✅ Checklist

Easy UI has certain UX standards that must be met. In general, non-trivial changes should meet the following criteria:

- [x] Visuals match Design Specs in Figma
- [x] Stories accompany any component changes
- [x] Code is in accordance with our style guide
- [x] Design tokens are utilized
- [x] Unit tests accompany any component changes
- [x] TSDoc is written for any API surface area
- [x] Specs are up-to-date
- [x] Console is free from warnings
- [x] No accessibility violations are reported
- [x] Cross-browser check is performed (Chrome, Safari, Firefox)
- [x] Changeset is added

~Strikethrough~ any items that are not applicable to this pull request.
