### PR TITLE
fix: remove theme-token helper

### DIFF
--- a/.changeset/honest-bees-shake.md
+++ b/.changeset/honest-bees-shake.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+fix: remove theme-token helper

--- a/easy-ui-react/src/Badge/Badge.module.scss
+++ b/easy-ui-react/src/Badge/Badge.module.scss
@@ -32,64 +32,64 @@
 
 // prettier-ignore
 .variantPrimary {
-  @include component-token("badge", "primary.color.background", theme-token("color.primary.600"));
-  @include component-token("badge", "primary.color.text", theme-token("color.neutral.000"));
-  @include component-token("badge", "secondary.color.background", theme-token("color.primary.100"));
-  @include component-token("badge", "secondary.color.text", theme-token("color.primary.800"));
+  @include component-token("badge", "primary.color.background", design-token("color.primary.600"));
+  @include component-token("badge", "primary.color.text", design-token("color.neutral.000"));
+  @include component-token("badge", "secondary.color.background", design-token("color.primary.100"));
+  @include component-token("badge", "secondary.color.text", design-token("color.primary.800"));
 }
 
 // prettier-ignore
 .variantSecondary {
-  @include component-token("badge", "primary.color.background", theme-token("color.secondary.600"));
-  @include component-token("badge", "primary.color.text", theme-token("color.neutral.000"));
-  @include component-token("badge", "secondary.color.background", theme-token("color.secondary.100"));
-  @include component-token("badge", "secondary.color.text", theme-token("color.primary.800"));
+  @include component-token("badge", "primary.color.background", design-token("color.secondary.600"));
+  @include component-token("badge", "primary.color.text", design-token("color.neutral.000"));
+  @include component-token("badge", "secondary.color.background", design-token("color.secondary.100"));
+  @include component-token("badge", "secondary.color.text", design-token("color.primary.800"));
 }
 
 // prettier-ignore
 .variantBlack {
-  @include component-token("badge", "primary.color.background", theme-token("color.neutral.800"));
-  @include component-token("badge", "primary.color.text", theme-token("color.neutral.000"));
-  @include component-token("badge", "secondary.color.background", theme-token("color.neutral.050"));
-  @include component-token("badge", "secondary.color.text", theme-token("color.primary.800"));
+  @include component-token("badge", "primary.color.background", design-token("color.neutral.800"));
+  @include component-token("badge", "primary.color.text", design-token("color.neutral.000"));
+  @include component-token("badge", "secondary.color.background", design-token("color.neutral.050"));
+  @include component-token("badge", "secondary.color.text", design-token("color.primary.800"));
 }
 
 // prettier-ignore
 .variantInverse {
-  @include component-token("badge", "primary.color.background", theme-token("color.neutral.100"));
-  @include component-token("badge", "primary.color.text", theme-token("color.neutral.900"));
-  @include component-token("badge", "secondary.color.background", theme-token("color.neutral.050"));
-  @include component-token("badge", "secondary.color.text", theme-token("color.primary.800"));
+  @include component-token("badge", "primary.color.background", design-token("color.neutral.100"));
+  @include component-token("badge", "primary.color.text", design-token("color.neutral.900"));
+  @include component-token("badge", "secondary.color.background", design-token("color.neutral.050"));
+  @include component-token("badge", "secondary.color.text", design-token("color.primary.800"));
 }
 
 // prettier-ignore
 .variantGray {
-  @include component-token("badge", "primary.color.background", theme-token("color.neutral.600"));
-  @include component-token("badge", "primary.color.text", theme-token("color.neutral.000"));
-  @include component-token("badge", "secondary.color.background", theme-token("color.neutral.050"));
-  @include component-token("badge", "secondary.color.text", theme-token("color.primary.800"));
+  @include component-token("badge", "primary.color.background", design-token("color.neutral.600"));
+  @include component-token("badge", "primary.color.text", design-token("color.neutral.000"));
+  @include component-token("badge", "secondary.color.background", design-token("color.neutral.050"));
+  @include component-token("badge", "secondary.color.text", design-token("color.primary.800"));
 }
 
 // prettier-ignore
 .variantSuccess {
-  @include component-token("badge", "primary.color.background", theme-token("color.positive.600"));
-  @include component-token("badge", "primary.color.text", theme-token("color.neutral.000"));
-  @include component-token("badge", "secondary.color.background", theme-token("color.positive.100"));
-  @include component-token("badge", "secondary.color.text", theme-token("color.primary.800"));
+  @include component-token("badge", "primary.color.background", design-token("color.positive.600"));
+  @include component-token("badge", "primary.color.text", design-token("color.neutral.000"));
+  @include component-token("badge", "secondary.color.background", design-token("color.positive.100"));
+  @include component-token("badge", "secondary.color.text", design-token("color.primary.800"));
 }
 
 // prettier-ignore
 .variantWarning {
-  @include component-token("badge", "primary.color.background", theme-token("color.warning.500"));
-  @include component-token("badge", "primary.color.text", theme-token("color.neutral.900"));
-  @include component-token("badge", "secondary.color.background", theme-token("color.warning.300"));
-  @include component-token("badge", "secondary.color.text", theme-token("color.primary.800"));
+  @include component-token("badge", "primary.color.background", design-token("color.warning.500"));
+  @include component-token("badge", "primary.color.text", design-token("color.neutral.900"));
+  @include component-token("badge", "secondary.color.background", design-token("color.warning.300"));
+  @include component-token("badge", "secondary.color.text", design-token("color.primary.800"));
 }
 
 // prettier-ignore
 .variantDanger {
-  @include component-token("badge", "primary.color.background", theme-token("color.negative.600"));
-  @include component-token("badge", "primary.color.text", theme-token("color.neutral.000"));
-  @include component-token("badge", "secondary.color.background", theme-token("color.negative.100"));
-  @include component-token("badge", "secondary.color.text", theme-token("color.primary.800"));
+  @include component-token("badge", "primary.color.background", design-token("color.negative.600"));
+  @include component-token("badge", "primary.color.text", design-token("color.neutral.000"));
+  @include component-token("badge", "secondary.color.background", design-token("color.negative.100"));
+  @include component-token("badge", "secondary.color.text", design-token("color.primary.800"));
 }

--- a/easy-ui-react/src/Banner/Banner.module.scss
+++ b/easy-ui-react/src/Banner/Banner.module.scss
@@ -1,24 +1,32 @@
 @use "../styles/common" as *;
 
 .colorSuccess {
-  @include component-token("banner", "color", theme-token("color.primary.800"));
+  @include component-token(
+    "banner",
+    "color",
+    design-token("color.primary.800")
+  );
   @include component-token(
     "banner",
     "color.background",
-    theme-token("color.positive.500")
+    design-token("color.positive.500")
   );
 }
 
 .colorPrimary,
 .colorNeutral {
-  @include component-token("banner", "color", theme-token("color.neutral.000"));
+  @include component-token(
+    "banner",
+    "color",
+    design-token("color.neutral.000")
+  );
 }
 
 .colorPrimary {
   @include component-token(
     "banner",
     "color.background",
-    theme-token("color.primary.500")
+    design-token("color.primary.500")
   );
 }
 
@@ -26,7 +34,7 @@
   @include component-token(
     "banner",
     "color.background",
-    theme-token("color.primary.800")
+    design-token("color.primary.800")
   );
 }
 

--- a/easy-ui-react/src/Button/_mixins.scss
+++ b/easy-ui-react/src/Button/_mixins.scss
@@ -26,8 +26,8 @@
   }
 
   &:disabled {
-    color: theme-token("color.neutral.000");
-    background-color: theme-token("color.neutral.200");
+    color: design-token("color.neutral.000");
+    background-color: design-token("color.neutral.200");
   }
 
   &:link {
@@ -61,9 +61,9 @@
   }
 
   &:disabled {
-    color: theme-token("color.neutral.300");
+    color: design-token("color.neutral.300");
     border: design-token("shape.border_width.1") solid
-      theme-token("color.neutral.300");
+      design-token("color.neutral.300");
   }
 
   &:link {
@@ -98,7 +98,7 @@
   }
 
   &:disabled {
-    color: theme-token("color.neutral.300");
+    color: design-token("color.neutral.300");
   }
 
   &:active:not(:disabled) {
@@ -121,7 +121,7 @@
   }
 
   &:disabled {
-    color: theme-token("color.neutral.300");
+    color: design-token("color.neutral.300");
   }
 
   &:active:not(:disabled) {
@@ -135,59 +135,59 @@
 
 // prettier-ignore
 @mixin colorPrimary {
-  @include component-token("button", "filled.font.color", theme-token("color.neutral.000"));
-  @include component-token("button", "filled.active.font.color", theme-token("color.neutral.000"));
-  @include component-token("button", "resting.color", theme-token("color.primary.500"));
-  @include component-token("button", "hover.focus.color", theme-token("color.primary.600"));
-  @include component-token("button", "active.color", theme-token("color.primary.700"));
+  @include component-token("button", "filled.font.color", design-token("color.neutral.000"));
+  @include component-token("button", "filled.active.font.color", design-token("color.neutral.000"));
+  @include component-token("button", "resting.color", design-token("color.primary.500"));
+  @include component-token("button", "hover.focus.color", design-token("color.primary.600"));
+  @include component-token("button", "active.color", design-token("color.primary.700"));
 }
 
 // prettier-ignore
 @mixin colorSecondary {
-  @include component-token("button", "filled.font.color", theme-token("color.neutral.000"));
-  @include component-token("button", "filled.active.font.color", theme-token("color.neutral.000"));
-  @include component-token("button", "resting.color", theme-token("color.secondary.500"));
-  @include component-token("button", "hover.focus.color", theme-token("color.secondary.600"));
-  @include component-token("button", "active.color", theme-token("color.secondary.700"));
+  @include component-token("button", "filled.font.color", design-token("color.neutral.000"));
+  @include component-token("button", "filled.active.font.color", design-token("color.neutral.000"));
+  @include component-token("button", "resting.color", design-token("color.secondary.500"));
+  @include component-token("button", "hover.focus.color", design-token("color.secondary.600"));
+  @include component-token("button", "active.color", design-token("color.secondary.700"));
 }
 
 // prettier-ignore
 @mixin colorSuccess {
-  @include component-token("button", "filled.font.color", theme-token("color.primary.800"));
-  @include component-token("button", "filled.active.font.color", theme-token("color.neutral.000"));
-  @include component-token("button", "resting.color", theme-token("color.positive.500"));
-  @include component-token("button", "hover.focus.color", theme-token("color.positive.600"));
-  @include component-token("button", "active.color", theme-token("color.positive.700"));
+  @include component-token("button", "filled.font.color", design-token("color.primary.800"));
+  @include component-token("button", "filled.active.font.color", design-token("color.neutral.000"));
+  @include component-token("button", "resting.color", design-token("color.positive.500"));
+  @include component-token("button", "hover.focus.color", design-token("color.positive.600"));
+  @include component-token("button", "active.color", design-token("color.positive.700"));
 }
 
 // prettier-ignore
 @mixin colorWarning {
-  @include component-token("button", "filled.font.color",theme-token("color.primary.800"));
-  @include component-token("button", "filled.active.font.color",theme-token("color.primary.800"));
-  @include component-token("button", "resting.color",theme-token("color.negative.500"));
-  @include component-token("button", "hover.focus.color",theme-token("color.negative.600"));
-  @include component-token("button", "active.color",theme-token("color.negative.700"));
+  @include component-token("button", "filled.font.color",design-token("color.primary.800"));
+  @include component-token("button", "filled.active.font.color",design-token("color.primary.800"));
+  @include component-token("button", "resting.color",design-token("color.negative.500"));
+  @include component-token("button", "hover.focus.color",design-token("color.negative.600"));
+  @include component-token("button", "active.color",design-token("color.negative.700"));
 }
 
 // prettier-ignore
 @mixin colorNeutral {
-  @include component-token("button", "filled.font.color", theme-token("color.neutral.000"));
-  @include component-token("button", "filled.active.font.color", theme-token("color.neutral.000"));
-  @include component-token("button", "resting.color", theme-token("color.primary.800"));
-  @include component-token("button", "hover.focus.color", theme-token("color.neutral.900"));
-  @include component-token("button", "active.color", theme-token("color.primary.700"));
+  @include component-token("button", "filled.font.color", design-token("color.neutral.000"));
+  @include component-token("button", "filled.active.font.color", design-token("color.neutral.000"));
+  @include component-token("button", "resting.color", design-token("color.primary.800"));
+  @include component-token("button", "hover.focus.color", design-token("color.neutral.900"));
+  @include component-token("button", "active.color", design-token("color.primary.700"));
 }
 
 // prettier-ignore
 @mixin colorSupport {
-  @include component-token("button", "resting.color", theme-token("color.primary.800"));
-  @include component-token("button", "hover.focus.color", theme-token("color.neutral.900"));
-  @include component-token("button", "active.color", theme-token("color.neutral.700"));
+  @include component-token("button", "resting.color", design-token("color.primary.800"));
+  @include component-token("button", "hover.focus.color", design-token("color.neutral.900"));
+  @include component-token("button", "active.color", design-token("color.neutral.700"));
 }
 
 // prettier-ignore
 @mixin colorInverse {
-  @include component-token("button", "resting.color", theme-token("color.neutral.000"));
-  @include component-token("button", "hover.focus.color", theme-token("color.neutral.100"));
-  @include component-token("button", "active.color", theme-token("color.neutral.200"));
+  @include component-token("button", "resting.color", design-token("color.neutral.000"));
+  @include component-token("button", "hover.focus.color", design-token("color.neutral.100"));
+  @include component-token("button", "active.color", design-token("color.neutral.200"));
 }

--- a/easy-ui-react/src/Card/Card.module.scss
+++ b/easy-ui-react/src/Card/Card.module.scss
@@ -42,7 +42,7 @@ button.container:not([disabled]) {
   @include component-token(
     "card",
     "color.border",
-    theme-token("color.neutral.400")
+    design-token("color.neutral.400")
   );
 }
 
@@ -50,7 +50,7 @@ button.container:not([disabled]) {
   @include component-token(
     "card",
     "color.border",
-    theme-token("color.primary.500")
+    design-token("color.primary.500")
   );
 }
 
@@ -58,7 +58,7 @@ button.container:not([disabled]) {
   @include component-token(
     "card",
     "color.border",
-    theme-token("color.neutral.300")
+    design-token("color.neutral.300")
   );
 }
 
@@ -66,7 +66,7 @@ button.container:not([disabled]) {
   @include component-token(
     "card",
     "color.border",
-    theme-token("color.negative.300")
+    design-token("color.negative.300")
   );
 }
 
@@ -74,7 +74,7 @@ button.container:not([disabled]) {
   @include component-token(
     "card",
     "color.border",
-    theme-token("color.warning.300")
+    design-token("color.warning.300")
   );
 }
 
@@ -82,7 +82,7 @@ button.container:not([disabled]) {
   @include component-token(
     "card",
     "color.border",
-    theme-token("color.positive.300")
+    design-token("color.positive.300")
   );
 }
 
@@ -90,7 +90,7 @@ button.container:not([disabled]) {
   @include component-token(
     "card",
     "color.border",
-    theme-token("color.neutral.300")
+    design-token("color.neutral.300")
   );
 }
 
@@ -98,7 +98,7 @@ button.container:not([disabled]) {
   @include component-token(
     "card",
     "color.border",
-    theme-token("color.blue.300")
+    design-token("color.blue.300")
   );
 }
 
@@ -106,6 +106,6 @@ button.container:not([disabled]) {
   @include component-token(
     "card",
     "color.border",
-    theme-token("color.purple.300")
+    design-token("color.purple.300")
   );
 }

--- a/easy-ui-react/src/Checkbox/Checkbox.module.scss
+++ b/easy-ui-react/src/Checkbox/Checkbox.module.scss
@@ -13,13 +13,13 @@
   @include component-token(
     "checkbox",
     "color.check",
-    theme-token("color.neutral.000")
+    design-token("color.neutral.000")
   );
   @include component-token("checkbox", "color.background", transparent);
   @include component-token(
     "checkbox",
     "color.border",
-    theme-token("color.neutral.500")
+    design-token("color.neutral.500")
   );
 }
 
@@ -88,7 +88,7 @@
   @include component-token(
     "checkbox",
     "color.border",
-    theme-token("color.negative.500")
+    design-token("color.negative.500")
   );
 }
 
@@ -96,7 +96,7 @@
   @include component-token(
     "checkbox",
     "color.border",
-    theme-token("color.neutral.200")
+    design-token("color.neutral.200")
   );
 }
 
@@ -105,12 +105,12 @@
   @include component-token(
     "checkbox",
     "color.background",
-    theme-token("color.primary.500")
+    design-token("color.primary.500")
   );
   @include component-token(
     "checkbox",
     "color.border",
-    theme-token("color.primary.500")
+    design-token("color.primary.500")
   );
 }
 
@@ -119,7 +119,7 @@
   @include component-token(
     "checkbox",
     "color.background",
-    theme-token("color.negative.500")
+    design-token("color.negative.500")
   );
 }
 
@@ -128,12 +128,12 @@
   @include component-token(
     "checkbox",
     "color.border",
-    theme-token("color.neutral.400")
+    design-token("color.neutral.400")
   );
   @include component-token(
     "checkbox",
     "color.background",
-    theme-token("color.neutral.400")
+    design-token("color.neutral.400")
   );
 }
 
@@ -141,7 +141,7 @@
   @include component-token(
     "checkbox",
     "color.border",
-    theme-token("color.primary.400")
+    design-token("color.primary.400")
   );
 }
 
@@ -150,7 +150,7 @@
   @include component-token(
     "checkbox",
     "color.background",
-    theme-token("color.primary.400")
+    design-token("color.primary.400")
   );
 }
 
@@ -158,7 +158,7 @@
   @include component-token(
     "checkbox",
     "color.border",
-    theme-token("color.negative.600")
+    design-token("color.negative.600")
   );
 }
 
@@ -167,6 +167,6 @@
   @include component-token(
     "checkbox",
     "color.background",
-    theme-token("color.negative.600")
+    design-token("color.negative.600")
   );
 }

--- a/easy-ui-react/src/CodeBlock/CodeBlock.module.scss
+++ b/easy-ui-react/src/CodeBlock/CodeBlock.module.scss
@@ -4,15 +4,15 @@
   @include component-token(
     "card-header",
     "background",
-    theme-token("color.neutral.000")
+    design-token("color.neutral.000")
   );
   @include component-token(
     "card-header",
     "color",
-    theme-token("color.primary.800")
+    design-token("color.primary.800")
   );
   border: design-token("shape.border_width.1") solid
-    theme-token("color.neutral.400");
+    design-token("color.neutral.400");
   border-radius: design-token("shape.border_radius.md");
   overflow: hidden;
 }
@@ -20,7 +20,7 @@
 .header {
   padding: design-token("space.1.5") design-token("space.2");
   border-bottom: design-token("shape.border_width.1") solid
-    theme-token("color.neutral.400");
+    design-token("color.neutral.400");
   background: component-token("card-header", "background");
   color: component-token("card-header", "color");
 }
@@ -34,19 +34,19 @@
   align-self: stretch;
   display: inline-flex;
   width: design-token("shape.border_width.1");
-  background-color: theme-token("color.neutral.400");
+  background-color: design-token("color.neutral.400");
 }
 
 .colorPrimary {
   @include component-token(
     "card-header",
     "background",
-    theme-token("color.primary.700")
+    design-token("color.primary.700")
   );
   @include component-token(
     "card-header",
     "color",
-    theme-token("color.neutral.000")
+    design-token("color.neutral.000")
   );
 }
 
@@ -54,6 +54,6 @@
   @include component-token(
     "card-header",
     "background",
-    theme-token("color.neutral.050")
+    design-token("color.neutral.050")
   );
 }

--- a/easy-ui-react/src/DatePicker/DatePicker.module.scss
+++ b/easy-ui-react/src/DatePicker/DatePicker.module.scss
@@ -53,7 +53,7 @@
 }
 
 .dialog {
-  background: theme-token("color.neutral.000");
+  background: design-token("color.neutral.000");
   border-radius: design-token("shape.border_radius.lg");
   box-shadow: design-token("shadow.modal");
   pointer-events: auto;

--- a/easy-ui-react/src/Drawer/Drawer.module.scss
+++ b/easy-ui-react/src/Drawer/Drawer.module.scss
@@ -18,7 +18,7 @@
   &::before {
     content: "";
     position: absolute;
-    background: theme-token("color.primary.800");
+    background: design-token("color.primary.800");
     opacity: design-token("opacity.underlay");
   }
 }
@@ -78,7 +78,7 @@
   max-width: component-token("drawer", "max-width");
   height: component-token("drawer", "height");
   overflow: hidden;
-  background: theme-token("color.neutral.000");
+  background: design-token("color.neutral.000");
   box-shadow: design-token("shadow.level.3");
   pointer-events: auto;
   position: relative;

--- a/easy-ui-react/src/ForgeLayout/ForgeLayoutControls.module.scss
+++ b/easy-ui-react/src/ForgeLayout/ForgeLayoutControls.module.scss
@@ -10,16 +10,16 @@
 
 .breadcrumbNavigationContainer {
   border: design-token("shape.border_width.1") solid
-    theme-token("color.neutral.300");
+    design-token("color.neutral.300");
   margin-right: design-token("space.3");
   display: inline-flex;
   z-index: design-token("z-index.nav");
 }
 
 .backButtonContainer {
-  background: theme-token("color.neutral.050");
+  background: design-token("color.neutral.050");
   border-right: design-token("shape.border_width.1") solid
-    theme-token("color.neutral.300");
+    design-token("color.neutral.300");
   padding: design-token("space.0-5") design-token("space.1.5")
     design-token("space.0-5") design-token("space.1");
   display: inline-flex;
@@ -30,7 +30,7 @@
   display: inline-flex;
   align-items: center;
   cursor: pointer;
-  color: theme-token("color.primary.600");
+  color: design-token("color.primary.600");
 }
 
 .breadcrumbsContainer {
@@ -44,7 +44,7 @@
   justify-content: space-between;
   gap: design-token("space.1");
   border: design-token("shape.border_width.1") solid
-    theme-token("color.neutral.300");
+    design-token("color.neutral.300");
   padding: calc(
     #{design-token("space.1")} - #{design-token("shape.border_width.1")}
   );
@@ -56,14 +56,14 @@
 }
 
 .triggerPopoverOpen {
-  border-color: theme-token("color.neutral.800");
+  border-color: design-token("color.neutral.800");
 }
 
 .popover {
   border: design-token("shape.border_width.1") solid
-    theme-token("color.neutral.300");
+    design-token("color.neutral.300");
   border-radius: design-token("shape.border_radius.md");
-  background-color: theme-token("color.neutral.000");
+  background-color: design-token("color.neutral.000");
   padding: design-token("space.2");
   box-shadow: design-token("shadow.overlay");
 }

--- a/easy-ui-react/src/FormLayout/FormLayout.module.scss
+++ b/easy-ui-react/src/FormLayout/FormLayout.module.scss
@@ -5,5 +5,5 @@
   flex-direction: column;
   gap: design-token("space.3");
   padding: design-token("space.3");
-  color: theme-token("color.primary.800");
+  color: design-token("color.primary.800");
 }

--- a/easy-ui-react/src/InputField/_mixins.scss
+++ b/easy-ui-react/src/InputField/_mixins.scss
@@ -14,62 +14,62 @@
   @include component-token(
     "inputfield",
     "color.text.resting",
-    theme-token("color.primary.800")
+    design-token("color.primary.800")
   );
   @include component-token(
     "inputfield",
     "color.text.gray.resting",
-    theme-token("color.neutral.500")
+    design-token("color.neutral.500")
   );
   @include component-token(
     "inputfield",
     "color.text.subdued",
-    theme-token("color.neutral.600")
+    design-token("color.neutral.600")
   );
   @include component-token(
     "inputfield",
     "color.text.gray.bold",
-    theme-token("color.neutral.800")
+    design-token("color.neutral.800")
   );
   @include component-token(
     "inputfield",
     "color.text.disabled",
-    theme-token("color.neutral.300")
+    design-token("color.neutral.300")
   );
   @include component-token(
     "inputfield",
     "color.text.engaged",
-    theme-token("color.neutral.900")
+    design-token("color.neutral.900")
   );
   @include component-token(
     "inputfield",
     "color.text.danger",
-    theme-token("color.negative.600")
+    design-token("color.negative.600")
   );
   @include component-token(
     "inputfield",
     "color.border.resting",
-    theme-token("color.neutral.200")
+    design-token("color.neutral.200")
   );
   @include component-token(
     "inputfield",
     "color.border.engaged",
-    theme-token("color.neutral.500")
+    design-token("color.neutral.500")
   );
   @include component-token(
     "inputfield",
     "color.border.danger",
-    theme-token("color.negative.500")
+    design-token("color.negative.500")
   );
   @include component-token(
     "inputfield",
     "color.background",
-    theme-token("color.neutral.000")
+    design-token("color.neutral.000")
   );
   @include component-token(
     "inputfield",
     "color.background.disabled",
-    theme-token("color.neutral.100")
+    design-token("color.neutral.100")
   );
   @include component-token("inputfield", "max-height-sm", 32px);
   @include component-token(

--- a/easy-ui-react/src/Menu/_mixins.scss
+++ b/easy-ui-react/src/Menu/_mixins.scss
@@ -9,29 +9,29 @@
   @include component-token(
     "menu",
     "color.background",
-    theme-token("color.neutral.000")
+    design-token("color.neutral.000")
   );
   @include component-token(
     "menu",
     "color.text",
-    theme-token("color.primary.800")
+    design-token("color.primary.800")
   );
   @include component-token(
     "menu",
     "color.text.disabled",
-    theme-token("color.neutral.300")
+    design-token("color.neutral.300")
   );
   @include component-token(
     "menu",
     "color.background.hovered",
-    theme-token("color.neutral.050")
+    design-token("color.neutral.050")
   );
   @include component-token("menu", "shadow", design-token("shadow.overlay"));
   @include component-token("menu", "padding.x", design-token("space.2"));
   @include component-token(
     "menu",
     "color.border",
-    theme-token("color.neutral.300")
+    design-token("color.neutral.300")
   );
 }
 

--- a/easy-ui-react/src/Modal/Modal.module.scss
+++ b/easy-ui-react/src/Modal/Modal.module.scss
@@ -12,7 +12,7 @@
   &::before {
     content: "";
     position: absolute;
-    background: theme-token("color.primary.800");
+    background: design-token("color.primary.800");
     opacity: design-token("opacity.underlay");
   }
 }
@@ -51,7 +51,7 @@
   max-width: component-token("modal", "max-width");
   width: component-token("modal", "width");
   overflow: hidden;
-  background: theme-token("color.neutral.000");
+  background: design-token("color.neutral.000");
   border-radius: design-token("shape.border_radius.lg");
   box-shadow: design-token("shadow.modal");
   pointer-events: auto;
@@ -62,7 +62,7 @@
   margin: 0;
   padding: design-token("space.5");
   padding-bottom: design-token("space.2");
-  color: theme-token("color.primary.800");
+  color: design-token("color.primary.800");
   &.stuck {
     box-shadow: design-token("shadow.stuck-from-top");
   }

--- a/easy-ui-react/src/Notification/Notification.module.scss
+++ b/easy-ui-react/src/Notification/Notification.module.scss
@@ -2,32 +2,32 @@
 
 // prettier-ignore
 .statusPromotional {
-  @include component-token("notification", "color", theme-token("color.neutral.000"));
-  @include component-token("notification", "color.background", theme-token("color.primary.500"));
+  @include component-token("notification", "color", design-token("color.neutral.000"));
+  @include component-token("notification", "color.background", design-token("color.primary.500"));
 }
 
 // prettier-ignore
 .statusSuccess {
-  @include component-token("notification", "color", theme-token("color.positive.800"));
-  @include component-token("notification", "color.background", theme-token("color.positive.100"));
+  @include component-token("notification", "color", design-token("color.positive.800"));
+  @include component-token("notification", "color.background", design-token("color.positive.100"));
 }
 
 // prettier-ignore
 .statusNeutral {
-  @include component-token("notification", "color", theme-token("color.secondary.800"));
-  @include component-token("notification", "color.background",theme-token("color.secondary.100"));
+  @include component-token("notification", "color", design-token("color.secondary.800"));
+  @include component-token("notification", "color.background",design-token("color.secondary.100"));
 }
 
 // prettier-ignore
 .statusWarning {
-  @include component-token("notification", "color", theme-token("color.neutral.900"));
-  @include component-token("notification", "color.background", theme-token("color.warning.300"));
+  @include component-token("notification", "color", design-token("color.neutral.900"));
+  @include component-token("notification", "color.background", design-token("color.warning.300"));
 }
 
 // prettier-ignore
 .statusError {
-  @include component-token("notification", "color", theme-token("color.negative.800"));
-  @include component-token("notification", "color.background", theme-token("color.negative.100"));
+  @include component-token("notification", "color", design-token("color.negative.800"));
+  @include component-token("notification", "color.background", design-token("color.negative.100"));
 }
 
 .typeToast {

--- a/easy-ui-react/src/ProductLayout/ProductLayoutSidebar.module.scss
+++ b/easy-ui-react/src/ProductLayout/ProductLayoutSidebar.module.scss
@@ -63,7 +63,7 @@
     bottom: 0;
     right: 0;
     position: absolute;
-    background: theme-token("color.primary.800");
+    background: design-token("color.primary.800");
     opacity: 0.05;
   }
 }

--- a/easy-ui-react/src/RadioGroup/RadioGroupItem.module.scss
+++ b/easy-ui-react/src/RadioGroup/RadioGroupItem.module.scss
@@ -5,7 +5,7 @@
   @include component-token(
     "radio-group-item",
     "color",
-    theme-token("color.neutral.500")
+    design-token("color.neutral.500")
   );
   display: inline-flex;
 }
@@ -53,7 +53,7 @@
   @include component-token(
     "radio-group-item",
     "color",
-    theme-token("color.negative.500")
+    design-token("color.negative.500")
   );
 }
 
@@ -61,7 +61,7 @@
   @include component-token(
     "radio-group-item",
     "color",
-    theme-token("color.neutral.200")
+    design-token("color.neutral.200")
   );
 }
 
@@ -69,7 +69,7 @@
   @include component-token(
     "radio-group-item",
     "color",
-    theme-token("color.primary.500")
+    design-token("color.primary.500")
   );
 }
 
@@ -77,7 +77,7 @@
   @include component-token(
     "radio-group-item",
     "color",
-    theme-token("color.neutral.400")
+    design-token("color.neutral.400")
   );
 }
 
@@ -85,7 +85,7 @@
   @include component-token(
     "radio-group-item",
     "color",
-    theme-token("color.primary.400")
+    design-token("color.primary.400")
   );
 }
 
@@ -93,6 +93,6 @@
   @include component-token(
     "radio-group-item",
     "color",
-    theme-token("color.negative.600")
+    design-token("color.negative.600")
   );
 }

--- a/easy-ui-react/src/SearchNav/CTAGroup.module.scss
+++ b/easy-ui-react/src/SearchNav/CTAGroup.module.scss
@@ -5,7 +5,7 @@
   @include component-token(
     "cta-group",
     "menu-color",
-    theme-token("color.primary.800")
+    design-token("color.primary.800")
   );
   grid-column-start: 3;
   align-items: center;

--- a/easy-ui-react/src/SearchNav/CondensedSearchNav.module.scss
+++ b/easy-ui-react/src/SearchNav/CondensedSearchNav.module.scss
@@ -15,17 +15,17 @@
   @include component-token(
     "condensed-search-nav",
     "menu-color",
-    theme-token("color.neutral.900")
+    design-token("color.neutral.900")
   );
   @include component-token(
     "condensed-search-nav",
     "menu-open-color",
-    theme-token("color.primary.500")
+    design-token("color.primary.500")
   );
   @include component-token(
     "condensed-search-nav",
     "search-color",
-    theme-token("color.primary.800")
+    design-token("color.primary.800")
   );
 }
 

--- a/easy-ui-react/src/SearchNav/SearchNav.module.scss
+++ b/easy-ui-react/src/SearchNav/SearchNav.module.scss
@@ -5,12 +5,12 @@
   @include component-token(
     "search-nav",
     "background-color",
-    theme-token("color.neutral.000")
+    design-token("color.neutral.000")
   );
   @include component-token(
     "search-nav",
     "border-color",
-    theme-token("color.neutral.100")
+    design-token("color.neutral.100")
   );
   padding: 0 design-token("space.3");
   height: component-token("search-nav", "height");

--- a/easy-ui-react/src/SearchNav/SecondaryCTAItem.module.scss
+++ b/easy-ui-react/src/SearchNav/SecondaryCTAItem.module.scss
@@ -1,7 +1,7 @@
 @use "../styles/common" as *;
 
 .cta {
-  @include component-token("cta", "color", theme-token("color.primary.800"));
+  @include component-token("cta", "color", design-token("color.primary.800"));
   display: flex;
   align-items: center;
   gap: design-token("space.1");

--- a/easy-ui-react/src/SearchNav/SelectorTrigger.module.scss
+++ b/easy-ui-react/src/SearchNav/SelectorTrigger.module.scss
@@ -4,7 +4,7 @@
   @include component-token(
     "selector-trigger",
     "color",
-    theme-token("color.positive.600")
+    design-token("color.positive.600")
   );
   @include font-style("subtitle1");
   display: flex;

--- a/easy-ui-react/src/SearchNav/Separator.module.scss
+++ b/easy-ui-react/src/SearchNav/Separator.module.scss
@@ -4,12 +4,12 @@
   @include component-token(
     "separator",
     "separator-logo",
-    theme-token("color.neutral.500")
+    design-token("color.neutral.500")
   );
   @include component-token(
     "separator",
     "separator-cta",
-    theme-token("color.primary.800")
+    design-token("color.primary.800")
   );
   width: design-token("space.0");
   height: design-token("space.3");

--- a/easy-ui-react/src/SelectorErrorTooltip/SelectorErrorTooltip.module.scss
+++ b/easy-ui-react/src/SelectorErrorTooltip/SelectorErrorTooltip.module.scss
@@ -2,5 +2,5 @@
 
 .SelectorErrorTooltip {
   display: inline-flex;
-  color: theme-token("color.negative.600");
+  color: design-token("color.negative.600");
 }

--- a/easy-ui-react/src/Stepper/Step.module.scss
+++ b/easy-ui-react/src/Stepper/Step.module.scss
@@ -4,7 +4,7 @@
   @include component-token(
     "step",
     "color-separator",
-    theme-token("color.primary.800")
+    design-token("color.primary.800")
   );
 }
 
@@ -12,7 +12,7 @@
   @include component-token(
     "step",
     "color-separator",
-    theme-token("color.neutral.000")
+    design-token("color.neutral.000")
   );
 }
 

--- a/easy-ui-react/src/Stepper/StepButton.module.scss
+++ b/easy-ui-react/src/Stepper/StepButton.module.scss
@@ -22,27 +22,27 @@
   @include component-token(
     "step-button",
     "color-active",
-    theme-token("color.primary.500")
+    design-token("color.primary.500")
   );
   @include component-token(
     "step-button",
     "color-incomplete",
-    theme-token("color.neutral.500")
+    design-token("color.neutral.500")
   );
   @include component-token(
     "step-button",
     "color-complete",
-    theme-token("color.primary.800")
+    design-token("color.primary.800")
   );
   @include component-token(
     "step-button",
     "active-background",
-    theme-token("color.primary.500")
+    design-token("color.primary.500")
   );
   @include component-token(
     "step-button",
     "incomplete-border",
-    theme-token("color.neutral.500")
+    design-token("color.neutral.500")
   );
 }
 
@@ -50,27 +50,27 @@
   @include component-token(
     "step-button",
     "color-active",
-    theme-token("color.neutral.000")
+    design-token("color.neutral.000")
   );
   @include component-token(
     "step-button",
     "color-incomplete",
-    theme-token("color.neutral.000")
+    design-token("color.neutral.000")
   );
   @include component-token(
     "step-button",
     "color-complete",
-    theme-token("color.neutral.000")
+    design-token("color.neutral.000")
   );
   @include component-token(
     "step-button",
     "active-background",
-    theme-token("color.neutral.000")
+    design-token("color.neutral.000")
   );
   @include component-token(
     "step-button",
     "incomplete-border",
-    theme-token("color.neutral.000")
+    design-token("color.neutral.000")
   );
 }
 

--- a/easy-ui-react/src/Toggle/Switch.module.scss
+++ b/easy-ui-react/src/Toggle/Switch.module.scss
@@ -4,12 +4,12 @@
   @include component-token(
     "switch",
     "color.track",
-    theme-token("color.neutral.100")
+    design-token("color.neutral.100")
   );
   @include component-token(
     "switch",
     "color.thumb",
-    theme-token("color.primary.800")
+    design-token("color.primary.800")
   );
   @include component-token("switch", "border_radius", 99px);
 
@@ -33,7 +33,7 @@
   @include component-token(
     "switch",
     "color.track",
-    theme-token("color.neutral.200")
+    design-token("color.neutral.200")
   );
 }
 
@@ -41,12 +41,12 @@
   @include component-token(
     "switch",
     "color.track",
-    theme-token("color.primary.500")
+    design-token("color.primary.500")
   );
   @include component-token(
     "switch",
     "color.thumb",
-    theme-token("color.neutral.000")
+    design-token("color.neutral.000")
   );
 }
 
@@ -54,7 +54,7 @@
   @include component-token(
     "switch",
     "color.track",
-    theme-token("color.primary.600")
+    design-token("color.primary.600")
   );
 }
 
@@ -62,11 +62,11 @@
   @include component-token(
     "switch",
     "color.track",
-    theme-token("color.neutral.050")
+    design-token("color.neutral.050")
   );
   @include component-token(
     "switch",
     "color.thumb",
-    theme-token("color.neutral.300")
+    design-token("color.neutral.300")
   );
 }

--- a/easy-ui-react/src/Tooltip/Tooltip.module.scss
+++ b/easy-ui-react/src/Tooltip/Tooltip.module.scss
@@ -5,7 +5,7 @@
   @include component-token(
     "tooltip",
     "background",
-    theme-token("color.neutral.000")
+    design-token("color.neutral.000")
   );
   @include component-token(
     "tooltip",
@@ -15,7 +15,7 @@
   @include component-token(
     "tooltip",
     "color",
-    theme-token("color.primary.800")
+    design-token("color.primary.800")
   );
   @include component-token(
     "tooltip",

--- a/easy-ui-react/src/VerticalNav/NavItem.module.scss
+++ b/easy-ui-react/src/VerticalNav/NavItem.module.scss
@@ -5,19 +5,19 @@
   display: flex;
   flex-direction: column;
   gap: design-token("space.1");
-  color: theme-token("color.primary.700");
+  color: design-token("color.primary.700");
 }
 
 .hovered {
-  color: theme-token("color.neutral.900");
+  color: design-token("color.neutral.900");
 }
 
 .selectedTree {
-  color: theme-token("color.primary.600");
+  color: design-token("color.primary.600");
 }
 
 .selectedList {
-  color: theme-token("color.primary.500");
+  color: design-token("color.primary.500");
 }
 
 .linkContainer {

--- a/easy-ui-react/src/VerticalNav/SubnavItem.module.scss
+++ b/easy-ui-react/src/VerticalNav/SubnavItem.module.scss
@@ -14,20 +14,20 @@
   position: relative;
   display: flex;
 
-  color: theme-token("color.primary.800");
+  color: design-token("color.primary.800");
   cursor: pointer;
 }
 
 .hovered > .link {
-  color: theme-token("color.primary.600");
+  color: design-token("color.primary.600");
 }
 
 .selected:has(.selected) > .link {
   font-weight: design-token("font.weight.medium");
-  color: theme-token("color.primary.700");
+  color: design-token("color.primary.700");
 }
 
 .selected:not(:has(.selected)) > .link {
   font-weight: design-token("font.weight.normal");
-  color: theme-token("color.primary.500");
+  color: design-token("color.primary.500");
 }

--- a/easy-ui-react/src/styles/_scrollbars.scss
+++ b/easy-ui-react/src/styles/_scrollbars.scss
@@ -2,12 +2,12 @@
 @use "token-helpers";
 
 @mixin default-os-style {
-  --os-track-bg: #{token-helpers.theme-token("color.neutral.050")};
-  --os-track-bg-hover: #{token-helpers.theme-token("color.neutral.100")};
-  --os-track-bg-active: #{token-helpers.theme-token("color.neutral.100")};
-  --os-handle-bg: #{token-helpers.theme-token("color.neutral.300")};
-  --os-handle-bg-hover: #{token-helpers.theme-token("color.neutral.400")};
-  --os-handle-bg-active: #{token-helpers.theme-token("color.neutral.500")};
+  --os-track-bg: #{token-helpers.design-token("color.neutral.050")};
+  --os-track-bg-hover: #{token-helpers.design-token("color.neutral.100")};
+  --os-track-bg-active: #{token-helpers.design-token("color.neutral.100")};
+  --os-handle-bg: #{token-helpers.design-token("color.neutral.300")};
+  --os-handle-bg-hover: #{token-helpers.design-token("color.neutral.400")};
+  --os-handle-bg-active: #{token-helpers.design-token("color.neutral.500")};
   --os-track-border-radius: 999px;
   --os-handle-border-radius: 999px;
 
@@ -35,7 +35,7 @@
 
 .os-scrollbar.ezui-os-theme-modal {
   @include default-os-style;
-  --os-handle-bg: #{token-helpers.theme-token("color.neutral.200")};
+  --os-handle-bg: #{token-helpers.design-token("color.neutral.200")};
   --os-size: #{token-helpers.design-token("space.1")};
   --os-padding-perpendicular: 0;
   --os-padding-axis: #{token-helpers.design-token("space.1")};
@@ -44,7 +44,7 @@
 
 .os-scrollbar.ezui-os-theme-drawer {
   @include default-os-style;
-  --os-handle-bg: #{token-helpers.theme-token("color.neutral.200")};
+  --os-handle-bg: #{token-helpers.design-token("color.neutral.200")};
   --os-size: #{token-helpers.design-token("space.1")};
   --os-padding-perpendicular: 0;
   --os-padding-axis: #{token-helpers.design-token("space.1")};

--- a/easy-ui-react/src/styles/_token-helpers.scss
+++ b/easy-ui-react/src/styles/_token-helpers.scss
@@ -9,15 +9,6 @@
   @return var(--ezui-#{$cleanedName});
 }
 
-/// Helper for referencing theme tokens consistently in CSS modules.
-///
-/// To use a theme token:
-/// color: theme-token("color.primary.800");
-@function theme-token($tokenName) {
-  $cleanedName: string.clean-name($tokenName);
-  @return var(--ezui-#{$cleanedName});
-}
-
 /// Helpers for referencing tokens in components in a structured way. Supports
 /// a consistent naming between CSS and JS.
 ///

--- a/easy-ui-react/src/styles/global.scss
+++ b/easy-ui-react/src/styles/global.scss
@@ -10,7 +10,7 @@
 }
 
 html {
-  font-family: token-helpers.theme-token("font.family");
+  font-family: token-helpers.design-token("font.family");
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   /* Deactivate auto-enlargement of small text in Safari */


### PR DESCRIPTION
## 📝 Changes

- remove `theme-token` css helper

`theme-token` has been deprecated for a while, in favor of `design-token` being the central token source. this finally removes it

## ✅ Checklist

Easy UI has certain UX standards that must be met. In general, non-trivial changes should meet the following criteria:

- [x] Visuals match Design Specs in Figma
- [x] Stories accompany any component changes
- [x] Code is in accordance with our style guide
- [x] Design tokens are utilized
- [x] Unit tests accompany any component changes
- [x] TSDoc is written for any API surface area
- [x] Specs are up-to-date
- [x] Console is free from warnings
- [x] No accessibility violations are reported
- [x] Cross-browser check is performed (Chrome, Safari, Firefox)
- [x] Changeset is added

~Strikethrough~ any items that are not applicable to this pull request.
