### PR TITLE
fix(Notification): border radius, margin, close button

### DIFF
--- a/.changeset/fresh-phones-talk.md
+++ b/.changeset/fresh-phones-talk.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+fix(Notification): border radius

--- a/easy-ui-react/src/Notification/Notification.module.scss
+++ b/easy-ui-react/src/Notification/Notification.module.scss
@@ -77,7 +77,6 @@
 
 .region {
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
 }

--- a/easy-ui-react/src/Notification/Notification.module.scss
+++ b/easy-ui-react/src/Notification/Notification.module.scss
@@ -36,13 +36,14 @@
 
 .typeAlert {
   display: flex;
-  width: 100%;
+  width: calc(100% - calc(#{component-token("notification", "margin-x")} * 2));
 }
 
 .Notification {
   /* prettier-ignore */
   @include component-token("notification", "border_radius", design-token("shape.border_radius.lg"));
   @include component-token("notification", "max-width", 1200px);
+  @include component-token("notification", "margin-x", design-token("space.6"));
   align-items: center;
   justify-content: space-between;
   margin: auto;
@@ -61,17 +62,22 @@
   gap: design-token("space.1");
 }
 
-.closeButton {
+.closeButtonContainer {
+  display: inline-flex;
   padding: design-token("space.0");
   /* prettier-ignore */
   margin: design-token("space.0.5") design-token("space.1") design-token("space.0.5") design-token("space.2");
   background-color: component-token("notification", "color.background");
   color: component-token("notification", "color.text");
+}
+
+.closeButton {
   cursor: pointer;
 }
 
 .region {
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
 }

--- a/easy-ui-react/src/Notification/Notification.module.scss
+++ b/easy-ui-react/src/Notification/Notification.module.scss
@@ -41,7 +41,7 @@
 
 .Notification {
   /* prettier-ignore */
-  @include component-token("notification", "border_radius", design-token("shape.border_radius.base"));
+  @include component-token("notification", "border_radius", design-token("shape.border_radius.lg"));
   @include component-token("notification", "max-width", 1200px);
   align-items: center;
   justify-content: space-between;

--- a/easy-ui-react/src/Notification/Notification.tsx
+++ b/easy-ui-react/src/Notification/Notification.tsx
@@ -155,12 +155,14 @@ export function Notification(props: NotificationItemStateProps) {
         </div>
       </div>
       {type === "alert" && (
-        <UnstyledButton
-          {...closeButtonPropsWithDismiss}
-          className={classNames(styles.closeButton)}
-        >
-          <Icon size="md" symbol={CloseIcon} />
-        </UnstyledButton>
+        <span className={styles.closeButtonContainer}>
+          <UnstyledButton
+            {...closeButtonPropsWithDismiss}
+            className={styles.closeButton}
+          >
+            <Icon size="md" symbol={CloseIcon} />
+          </UnstyledButton>
+        </span>
       )}
     </div>
   );


### PR DESCRIPTION
## 📝 Changes

- Fixes `Notification` to be closer to most up-to-date Figma spec
- Also fixes an issue where the close button styles were sometimes colliding with the UnstyledButton styles due to CSS build order. (i.e. .closeButton was included before the .unstyledButton class in the styles.css file). fix is to separate the colliding styles into their own element. we may want to look into this for other situations

add bottom border radius and 48px side margin:

<img width="996" alt="image" src="https://github.com/user-attachments/assets/9e227565-d7b6-4409-9fd3-266068b99c98" />

per Figma:

<img width="499" alt="image" src="https://github.com/user-attachments/assets/106fd55d-e47c-45c9-9e65-f4adf8164a26" />

## ✅ Checklist

Easy UI has certain UX standards that must be met. In general, non-trivial changes should meet the following criteria:

- [x] Visuals match Design Specs in Figma
- [x] Stories accompany any component changes
- [x] Code is in accordance with our style guide
- [x] Design tokens are utilized
- [x] Unit tests accompany any component changes
- [x] TSDoc is written for any API surface area
- [x] Specs are up-to-date
- [x] Console is free from warnings
- [x] No accessibility violations are reported
- [x] Cross-browser check is performed (Chrome, Safari, Firefox)
- [x] Changeset is added

~Strikethrough~ any items that are not applicable to this pull request.
