### PR TITLE
Fix: Fixes the DataGrid kebab button on safari

### DIFF
--- a/.changeset/chilly-mugs-hunt.md
+++ b/.changeset/chilly-mugs-hunt.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+Fixes DataGrid Kebab Menu in Safari

--- a/easy-ui-react/src/KebabButton/KebabButton.tsx
+++ b/easy-ui-react/src/KebabButton/KebabButton.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import MoreVertIcon from "@easypost/easy-ui-icons/MoreVert";
 import { AriaButtonProps } from "react-aria";
-import { UnstyledPressButton } from "../UnstyledButton/UnstyledPressButton";
+import { UnstyledButton } from "../UnstyledButton/UnstyledButton";
 import { Text } from "../Text";
 import { Icon } from "../Icon";
 import styles from "./KebabButton.module.scss";
@@ -24,14 +24,10 @@ export const KebabButton = React.forwardRef<null, KebabButtonProps>(
     const { accessibilityLabel = "Actions", ...restProps } = props;
 
     return (
-      <UnstyledPressButton
-        ref={inRef}
-        className={styles.KebabButton}
-        {...restProps}
-      >
+      <UnstyledButton ref={inRef} className={styles.KebabButton} {...restProps}>
         <Text visuallyHidden>{accessibilityLabel}</Text>
         <Icon symbol={MoreVertIcon} />
-      </UnstyledPressButton>
+      </UnstyledButton>
     );
   },
 );


### PR DESCRIPTION
## 📝 Changes

There is currently an issue in prod where on safari the kebab menu on data grids do not work.

This just swaps out the `UnstyledPressButton` for `UnstyledButton` in the kebab for the datagrid's kebab menu. Not sure why that fixes it, but Steve suggested it and it does in fact fix it.

## ✅ Checklist

Easy UI has certain UX standards that must be met. In general, non-trivial changes should meet the following criteria:

- [x] Visuals match Design Specs in Figma
- [x] Stories accompany any component changes
- [x] Code is in accordance with our style guide
- [x] Design tokens are utilized
- [x] Unit tests accompany any component changes
- [x] TSDoc is written for any API surface area
- [x] Specs are up-to-date
- [x] Console is free from warnings
- [x] No accessibility violations are reported
- [x] Cross-browser check is performed (Chrome, Safari, Firefox)
- [x] Changeset is added

~Strikethrough~ any items that are not applicable to this pull request.
