### PR TITLE
Datagrid types fix

### DIFF
--- a/.changeset/green-chefs-retire.md
+++ b/.changeset/green-chefs-retire.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+Renames .d.ts to .ts to fix types for DataGrid

--- a/easy-ui-react/src/DataGrid/types.ts
+++ b/easy-ui-react/src/DataGrid/types.ts
@@ -101,7 +101,7 @@ export type DataGridProps<C extends Column = Column> = AriaLabelingProps & {
   renderExpandedRow?: (key: Key) => ReactNode;
 
   /** Renders the content of a row cell. */
-  renderRowCell: (cell: unknown, columnKey: Key, row: R) => ReactNode;
+  renderRowCell: (cell: unknown, columnKey: Key, row: Row<C>) => ReactNode;
 
   /** Actions for the row */
   rowActions?: (key: Key) => RowAction[];


### PR DESCRIPTION
## 📝 Changes

Currently there are no types for the data grid component because the typedefs are in a `.d.ts` file. This changes it to a `.ts` file. I checked by installing the built package in another next app, and this fixes the types on the datagrid

## ✅ Checklist

Easy UI has certain UX standards that must be met. In general, non-trivial changes should meet the following criteria:

- [ ] Visuals match Design Specs in Figma
- [ ] Stories accompany any component changes
- [ ] Code is in accordance with our style guide
- [ ] Design tokens are utilized
- [ ] Unit tests accompany any component changes
- [ ] TSDoc is written for any API surface area
- [ ] Specs are up-to-date
- [ ] Console is free from warnings
- [ ] No accessibility violations are reported
- [ ] Cross-browser check is performed (Chrome, Safari, Firefox)
- [ ] Changeset is added

~Strikethrough~ any items that are not applicable to this pull request.
