### PR TITLE
Fix Datagrid Types

### DIFF
--- a/.changeset/tall-paths-reply.md
+++ b/.changeset/tall-paths-reply.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+Adds better types for the datagrid component

--- a/easy-ui-react/src/DataGrid/DataGrid.tsx
+++ b/easy-ui-react/src/DataGrid/DataGrid.tsx
@@ -7,7 +7,7 @@ import { Table } from "./Table";
 import { VisuallyHiddenCellContent } from "./VisuallyHiddenCellContent";
 import { ACTIONS_COLUMN_KEY, EXPAND_COLUMN_KEY } from "./constants";
 import { DataGridContext } from "./context";
-import { Column as ColumnType, DataGridProps } from "./types";
+import { Column as ColumnType, Row as RowType, DataGridProps } from "./types";
 
 /**
  * A `DataGrid` is an interactive table used for working with a large
@@ -44,9 +44,10 @@ import { Column as ColumnType, DataGridProps } from "./types";
  *   )}
  * />
  */
-export function DataGrid<C extends ColumnType = ColumnType>(
-  props: DataGridProps<C>,
-) {
+export function DataGrid<
+  C extends ColumnType = ColumnType,
+  R extends RowType = RowType,
+>(props: DataGridProps<C, R>) {
   const {
     columns: unprocessedColumns,
     columnKeysAllowingSort = [],
@@ -197,8 +198,8 @@ function useProcessedColumns<C extends ColumnType>(
  * @param expandedKey the currently expanded row key
  * @returns processed rows
  */
-function useProcessedRows<C extends ColumnType>(
-  props: Pick<DataGridProps<C>, "renderExpandedRow" | "rows" | "rowActions">,
+function useProcessedRows<C extends ColumnType, R extends RowType>(
+  props: Pick<DataGridProps<C, R>, "renderExpandedRow" | "rows" | "rowActions">,
   expandedKey: Key | null,
 ) {
   const { renderExpandedRow, rows, rowActions } = props;

--- a/easy-ui-react/src/DataGrid/Table.tsx
+++ b/easy-ui-react/src/DataGrid/Table.tsx
@@ -15,18 +15,23 @@ import {
   EXPAND_COLUMN_KEY,
 } from "./constants";
 import { DataGridTableContext } from "./context";
-import { Column, DataGridProps } from "./types";
+import { Column, DataGridProps, Row as RowType } from "./types";
 import { useEdgeInterceptors } from "./useEdgeInterceptors";
 import { useExpandedRow } from "./useExpandedRow";
 import { Spinner } from "../Spinner";
 
 import styles from "./DataGrid.module.scss";
 
-type TableProps<C extends Column> = Omit<DataGridProps<C>, "children"> & {
+type TableProps<C extends Column, R extends RowType> = Omit<
+  DataGridProps<C, R>,
+  "children"
+> & {
   children?: [ReactElement, ReactElement];
 };
 
-export function Table<C extends Column>(props: TableProps<C>) {
+export function Table<C extends Column, R extends RowType>(
+  props: TableProps<C, R>,
+) {
   const {
     headerVariant,
     maxRows = DEFAULT_MAX_ROWS,

--- a/easy-ui-react/src/DataGrid/types.ts
+++ b/easy-ui-react/src/DataGrid/types.ts
@@ -47,6 +47,13 @@ export type ActionRowAction = {
 export type ColumnKey<C extends Column = Column> = C["key"];
 export type RowKey<R extends Row = Row> = R["key"];
 
+export type KeyedSortDescriptor<K extends Key = Key> = Omit<
+  SortDescriptor,
+  "column"
+> & {
+  column: K;
+};
+
 export type RowAction = MenuRowAction | ActionRowAction;
 
 export type DataGridProps<
@@ -96,7 +103,7 @@ export type DataGridProps<
   onSelectionChange?: (keys: Selection) => void;
 
   /** Handler that is called when the sorted column or direction changes. */
-  onSortChange?: (descriptor: SortDescriptor) => void;
+  onSortChange?: (descriptor: KeyedSortDescriptor<ColumnKey<C>>) => void;
 
   /** Renders the content of a column cell. */
   renderColumnCell: (cell: C) => ReactNode;
@@ -126,7 +133,7 @@ export type DataGridProps<
   size?: "sm" | "md" | "lg";
 
   /** The current sorted column and direction. */
-  sortDescriptor?: SortDescriptor;
+  sortDescriptor?: KeyedSortDescriptor<ColumnKey<C>>;
 
   /**
    * Renders the content of empty state.

--- a/easy-ui-react/src/DataGrid/types.ts
+++ b/easy-ui-react/src/DataGrid/types.ts
@@ -18,10 +18,8 @@ export type Column = KeyedObject & {
   [property: string]: unknown;
 };
 
-export type Row<C extends Column> = KeyedObject & {
-  /** Must contain a property for each key in column. */
-  [property in C["key"]]: unknown;
-};
+export type Row<D extends Record<string, unknown> = Record<string, unknown>> =
+  KeyedObject & D;
 
 export type MenuRowAction = {
   type: "menu";
@@ -48,7 +46,10 @@ export type ActionRowAction = {
 
 export type RowAction = MenuRowAction | ActionRowAction;
 
-export type DataGridProps<C extends Column = Column> = AriaLabelingProps & {
+export type DataGridProps<
+  C extends Column = Column,
+  R extends Row = Row,
+> = AriaLabelingProps & {
   /** Use columns and rows to specify data grid content. */
   children?: never;
 
@@ -101,13 +102,13 @@ export type DataGridProps<C extends Column = Column> = AriaLabelingProps & {
   renderExpandedRow?: (key: Key) => ReactNode;
 
   /** Renders the content of a row cell. */
-  renderRowCell: (cell: unknown, columnKey: Key, row: Row<C>) => ReactNode;
+  renderRowCell: (cell: unknown, columnKey: Key, row: R) => ReactNode;
 
   /** Actions for the row */
   rowActions?: (key: Key) => RowAction[];
 
   /** Rows for the table. */
-  rows: Row<C>[];
+  rows: R[];
 
   /** The currently selected keys in the collection (controlled). */
   selectedKeys?: "all" | Iterable<Key>;

--- a/easy-ui-react/src/DataGrid/types.ts
+++ b/easy-ui-react/src/DataGrid/types.ts
@@ -9,8 +9,8 @@ import { ReactNode } from "react";
 import { IconSymbol } from "../types";
 
 /** Denote that an object must contain a key. */
-export type KeyedObject = {
-  readonly key: Key;
+export type KeyedObject<K extends Key = Key> = {
+  readonly key: K;
 };
 
 export type Column = KeyedObject & {
@@ -44,6 +44,9 @@ export type ActionRowAction = {
   onAction: () => void;
 };
 
+export type ColumnKey<C extends Column = Column> = C["key"];
+export type RowKey<R extends Row = Row> = R["key"];
+
 export type RowAction = MenuRowAction | ActionRowAction;
 
 export type DataGridProps<
@@ -54,22 +57,22 @@ export type DataGridProps<
   children?: never;
 
   /** List of keys for columns to allow sort. */
-  columnKeysAllowingSort?: Key[];
+  columnKeysAllowingSort?: ColumnKey<C>[];
 
   /** Columns for the table. */
   columns: C[];
 
   /** The initial expanded key in the collection (uncontrolled). */
-  defaultExpandedKey?: Key;
+  defaultExpandedKey?: RowKey<R>;
 
   /** The initial selected keys in the collection (uncontrolled). */
-  defaultSelectedKeys?: "all" | Iterable<Key>;
+  defaultSelectedKeys?: "all" | Iterable<RowKey<R>>;
 
   /** A list of row keys to disable from selection. */
-  disabledKeys?: Iterable<Key>;
+  disabledKeys?: Iterable<RowKey<R>>;
 
   /** The currently expanded key in the collection (controlled). */
-  expandedKey?: Key;
+  expandedKey?: RowKey<R>;
 
   /**
    * Variant of the data grid header to use.
@@ -81,13 +84,13 @@ export type DataGridProps<
   maxRows?: number;
 
   /** Handler that is called when a user performs an action on the cell. */
-  onCellAction?: (key: Key) => void;
+  onCellAction?: (key: RowKey<R>) => void;
 
   /** Handler that is called when the expansion changes. */
-  onExpandedChange?: (key: Key) => void;
+  onExpandedChange?: (key: RowKey<R>) => void;
 
   /** Handler that is called when a user performs an action on the row. */
-  onRowAction?: (key: Key) => void;
+  onRowAction?: (key: RowKey<R>) => void;
 
   /** Handler that is called when the selection changes. */
   onSelectionChange?: (keys: Selection) => void;
@@ -99,19 +102,19 @@ export type DataGridProps<
   renderColumnCell: (cell: C) => ReactNode;
 
   /** Renders the contents of the expanded row. */
-  renderExpandedRow?: (key: Key) => ReactNode;
+  renderExpandedRow?: (key: RowKey<R>) => ReactNode;
 
   /** Renders the content of a row cell. */
-  renderRowCell: (cell: unknown, columnKey: Key, row: R) => ReactNode;
+  renderRowCell: (cell: unknown, columnKey: ColumnKey<C>, row: R) => ReactNode;
 
   /** Actions for the row */
-  rowActions?: (key: Key) => RowAction[];
+  rowActions?: (key: RowKey<R>) => RowAction[];
 
   /** Rows for the table. */
   rows: R[];
 
   /** The currently selected keys in the collection (controlled). */
-  selectedKeys?: "all" | Iterable<Key>;
+  selectedKeys?: "all" | Iterable<RowKey<R>>;
 
   /** The type of selection that is allowed in the collection. */
   selectionMode?: SelectionMode;

--- a/package-lock.json
+++ b/package-lock.json
@@ -104,10 +104,10 @@
     },
     "easy-ui-react": {
       "name": "@easypost/easy-ui",
-      "version": "1.0.0-alpha.76",
+      "version": "1.0.0-alpha.77",
       "dependencies": {
         "@easypost/easy-ui-icons": "1.0.0-alpha.39",
-        "@easypost/easy-ui-tokens": "1.0.0-alpha.15",
+        "@easypost/easy-ui-tokens": "1.0.0-alpha.16",
         "@react-aria/toast": "^3.0.1",
         "@react-aria/utils": "^3.28.1",
         "@react-stately/toast": "^3.0.0",
@@ -356,7 +356,7 @@
     },
     "easy-ui-tokens": {
       "name": "@easypost/easy-ui-tokens",
-      "version": "1.0.0-alpha.15",
+      "version": "1.0.0-alpha.16",
       "devDependencies": {
         "nodemon": "^3.1.9",
         "style-dictionary": "^4.3.3"
@@ -15692,7 +15692,7 @@
       "version": "file:easy-ui-react",
       "requires": {
         "@easypost/easy-ui-icons": "1.0.0-alpha.39",
-        "@easypost/easy-ui-tokens": "1.0.0-alpha.15",
+        "@easypost/easy-ui-tokens": "1.0.0-alpha.16",
         "@react-aria/toast": "^3.0.1",
         "@react-aria/utils": "^3.28.1",
         "@react-stately/toast": "^3.0.0",


### PR DESCRIPTION
## 📝 Changes

- Makes the Columns and Rows types mutually exclusive
- Makes the `Key` types generic, and based on the `key` property of the column/row its referring to
- Makes the sort descriptor type `key` aware

I went and checked all the instances of DataGrid in TS files, and these changes allow us to get rid of all the `ts-expect-error` comments

![CleanShot 2025-04-11 at 10 57 01@2x](https://github.com/user-attachments/assets/783fdcbe-15d3-4299-8b94-b12963fff222)
![CleanShot 2025-04-11 at 10 57 21@2x](https://github.com/user-attachments/assets/65c284a3-2e19-465a-b1cd-ba93a308f88f)
![CleanShot 2025-04-11 at 10 57 38@2x](https://github.com/user-attachments/assets/0c9ff206-2c30-453a-b62d-dedc51243fb7)
![CleanShot 2025-04-11 at 10 57 50@2x](https://github.com/user-attachments/assets/7aa350cb-20f6-46ea-9faa-fabe9bbaac79)
![CleanShot 2025-04-11 at 10 58 04@2x](https://github.com/user-attachments/assets/c9bf2e6c-c8d6-4536-93cf-d69fa6443710)


## ✅ Checklist

Easy UI has certain UX standards that must be met. In general, non-trivial changes should meet the following criteria:

- [ ] Visuals match Design Specs in Figma
- [ ] Stories accompany any component changes
- [ ] Code is in accordance with our style guide
- [ ] Design tokens are utilized
- [ ] Unit tests accompany any component changes
- [ ] TSDoc is written for any API surface area
- [ ] Specs are up-to-date
- [ ] Console is free from warnings
- [ ] No accessibility violations are reported
- [ ] Cross-browser check is performed (Chrome, Safari, Firefox)
- [x] Changeset is added

~Strikethrough~ any items that are not applicable to this pull request.
