### PR TITLE
Makes the select and radiogroup components take generic keys

### DIFF
--- a/.changeset/spicy-moments-mate.md
+++ b/.changeset/spicy-moments-mate.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+Makes the `Select` component accept a generic key

--- a/.changeset/spicy-moments-mate.md
+++ b/.changeset/spicy-moments-mate.md
@@ -2,4 +2,4 @@
 "@easypost/easy-ui": patch
 ---
 
-Makes the `Select` component accept a generic key
+Makes the `Select` and `RadioGroup` components accept generic keys

--- a/easy-ui-react/src/RadioGroup/RadioGroup.stories.tsx
+++ b/easy-ui-react/src/RadioGroup/RadioGroup.stories.tsx
@@ -12,7 +12,7 @@ import {
 type Story = StoryObj<typeof RadioGroup>;
 type ItemStory = StoryObj<typeof RadioGroup.Item>;
 
-const Template = (args: RadioGroupProps) => {
+const Template = (args: RadioGroupProps<string>) => {
   return (
     <RadioGroup {...args}>
       <RadioGroup.Item value="first">First item</RadioGroup.Item>

--- a/easy-ui-react/src/RadioGroup/RadioGroup.tsx
+++ b/easy-ui-react/src/RadioGroup/RadioGroup.tsx
@@ -8,12 +8,12 @@ import { RadioGroupItem, RadioGroupItemProps } from "./RadioGroupItem";
 
 import styles from "./RadioGroup.module.scss";
 
-export type RadioGroupProps = AriaLabelingProps & {
+export type RadioGroupProps<K extends string> = AriaLabelingProps & {
   /** Radio buttons to render inside the radio group. */
   children?: ReactNode;
 
   /** The default value (uncontrolled). */
-  defaultValue?: string;
+  defaultValue?: K;
 
   /** Whether the radio is disabled. */
   isDisabled?: boolean;
@@ -31,17 +31,22 @@ export type RadioGroupProps = AriaLabelingProps & {
   name?: string;
 
   /** Handler that is called when the value changes. */
-  onChange?: (value: string) => void;
+  onChange?: (value: K) => void;
 
   /** The current value (controlled). */
-  value?: string;
+  value?: K;
 };
 
-function RadioGroupContainer(props: RadioGroupProps) {
+function RadioGroupContainer<K extends string>(props: RadioGroupProps<K>) {
   const { children, label } = props;
 
-  const state = useRadioGroupState(props);
-  const { radioGroupProps, labelProps } = useRadioGroup(props, state);
+  // hate to do this, but react-aria doesn't support generics, but it would
+  // really be ideal to have the select be generic. FIXME when react-aria's
+  // types around `Key` are fixed.
+  const castProps = props as RadioGroupProps<string>;
+
+  const state = useRadioGroupState(castProps);
+  const { radioGroupProps, labelProps } = useRadioGroup(castProps, state);
 
   return (
     <fieldset className={styles.RadioGroup} {...radioGroupProps}>
@@ -101,7 +106,7 @@ function RadioGroupContainer(props: RadioGroupProps) {
  * </RadioGroup>
  * ```
  */
-export function RadioGroup(props: RadioGroupProps) {
+export function RadioGroup<K extends string>(props: RadioGroupProps<K>) {
   const { children, ...containerProps } = props;
   return (
     <RadioGroupContainer {...containerProps}>

--- a/easy-ui-react/src/Select/Select.stories.tsx
+++ b/easy-ui-react/src/Select/Select.stories.tsx
@@ -7,7 +7,7 @@ import { Select, SelectProps } from "./Select";
 
 type Story = StoryObj<typeof Select>;
 
-const Template = (args: SelectProps<object>) => {
+const Template = (args: SelectProps<object, Key>) => {
   return (
     <Select {...args}>
       <Select.Option key="Option 1">Option 1</Select.Option>


### PR DESCRIPTION
## 📝 Changes

This opens the `Select` and `RadioGroup` component's keys to be generic instead just the `Key = string | number` loose type. I checked in EPWA and this seems to work as expected.

Unfortunately react-aria isn't super happy with these changes, as it wants the keys to be of type `Key`. I added a type case for the props being passed to react aria stuff :/ not ideal, but open to suggestions if we don't want that...

## ✅ Checklist

Easy UI has certain UX standards that must be met. In general, non-trivial changes should meet the following criteria:

- [x] Code is in accordance with our style guide
- [x] Changeset is added

~Strikethrough~ any items that are not applicable to this pull request.
