### PR TITLE
fix(Modal): disable hiding parent of nested modal

### DIFF
--- a/.changeset/pink-paths-film.md
+++ b/.changeset/pink-paths-film.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+fix(Modal): disable hiding parent nested modal

--- a/easy-ui-react/src/Modal/Modal.module.scss
+++ b/easy-ui-react/src/Modal/Modal.module.scss
@@ -15,12 +15,6 @@
     background: design-token("color.primary.800");
     opacity: design-token("opacity.underlay");
   }
-
-  // React Aria marks parents of nested overlays as hidden. Ensure the
-  // hidden modals don't show in such cases to support nesting
-  &[aria-hidden="true"] {
-    display: none;
-  }
 }
 
 .underlayBg,


### PR DESCRIPTION
## 📝 Changes

React Aria hides the modal for any subcomponent popover, which meant it was hiding for certain dropdowns. So for now, revert the hiding, but keep the nesting allowance.

Will figure out alternative approach for presentation.