### PR TITLE
fix(Text): inherit theme font family

### DIFF
--- a/.changeset/polite-months-rule.md
+++ b/.changeset/polite-months-rule.md
@@ -1,0 +1,6 @@
+---
+"@easypost/easy-ui-tokens": patch
+"@easypost/easy-ui": patch
+---
+
+fix(Text): inherit theme font family

--- a/easy-ui-react/src/Text/Text.tsx
+++ b/easy-ui-react/src/Text/Text.tsx
@@ -30,7 +30,7 @@ export type TextColor =
   | "inverse"
   | "primary"
   | "subdued";
-export type TextVariant = DesignTokenNamespace<"font.style", "family">;
+export type TextVariant = DesignTokenNamespace<"font.style", "size">;
 export type TextWeight = "normal" | "medium" | "semibold" | "bold";
 export type TextTransform = "none" | "capitalize" | "uppercase" | "lowercase";
 export type TextWhiteSpace =

--- a/easy-ui-react/src/Typography.mdx
+++ b/easy-ui-react/src/Typography.mdx
@@ -1,12 +1,15 @@
 import React from "react";
 import { Meta, Canvas } from "@storybook/blocks";
 import { Text } from "./Text";
+import { Provider as EasyUIProvider } from "./Provider";
 
 <Meta title="Foundations/Typography" />
 
 # Typography
 
 Easy UI comes with a set of predefined styles for headings, paragraphs, and other text elements. You can use these styles to maintain consistency across your application.
+
+<EasyUIProvider>
 
 <div className="sb-unstyled">
 
@@ -60,3 +63,5 @@ Easy UI comes with a set of predefined styles for headings, paragraphs, and othe
 </Text>
 
 </div>
+
+</EasyUIProvider>

--- a/easy-ui-react/src/styles/_typography.scss
+++ b/easy-ui-react/src/styles/_typography.scss
@@ -31,9 +31,9 @@
 @function font-style-aliases() {
   $aliases: ();
   @each $key, $value in $ezui-tokens {
-    @if string.index($key, "font-style-") and string.index($key, "-family") {
+    @if string.index($key, "font-style-") and string.index($key, "-size") {
       $alias: string.slice($key, string.length("font-style-") + 1);
-      $alias: string.slice($alias, 0, string.index($alias, "-family") - 1);
+      $alias: string.slice($alias, 0, string.index($alias, "-size") - 1);
       $aliases: list.append($aliases, $alias);
     }
   }

--- a/easy-ui-tokens/src/font/styles.json
+++ b/easy-ui-tokens/src/font/styles.json
@@ -2,7 +2,6 @@
   "font": {
     "style": {
       "heading1": {
-        "family": { "value": "{font.family.sans.value}" },
         "weight": { "value": "{font.weight.medium.value}" },
         "size": { "value": "{font.size.700.value}" },
         "letter_spacing": {
@@ -11,7 +10,6 @@
         "line_height": { "value": "{font.line_height.7.value}" }
       },
       "heading2": {
-        "family": { "value": "{font.family.sans.value}" },
         "weight": { "value": "{font.weight.medium.value}" },
         "size": { "value": "{font.size.500.value}" },
         "letter_spacing": {
@@ -20,7 +18,6 @@
         "line_height": { "value": "{font.line_height.5.value}" }
       },
       "heading3": {
-        "family": { "value": "{font.family.sans.value}" },
         "weight": { "value": "{font.weight.medium.value}" },
         "size": { "value": "{font.size.400.value}" },
         "letter_spacing": {
@@ -29,7 +26,6 @@
         "line_height": { "value": "{font.line_height.4.value}" }
       },
       "heading4": {
-        "family": { "value": "{font.family.sans.value}" },
         "weight": { "value": "{font.weight.semibold.value}" },
         "size": { "value": "{font.size.300.value}" },
         "letter_spacing": {
@@ -38,7 +34,6 @@
         "line_height": { "value": "{font.line_height.3.value}" }
       },
       "heading5": {
-        "family": { "value": "{font.family.sans.value}" },
         "weight": { "value": "{font.weight.semibold.value}" },
         "size": { "value": "{font.size.200.value}" },
         "letter_spacing": {
@@ -47,7 +42,6 @@
         "line_height": { "value": "{font.line_height.2.value}" }
       },
       "subtitle1": {
-        "family": { "value": "{font.family.sans.value}" },
         "weight": { "value": "{font.weight.semibold.value}" },
         "size": { "value": "{font.size.100.value}" },
         "letter_spacing": {
@@ -56,7 +50,6 @@
         "line_height": { "value": "{font.line_height.2.value}" }
       },
       "subtitle2": {
-        "family": { "value": "{font.family.sans.value}" },
         "weight": { "value": "{font.weight.medium.value}" },
         "size": { "value": "{font.size.75.value}" },
         "letter_spacing": {
@@ -65,7 +58,6 @@
         "line_height": { "value": "{font.line_height.1.value}" }
       },
       "body1": {
-        "family": { "value": "{font.family.sans.value}" },
         "weight": { "value": "{font.weight.normal.value}" },
         "size": { "value": "{font.size.100.value}" },
         "letter_spacing": {
@@ -74,7 +66,6 @@
         "line_height": { "value": "{font.line_height.2.value}" }
       },
       "body2": {
-        "family": { "value": "{font.family.sans.value}" },
         "weight": { "value": "{font.weight.normal.value}" },
         "size": { "value": "{font.size.75.value}" },
         "letter_spacing": {
@@ -83,7 +74,6 @@
         "line_height": { "value": "{font.line_height.1.value}" }
       },
       "caption": {
-        "family": { "value": "{font.family.sans.value}" },
         "weight": { "value": "{font.weight.light.value}" },
         "size": { "value": "{font.size.50.value}" },
         "letter_spacing": {
@@ -92,7 +82,6 @@
         "line_height": { "value": "{font.line_height.1.value}" }
       },
       "caption2": {
-        "family": { "value": "{font.family.sans.value}" },
         "weight": { "value": "{font.weight.light.value}" },
         "size": { "value": "{font.size.37_5.value}" },
         "letter_spacing": {
@@ -101,7 +90,6 @@
         "line_height": { "value": "{font.line_height.1.value}" }
       },
       "caption3": {
-        "family": { "value": "{font.family.sans.value}" },
         "weight": { "value": "{font.weight.light.value}" },
         "size": { "value": "{font.size.17_5.value}" },
         "letter_spacing": {
@@ -110,7 +98,6 @@
         "line_height": { "value": "{font.line_height.1.value}" }
       },
       "overline": {
-        "family": { "value": "{font.family.sans.value}" },
         "weight": { "value": "{font.weight.normal.value}" },
         "size": { "value": "{font.size.50.value}" },
         "letter_spacing": {
@@ -119,7 +106,6 @@
         "line_height": { "value": "{font.line_height.1.value}" }
       },
       "overline2": {
-        "family": { "value": "{font.family.sans.value}" },
         "weight": { "value": "{font.weight.normal.value}" },
         "size": { "value": "{font.size.25.value}" },
         "letter_spacing": {
@@ -128,7 +114,6 @@
         "line_height": { "value": "{font.line_height.1.value}" }
       },
       "button": {
-        "family": { "value": "{font.family.sans.value}" },
         "weight": { "value": "{font.weight.medium.value}" },
         "size": { "value": "{font.size.100.value}" },
         "letter_spacing": {
@@ -137,7 +122,6 @@
         "line_height": { "value": "{font.line_height.2.value}" }
       },
       "small_button": {
-        "family": { "value": "{font.family.sans.value}" },
         "weight": { "value": "{font.weight.medium.value}" },
         "size": { "value": "{font.size.50.value}" },
         "letter_spacing": {


### PR DESCRIPTION
## 📝 Changes

Instead of setting a font family explicitly it should inherit the root font family so that it can pick up font families on the theme.

## ✅ Checklist

Easy UI has certain UX standards that must be met. In general, non-trivial changes should meet the following criteria:

- [x] Visuals match Design Specs in Figma
- [x] Stories accompany any component changes
- [x] Code is in accordance with our style guide
- [x] Design tokens are utilized
- [x] Unit tests accompany any component changes
- [x] TSDoc is written for any API surface area
- [x] Specs are up-to-date
- [x] Console is free from warnings
- [x] No accessibility violations are reported
- [x] Cross-browser check is performed (Chrome, Safari, Firefox)
- [x] Changeset is added

~Strikethrough~ any items that are not applicable to this pull request.
