### PR TITLE
fix(Modal): hide nested parent modal

### DIFF
--- a/.changeset/tough-dragons-fry.md
+++ b/.changeset/tough-dragons-fry.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+fix(Modal): hide nested parent modal


### PR DESCRIPTION
## 📝 Changes

- Fixes the bug that didn't allow for hiding the nested modal parent properly

## ✅ Checklist

Easy UI has certain UX standards that must be met. In general, non-trivial changes should meet the following criteria:

- [x] Visuals match Design Specs in Figma
- [x] Stories accompany any component changes
- [x] Code is in accordance with our style guide
- [x] Design tokens are utilized
- [x] Unit tests accompany any component changes
- [x] TSDoc is written for any API surface area
- [x] Specs are up-to-date
- [x] Console is free from warnings
- [x] No accessibility violations are reported
- [x] Cross-browser check is performed (Chrome, Safari, Firefox)
- [x] Changeset is added

~Strikethrough~ any items that are not applicable to this pull request.
