### PR TITLE
feat(Select): maintain size of select fields after value selection

### DIFF
--- a/.changeset/fancy-results-refuse.md
+++ b/.changeset/fancy-results-refuse.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+Select now keeps its size after you choose a value, so medium and large fields stay the same height instead of shrinking a step

--- a/easy-ui-react/src/Select/SelectField.tsx
+++ b/easy-ui-react/src/Select/SelectField.tsx
@@ -123,9 +123,7 @@ export function SelectField(props: SelectFieldProps) {
       >
         {selectState.selectedItem ? (
           <>
-            <Text variant="body2" truncate>
-              {selectState.selectedItem.rendered}
-            </Text>
+            <Text truncate>{selectState.selectedItem.rendered}</Text>
             {selectedDescription && (
               <span className={styles.selectedDescription}>
                 <Text variant="caption" color="neutral.600" truncate>


### PR DESCRIPTION
## 📝 Changes

A Select with size="md" or size="lg" shrinks by one size step once a value is selected: md renders like sm, and lg renders like md, while sm is unaffected.
Hardcoding variant="body2" on the selected value overrides the inherited size, causing md and lg to render with the smaller body2 style.
Remove the hardcoded variant="body2" so the selected value inherits the trigger's size

## ✅ Checklist

Easy UI has certain UX standards that must be met. In general, non-trivial changes should meet the following criteria:

- [ ] Visuals match Design Specs in Figma
- [ ] Stories accompany any component changes
- [ ] Code is in accordance with our style guide
- [ ] Design tokens are utilized
- [ ] Unit tests accompany any component changes
- [ ] TSDoc is written for any API surface area
- [ ] Specs are up-to-date
- [ ] Console is free from warnings
- [ ] No accessibility violations are reported
- [ ] Cross-browser check is performed (Chrome, Safari, Firefox)
- [ ] Changeset is added

~Strikethrough~ any items that are not applicable to this pull request.
