### PR TITLE
feat(ForgeLayout): add icon-only nav rail

### DIFF
--- a/.changeset/forge-layout-nav-rail.md
+++ b/.changeset/forge-layout-nav-rail.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": minor
+---
+
+`ForgeLayout` supports an icon-only nav rail with `navState="rail"`, toggled by the new `ForgeLayout.NavToggle`. `navState` can now be left uncontrolled with `defaultNavState`, and changes are reported through `onNavStateChange`. `ForgeLayout.Nav` accepts `renderLogo` for a per-state logo, and `ForgeLayout.NavLink` accepts `label` and `renderBadge` so railed links keep their tooltip and badge. Existing `expanded` and `collapsed` behavior is unchanged.

--- a/.changeset/left-panel-icons.md
+++ b/.changeset/left-panel-icons.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui-icons": minor
+---
+
+Adds LeftPanelClose and LeftPanelOpen icons

--- a/easy-ui-icons/src/LeftPanelClose.json
+++ b/easy-ui-icons/src/LeftPanelClose.json
@@ -1,0 +1,5 @@
+{
+  "name": "left_panel_close",
+  "style": "outlined",
+  "source": "@material-symbols/svg-400"
+}

--- a/easy-ui-icons/src/LeftPanelOpen.json
+++ b/easy-ui-icons/src/LeftPanelOpen.json
@@ -1,0 +1,5 @@
+{
+  "name": "left_panel_open",
+  "style": "outlined",
+  "source": "@material-symbols/svg-400"
+}

--- a/easy-ui-react/src/ForgeLayout/ForgeLayout.mdx
+++ b/easy-ui-react/src/ForgeLayout/ForgeLayout.mdx
@@ -33,6 +33,81 @@ import * as ForgeLayoutStories from "./ForgeLayout.stories";
 
 <Controls of={ForgeLayoutStories.Collapsed} include={["navState"]} />
 
+## Railed Navigation
+
+`ForgeLayout` supports a narrow, icon-only nav with the `navState="rail"` prop.
+
+Design calls this state "Collapsed". `ForgeLayout` calls it `rail`, because `navState="collapsed"` already means the nav is gone entirely. The three states are:
+
+| `navState`  | Nav                    | Header               |
+| ----------- | ---------------------- | -------------------- |
+| `expanded`  | Full width with labels | Product controls     |
+| `rail`      | Icon-only              | Product controls     |
+| `collapsed` | Not rendered           | Breadcrumbs and back |
+
+Railing the nav is a nav-only concern, so `ForgeLayout.Controls` treats `rail` the same as `expanded`. Controls gated on `visibleWhenNavStateIs="expanded"` stay put when the nav rails.
+
+Railed links hide their labels, so each one gets a tooltip. `ForgeLayout.NavLink` builds it from `children` when those are plain text, and from `label` otherwise. Badges belong in `renderBadge` rather than `children`, so they can overlay the icon once the label is gone. `renderBadge` receives the nav state, so a badge that carries text next to a label can fall back to a dot on the icon.
+
+<Canvas of={ForgeLayoutStories.Rail} />
+
+<Controls of={ForgeLayoutStories.Rail} include={["defaultNavState"]} />
+
+### Toggling the nav
+
+`ForgeLayout.NavToggle` is a standalone control, so it can go wherever a product needs it—typically at the start of a `ForgeLayout.Controls`. It renders nothing when the nav is `collapsed`, since there is no nav to toggle.
+
+Pass `navState` to control the state, or `defaultNavState` to leave it uncontrolled. `onNavStateChange` reports every change. Persisting a person's choice across sessions is up to the consuming application.
+
+```tsx
+<ForgeLayout
+  navState={navState}
+  onNavStateChange={(nextNavState) => {
+    localStorage.setItem("navState", nextNavState);
+    setNavState(nextNavState);
+  }}
+>
+  <ForgeLayout.Nav
+    selectedHref={pathname}
+    renderLogo={({ navState }) =>
+      navState === "rail" ? <ProductGlyph /> : <ProductLogo />
+    }
+  >
+    <ForgeLayout.NavLink
+      href="/insurance"
+      iconSymbol={ShieldIcon}
+      renderBadge={({ navState }) =>
+        navState === "rail" ? (
+          <AlertBadge show={hasAlerts}>{null}</AlertBadge>
+        ) : (
+          <Badge variant="danger">{alertCount}</Badge>
+        )
+      }
+    >
+      Guard Insurance
+    </ForgeLayout.NavLink>
+  </ForgeLayout.Nav>
+  <ForgeLayout.Header>
+    <ForgeLayout.Controls visibleWhenNavStateIs="expanded">
+      <ForgeLayout.NavToggle />
+      <ForgeLayout.ModeSwitcher onModeChange={() => {}} />
+    </ForgeLayout.Controls>
+  </ForgeLayout.Header>
+  <ForgeLayout.Content>Page Content</ForgeLayout.Content>
+</ForgeLayout>
+```
+
+### Adding a rail to an existing layout
+
+This story mirrors the Forge app's layout, including the four places adding a rail needs care. Switch pages within the story to see each one.
+
+- **Page config outranks preference.** Pages that pin `navState="collapsed"` have to keep winning, or a drill-in page renders as a rail and loses its breadcrumbs.
+- **Badges move out of `children`.** A badge nested in `children` disappears when the nav rails. `renderBadge` keeps it over the icon.
+- **Ungrouped controls still fit.** `ForgeLayout.NavToggle` sets `flex: none`, so it holds its footprint whether or not `areControlsGrouped` is set.
+- **Grids sized for their old contents.** Controls wrapped in a `HorizontalGrid` with a fixed `columns` count push a new child onto another row. Keep the toggle outside the grid, or widen the count.
+
+<Canvas of={ForgeLayoutStories.ForgeApp} />
+
 ## Properties
 
 ### ForgeLayout

--- a/easy-ui-react/src/ForgeLayout/ForgeLayout.stories.tsx
+++ b/easy-ui-react/src/ForgeLayout/ForgeLayout.stories.tsx
@@ -3,8 +3,10 @@ import AccountCircleIcon from "@easypost/easy-ui-icons/AccountCircle";
 import AccountTreeIcon from "@easypost/easy-ui-icons/AccountTree";
 import DoorOpenIcon from "@easypost/easy-ui-icons/DoorOpen";
 import GroupsIcon from "@easypost/easy-ui-icons/Groups";
+import HandshakeIcon from "@easypost/easy-ui-icons/Handshake";
 import HomeIcon from "@easypost/easy-ui-icons/Home";
 import KeyIcon from "@easypost/easy-ui-icons/Key";
+import LocalPoliceIcon from "@easypost/easy-ui-icons/LocalPolice";
 import LocalShippingIcon from "@easypost/easy-ui-icons/LocalShipping";
 import RadarIcon from "@easypost/easy-ui-icons/Radar";
 import SettingsIcon from "@easypost/easy-ui-icons/Settings";
@@ -15,9 +17,16 @@ import WebhookIcon from "@easypost/easy-ui-icons/Webhook";
 import WidgetsIcon from "@easypost/easy-ui-icons/Widgets";
 import { action } from "storybook/actions";
 import { Meta, StoryObj } from "@storybook/react-vite";
-import React from "react";
+import React, { useState } from "react";
+import { AlertBadge } from "../AlertBadge";
+import { Badge } from "../Badge";
+import { Button } from "../Button";
+import { HorizontalGrid } from "../HorizontalGrid";
+import { HorizontalStack } from "../HorizontalStack";
 import { Menu } from "../Menu";
-import { ForgeLayout, ForgeLayoutProps } from "./ForgeLayout";
+import { Text } from "../Text";
+import { VerticalStack } from "../VerticalStack";
+import { ForgeLayout, ForgeLayoutProps, NavState } from "./ForgeLayout";
 import { Card } from "../Card";
 
 type Story = StoryObj<typeof ForgeLayout>;
@@ -30,7 +39,19 @@ const Template = (args: Partial<ForgeLayoutProps>) => {
           Dashboard
         </ForgeLayout.NavLink>
         <ForgeLayout.NavSection title={<>Management</>}>
-          <ForgeLayout.NavLink href="/2" iconSymbol={ShieldIcon}>
+          <ForgeLayout.NavLink
+            href="/2"
+            iconSymbol={ShieldIcon}
+            // A counted badge reads fine next to a label, but has nowhere to go
+            // once the label does, so the rail trades it for a dot on the icon.
+            renderBadge={({ navState }) =>
+              navState === "rail" ? (
+                <AlertBadge show>{null}</AlertBadge>
+              ) : (
+                <Badge variant="danger">3</Badge>
+              )
+            }
+          >
             Insurance
           </ForgeLayout.NavLink>
           <ForgeLayout.NavLink href="/2" iconSymbol={AccountTreeIcon}>
@@ -80,6 +101,7 @@ const Template = (args: Partial<ForgeLayoutProps>) => {
             </ForgeLayout.BreadcrumbsNavigation>
           </ForgeLayout.Controls>
           <ForgeLayout.Controls visibleWhenNavStateIs="expanded">
+            <ForgeLayout.NavToggle onPress={action("Nav toggled!")} />
             <ForgeLayout.ModeSwitcher onModeChange={action("Mode changed!")} />
             <ForgeLayout.Search />
           </ForgeLayout.Controls>
@@ -163,6 +185,260 @@ export const Collapsed: Story = {
   parameters: {
     controls: {
       include: ["navState"],
+    },
+  },
+};
+
+export const Rail: Story = {
+  render: Template.bind({}),
+  args: {
+    defaultNavState: "rail",
+  },
+  parameters: {
+    controls: {
+      include: ["defaultNavState"],
+    },
+  },
+};
+
+type ForgeAppPageKey =
+  | "dashboard"
+  | "insurance"
+  | "accountSettings"
+  | "subAccountDetails";
+
+type ForgeAppPage = {
+  /** Label for the page switcher in this story. */
+  name: string;
+
+  /**
+   * Nav state the page pins through the app's static page config. Only
+   * drill-in pages set this.
+   */
+  navState?: NavState;
+
+  /** Whether the page groups its header controls. */
+  areControlsGrouped: boolean;
+
+  /** Whether the page shows a product logo beside the mode switcher. */
+  hasProductLogo: boolean;
+};
+
+const FORGE_APP_PAGES: Record<ForgeAppPageKey, ForgeAppPage> = {
+  dashboard: {
+    name: "Dashboard",
+    areControlsGrouped: true,
+    hasProductLogo: false,
+  },
+  insurance: {
+    name: "Guard Insurance",
+    areControlsGrouped: true,
+    hasProductLogo: true,
+  },
+  accountSettings: {
+    name: "Account Settings",
+    areControlsGrouped: false,
+    hasProductLogo: false,
+  },
+  subAccountDetails: {
+    name: "Sub Account Detail",
+    navState: "collapsed",
+    areControlsGrouped: true,
+    hasProductLogo: false,
+  },
+};
+
+const FORGE_APP_PAGE_KEYS = Object.keys(FORGE_APP_PAGES) as ForgeAppPageKey[];
+
+/**
+ * Replicates the Forge app's `AuthenticatedForgeAppLayout`, including the four
+ * places a rail needs care. Switch pages to see each one.
+ */
+const ForgeAppTemplate = (args: Partial<ForgeLayoutProps>) => {
+  const [pageKey, setPageKey] = useState<ForgeAppPageKey>("dashboard");
+  const [prefersRail, setPrefersRail] = useState(false);
+  const page = FORGE_APP_PAGES[pageKey];
+
+  // Gotcha 1: pages pin `navState: "collapsed"` through a static page config,
+  // and that has to outrank the rail preference. Otherwise a drill-in page
+  // renders as a rail and loses its breadcrumbs.
+  //
+  // Overcoming: resolve the two in one place, page config first.
+  const navState = page.navState ?? (prefersRail ? "rail" : "expanded");
+
+  const handleNavStateChange = (nextNavState: NavState) => {
+    // The library never persists this. A real app would write to local storage
+    // here, the same way it already does for mode.
+    setPrefersRail(nextNavState === "rail");
+    action("Nav state changed!")(nextNavState);
+  };
+
+  return (
+    <ForgeLayout
+      {...args}
+      navState={navState}
+      onNavStateChange={handleNavStateChange}
+    >
+      <ForgeLayout.Nav selectedHref={`/forge/${pageKey}`}>
+        <ForgeLayout.NavLink href="/forge/dashboard" iconSymbol={HomeIcon}>
+          Dashboard
+        </ForgeLayout.NavLink>
+        <ForgeLayout.NavLink
+          href="/forge/referral-dashboard"
+          iconSymbol={HandshakeIcon}
+        >
+          Referral Dashboard
+        </ForgeLayout.NavLink>
+        <ForgeLayout.NavSection title={<>Management</>}>
+          {/*
+            Gotcha 2: the app renders its alert badge inside `children`, wrapped
+            in a `HorizontalStack`. A railed link hides its children, so the
+            badge would disappear, and the rail tooltip would have no plain text
+            to name the link with.
+
+            Overcoming: hand the badge to `renderBadge`, which keeps it over the
+            icon when railed. That leaves `children` as plain text, so the
+            tooltip needs no `label`. Links whose children still render more
+            than text should pass one.
+          */}
+          <ForgeLayout.NavLink
+            href="/forge/insurance"
+            iconSymbol={LocalPoliceIcon}
+            renderBadge={() => <AlertBadge show>{null}</AlertBadge>}
+          >
+            Guard Insurance
+          </ForgeLayout.NavLink>
+          <ForgeLayout.NavLink
+            href="/forge/sub-accounts"
+            iconSymbol={AccountTreeIcon}
+          >
+            Sub Accounts
+          </ForgeLayout.NavLink>
+          <ForgeLayout.NavLink href="/forge/reports" iconSymbol={ViewListIcon}>
+            Reports
+          </ForgeLayout.NavLink>
+        </ForgeLayout.NavSection>
+        <ForgeLayout.NavSection title={<>Development</>}>
+          <ForgeLayout.NavLink href="/forge/api-keys" iconSymbol={KeyIcon}>
+            API Keys
+          </ForgeLayout.NavLink>
+          <ForgeLayout.NavLink href="/forge/webhooks" iconSymbol={WebhookIcon}>
+            Webhooks
+          </ForgeLayout.NavLink>
+        </ForgeLayout.NavSection>
+      </ForgeLayout.Nav>
+      <ForgeLayout.Body>
+        {/*
+          Gotcha 3: `areControlsGrouped` is false on a couple of pages, which
+          drops the wrapper the controls otherwise share. The toggle has to hold
+          its size either way.
+
+          Overcoming: nothing to do in the app. `ForgeLayout.NavToggle` sets
+          `flex: none`, so it keeps its footprint grouped or not. Switch to
+          Account Settings to confirm.
+        */}
+        <ForgeLayout.Header areControlsGrouped={page.areControlsGrouped}>
+          <ForgeLayout.Controls visibleWhenNavStateIs="collapsed">
+            <ForgeLayout.BreadcrumbsNavigation>
+              <ForgeLayout.BackButton
+                onPress={() => setPageKey("subAccountDetails")}
+              >
+                Back
+              </ForgeLayout.BackButton>
+              <ForgeLayout.Breadcrumbs>
+                <ForgeLayout.Breadcrumb>Sub Accounts</ForgeLayout.Breadcrumb>
+                <ForgeLayout.Breadcrumb>Acme Shipping</ForgeLayout.Breadcrumb>
+              </ForgeLayout.Breadcrumbs>
+            </ForgeLayout.BreadcrumbsNavigation>
+          </ForgeLayout.Controls>
+          <ForgeLayout.Controls visibleWhenNavStateIs="expanded">
+            {/*
+              Gotcha 4: the app wraps these controls in a `HorizontalGrid` with
+              a hardcoded `columns={2}`. Adding the toggle as a third child
+              pushes the mode switcher onto a second grid row.
+
+              Overcoming: leave the toggle outside the grid, so the grid keeps
+              sizing only the controls it was written for. Widening to
+              `columns={3}` works too, but then the count has to track the
+              conditional logo.
+            */}
+            <ForgeLayout.NavToggle />
+            <HorizontalGrid gap="2" columns={2} alignItems="center">
+              {page.hasProductLogo && (
+                <Text variant="subtitle1" color="primary.500">
+                  Guard
+                </Text>
+              )}
+              <ForgeLayout.ModeSwitcher
+                onModeChange={action("Mode changed!")}
+              />
+            </HorizontalGrid>
+          </ForgeLayout.Controls>
+          <ForgeLayout.Actions>
+            <ForgeLayout.LinkAction
+              href="https://www.easypoststatus.com"
+              target="_blank"
+              accessibilityLabel="API status"
+              iconSymbol={RadarIcon}
+            />
+            <ForgeLayout.MenuAction
+              accessibilityLabel="Help"
+              iconSymbol={SupportIcon}
+            >
+              <Menu.Overlay onAction={action("Menu item clicked!")}>
+                <Menu.Item>Forge overview</Menu.Item>
+                <Menu.Item>Support</Menu.Item>
+              </Menu.Overlay>
+            </ForgeLayout.MenuAction>
+            <ForgeLayout.LinkAction
+              href="/account"
+              accessibilityLabel="Account"
+              iconSymbol={AccountCircleIcon}
+            />
+          </ForgeLayout.Actions>
+        </ForgeLayout.Header>
+        <ForgeLayout.Content>
+          <Card background="primary" boxShadow="1" variant="solid">
+            <VerticalStack gap="2">
+              <Text variant="heading5">{page.name}</Text>
+              <Text variant="body2">
+                Nav state resolves to <strong>{navState}</strong>. Page config
+                pins it to{" "}
+                <strong>
+                  {page.navState ?? "nothing, so the preference wins"}
+                </strong>
+                . Controls are{" "}
+                <strong>
+                  {page.areControlsGrouped ? "grouped" : "ungrouped"}
+                </strong>
+                .
+              </Text>
+              <HorizontalStack gap="1" wrap>
+                {FORGE_APP_PAGE_KEYS.map((key) => (
+                  <Button
+                    key={key}
+                    size="sm"
+                    variant={key === pageKey ? "filled" : "outlined"}
+                    onPress={() => setPageKey(key)}
+                  >
+                    {FORGE_APP_PAGES[key].name}
+                  </Button>
+                ))}
+              </HorizontalStack>
+              <div style={{ height: 600 }} />
+            </VerticalStack>
+          </Card>
+        </ForgeLayout.Content>
+      </ForgeLayout.Body>
+    </ForgeLayout>
+  );
+};
+
+export const ForgeApp: Story = {
+  render: ForgeAppTemplate.bind({}),
+  parameters: {
+    controls: {
+      include: ["mode"],
     },
   },
 };

--- a/easy-ui-react/src/ForgeLayout/ForgeLayout.test.tsx
+++ b/easy-ui-react/src/ForgeLayout/ForgeLayout.test.tsx
@@ -209,8 +209,15 @@ describe("<ForgeLayout />", () => {
       "should pass link props through once when %s",
       async (navState) => {
         const handleFocus = vi.fn();
+        const handleClick = vi.fn();
+        const handlePress = vi.fn();
         const { user } = render(
-          createNavLinkLayout({ navState, onFocus: handleFocus }),
+          createNavLinkLayout({
+            navState,
+            onFocus: handleFocus,
+            onClick: handleClick,
+            onPress: handlePress,
+          }),
         );
         const link = screen.getByRole("link", { name: "Nav Link" });
         expect(link).toHaveAttribute("target", "_blank");
@@ -218,6 +225,9 @@ describe("<ForgeLayout />", () => {
         await user.tab();
         expect(link).toHaveFocus();
         expect(handleFocus).toHaveBeenCalledTimes(1);
+        await userClick(user, link);
+        expect(handleClick).toHaveBeenCalledTimes(1);
+        expect(handlePress).toHaveBeenCalledTimes(1);
       },
     );
   });
@@ -441,8 +451,10 @@ function createForgeLayout(
 function createNavLinkLayout(props: {
   navState: NavState;
   onFocus: () => void;
+  onClick?: () => void;
+  onPress?: () => void;
 }) {
-  const { navState, onFocus } = props;
+  const { navState, onFocus, onClick, onPress } = props;
   return (
     <ForgeLayout navState={navState}>
       <ForgeLayout.Nav selectedHref="/1">
@@ -451,6 +463,8 @@ function createNavLinkLayout(props: {
           target="_blank"
           iconSymbol={Icon}
           onFocus={onFocus}
+          onClick={onClick}
+          onPress={onPress}
         >
           Nav Link
         </ForgeLayout.NavLink>

--- a/easy-ui-react/src/ForgeLayout/ForgeLayout.test.tsx
+++ b/easy-ui-react/src/ForgeLayout/ForgeLayout.test.tsx
@@ -2,6 +2,7 @@ import { screen } from "@testing-library/react";
 import React, { ReactNode } from "react";
 import { vi } from "vitest";
 import { Menu } from "../Menu";
+import { hoverOverTooltipTrigger } from "../Tooltip/Tooltip.test";
 import {
   mockGetComputedStyle,
   mockIntersectionObserver,
@@ -9,6 +10,7 @@ import {
   userClick,
 } from "../utilities/test";
 import { ForgeLayout, Mode, NavState } from "./ForgeLayout";
+import type { ForgeLayoutNavProps } from "./ForgeLayoutNav";
 
 describe("<ForgeLayout />", () => {
   let restoreGetComputedStyle: () => void;
@@ -112,42 +114,268 @@ describe("<ForgeLayout />", () => {
       expect.stringContaining("modeTest"),
     );
   });
+
+  describe("rail nav state", () => {
+    it("should keep the nav and its links named", async () => {
+      render(createForgeLayout({ navState: "rail" }));
+      expect(
+        screen.getByRole("navigation", { name: "Main" }),
+      ).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: "Nav Link 1" })).toHaveAttribute(
+        "aria-current",
+        "page",
+      );
+      expect(
+        screen.getByRole("link", { name: "Nav Link 3" }),
+      ).toBeInTheDocument();
+    });
+
+    it("should hide section titles visually while keeping them announced", async () => {
+      render(createForgeLayout({ navState: "rail" }));
+      expect(screen.getByText("Nav Section Title")).toHaveAttribute(
+        "class",
+        expect.stringContaining("visuallyHidden"),
+      );
+    });
+
+    it.each(["expanded", "rail"] as const)(
+      "should render badges with the %s nav state",
+      async (navState) => {
+        render(createForgeLayout({ navState }));
+        expect(screen.getByTestId("nav-link-2-badge")).toHaveTextContent(
+          navState,
+        );
+      },
+    );
+
+    it("should keep the controls shown when expanded", async () => {
+      render(createForgeLayout({ navState: "rail" }));
+      expect(
+        screen.getByRole("button", { name: "Production" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("searchbox", { name: "Search for content" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Back" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should show a tooltip built from text children", async () => {
+      const { user } = render(createForgeLayout({ navState: "rail" }));
+      await hoverOverTooltipTrigger(
+        user,
+        screen.getByRole("link", { name: "Nav Link 1" }),
+      );
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Nav Link 1");
+    });
+
+    it("should show a tooltip built from label when children aren't text", async () => {
+      const { user } = render(createForgeLayout({ navState: "rail" }));
+      await hoverOverTooltipTrigger(
+        user,
+        screen.getByRole("link", { name: "Nav Link 3" }),
+      );
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Nav Link 3");
+    });
+
+    it("should skip the tooltip when there is no text to show", async () => {
+      const { user } = render(createForgeLayout({ navState: "rail" }));
+      await hoverOverTooltipTrigger(
+        user,
+        screen.getByRole("link", { name: "Nav Link 5" }),
+      );
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+
+    it("should not render a nav when collapsed", async () => {
+      render(createForgeLayout({ navState: "collapsed" }));
+      expect(
+        screen.queryByRole("navigation", { name: "Main" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should support a custom logo per nav state", async () => {
+      render(
+        createForgeLayout({
+          navState: "rail",
+          renderLogo: ({ navState }) => <div>Logo {navState}</div>,
+        }),
+      );
+      expect(screen.getByText("Logo rail")).toBeInTheDocument();
+    });
+
+    it.each(["expanded", "rail"] as const)(
+      "should pass link props through once when %s",
+      async (navState) => {
+        const handleFocus = vi.fn();
+        const { user } = render(
+          createNavLinkLayout({ navState, onFocus: handleFocus }),
+        );
+        const link = screen.getByRole("link", { name: "Nav Link" });
+        expect(link).toHaveAttribute("target", "_blank");
+        expect(link).toHaveAttribute("href", "/1");
+        await user.tab();
+        expect(link).toHaveFocus();
+        expect(handleFocus).toHaveBeenCalledTimes(1);
+      },
+    );
+  });
+
+  describe("nav toggle", () => {
+    it("should be wired to the nav it controls", async () => {
+      render(createForgeLayout({ defaultNavState: "expanded" }));
+      const toggle = screen.getByRole("button", {
+        name: "Collapse navigation",
+      });
+      const nav = screen.getByRole("navigation", { name: "Main" });
+      expect(toggle).toHaveAttribute("aria-expanded", "true");
+      expect(toggle).toHaveAttribute(
+        "aria-controls",
+        nav.parentElement?.getAttribute("id"),
+      );
+    });
+
+    it("should toggle an uncontrolled nav between expanded and rail", async () => {
+      const handleNavStateChange = vi.fn();
+      const { user } = render(
+        createForgeLayout({
+          defaultNavState: "expanded",
+          onNavStateChange: handleNavStateChange,
+        }),
+      );
+
+      await userClick(
+        user,
+        screen.getByRole("button", { name: "Collapse navigation" }),
+      );
+      expect(handleNavStateChange).toHaveBeenCalledWith("rail");
+      expect(screen.getByText("Nav Section Title")).toHaveAttribute(
+        "class",
+        expect.stringContaining("visuallyHidden"),
+      );
+
+      await userClick(
+        user,
+        screen.getByRole("button", { name: "Expand navigation" }),
+      );
+      expect(handleNavStateChange).toHaveBeenLastCalledWith("expanded");
+      expect(screen.getByText("Nav Section Title")).not.toHaveAttribute(
+        "class",
+        expect.stringContaining("visuallyHidden"),
+      );
+    });
+
+    it("should leave a controlled nav to its owner", async () => {
+      const handleNavStateChange = vi.fn();
+      const { user } = render(
+        createForgeLayout({
+          navState: "expanded",
+          onNavStateChange: handleNavStateChange,
+        }),
+      );
+
+      await userClick(
+        user,
+        screen.getByRole("button", { name: "Collapse navigation" }),
+      );
+      expect(handleNavStateChange).toHaveBeenCalledWith("rail");
+      expect(
+        screen.getByRole("button", { name: "Collapse navigation" }),
+      ).toBeInTheDocument();
+    });
+
+    it("should not render when the nav is collapsed", async () => {
+      render(createForgeLayout({ navState: "collapsed" }));
+      expect(
+        screen.queryByRole("button", { name: "Collapse navigation" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Expand navigation" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should support a custom accessibility label", async () => {
+      render(
+        <ForgeLayout defaultNavState="expanded">
+          <ForgeLayout.Nav selectedHref="/1">
+            <ForgeLayout.NavLink href="/1" iconSymbol={Icon}>
+              Nav Link 1
+            </ForgeLayout.NavLink>
+          </ForgeLayout.Nav>
+          <ForgeLayout.Header>
+            <ForgeLayout.Controls>
+              <ForgeLayout.NavToggle accessibilityLabel="Toggle menu" />
+            </ForgeLayout.Controls>
+          </ForgeLayout.Header>
+          <ForgeLayout.Content>Content</ForgeLayout.Content>
+        </ForgeLayout>,
+      );
+      expect(
+        screen.getByRole("button", { name: "Toggle menu" }),
+      ).toBeInTheDocument();
+    });
+  });
 });
 
 function createForgeLayout(
   props: {
     mode?: Mode;
     navState?: NavState;
+    defaultNavState?: NavState;
     content?: ReactNode;
     selectedHref?: string;
+    renderLogo?: ForgeLayoutNavProps["renderLogo"];
     onMenuAction1?: () => void;
     onMenuAction2?: () => void;
     onBackButton?: () => void;
     onModeChange?: () => void;
+    onNavStateChange?: (navState: NavState) => void;
   } = {},
 ) {
   const {
     mode = "production",
-    navState = "expanded",
+    navState,
+    defaultNavState = "expanded",
     content = <div>Content</div>,
     selectedHref = "/1",
+    renderLogo,
     onMenuAction1 = vi.fn(),
     onMenuAction2 = vi.fn(),
     onBackButton = vi.fn(),
     onModeChange = vi.fn(),
+    onNavStateChange = vi.fn(),
   } = props;
   return (
-    <ForgeLayout mode={mode} navState={navState}>
-      <ForgeLayout.Nav selectedHref={selectedHref}>
+    <ForgeLayout
+      mode={mode}
+      navState={navState}
+      defaultNavState={defaultNavState}
+      onNavStateChange={onNavStateChange}
+    >
+      <ForgeLayout.Nav selectedHref={selectedHref} renderLogo={renderLogo}>
         <ForgeLayout.NavLink href="/1" iconSymbol={Icon}>
           Nav Link 1
         </ForgeLayout.NavLink>
         <ForgeLayout.NavSection title={<>Nav Section Title</>}>
-          <ForgeLayout.NavLink href="/2" iconSymbol={Icon}>
+          <ForgeLayout.NavLink
+            href="/2"
+            iconSymbol={Icon}
+            renderBadge={({ navState }) => (
+              <span data-testid="nav-link-2-badge">{navState}</span>
+            )}
+          >
             Nav Link 2
           </ForgeLayout.NavLink>
-          <ForgeLayout.NavLink href="/3" iconSymbol={Icon}>
-            Nav Link 3
+          {/* Children that aren't plain text, so the rail tooltip has to come
+              from `label`. */}
+          <ForgeLayout.NavLink href="/3" iconSymbol={Icon} label="Nav Link 3">
+            <span>Nav Link 3</span>
+          </ForgeLayout.NavLink>
+          {/* Neither plain text children nor a `label`, so there is nothing for
+              a tooltip to show. */}
+          <ForgeLayout.NavLink href="/5" iconSymbol={Icon}>
+            <span>Nav Link 5</span>
           </ForgeLayout.NavLink>
         </ForgeLayout.NavSection>
       </ForgeLayout.Nav>
@@ -165,6 +393,7 @@ function createForgeLayout(
           </ForgeLayout.BreadcrumbsNavigation>
         </ForgeLayout.Controls>
         <ForgeLayout.Controls visibleWhenNavStateIs="expanded">
+          <ForgeLayout.NavToggle />
           <ForgeLayout.ModeSwitcher onModeChange={onModeChange} />
           <ForgeLayout.Search />
         </ForgeLayout.Controls>
@@ -201,6 +430,32 @@ function createForgeLayout(
         </ForgeLayout.Actions>
       </ForgeLayout.Header>
       <ForgeLayout.Content>{content}</ForgeLayout.Content>
+    </ForgeLayout>
+  );
+}
+
+/**
+ * A layout pared down to a single nav link, so the link is the only tabbable
+ * element and its props can be asserted in isolation.
+ */
+function createNavLinkLayout(props: {
+  navState: NavState;
+  onFocus: () => void;
+}) {
+  const { navState, onFocus } = props;
+  return (
+    <ForgeLayout navState={navState}>
+      <ForgeLayout.Nav selectedHref="/1">
+        <ForgeLayout.NavLink
+          href="/1"
+          target="_blank"
+          iconSymbol={Icon}
+          onFocus={onFocus}
+        >
+          Nav Link
+        </ForgeLayout.NavLink>
+      </ForgeLayout.Nav>
+      <ForgeLayout.Content>Content</ForgeLayout.Content>
     </ForgeLayout>
   );
 }

--- a/easy-ui-react/src/ForgeLayout/ForgeLayout.tsx
+++ b/easy-ui-react/src/ForgeLayout/ForgeLayout.tsx
@@ -1,4 +1,11 @@
-import React, { ReactNode, useContext, useMemo } from "react";
+import React, {
+  ReactNode,
+  useCallback,
+  useContext,
+  useId,
+  useMemo,
+  useState,
+} from "react";
 import { classNames, variationName } from "../utilities/css";
 import {
   ForgeLayoutActionBadge,
@@ -23,12 +30,29 @@ import {
   ForgeLayoutSearch,
   ForgeLayoutModeSwitcher,
 } from "./ForgeLayoutControls";
+import { ForgeLayoutNavToggle } from "./ForgeLayoutNavToggle";
 
 import styles from "./ForgeLayout.module.scss";
 
 export type Mode = "test" | "production";
 
-export type NavState = "expanded" | "collapsed";
+/**
+ * Display state of the nav menu.
+ *
+ * - `expanded` renders the nav at full width with labelled links.
+ * - `rail` renders the nav as a narrow, icon-only rail. This is the state
+ *   design refers to as "collapsed".
+ * - `collapsed` removes the nav entirely for distraction-free content.
+ */
+export type NavState = "expanded" | "rail" | "collapsed";
+
+/**
+ * Nav states that `ForgeLayout.Controls` can be gated on.
+ *
+ * `rail` is deliberately excluded. A rail is a nav-only concern, so it shares
+ * `expanded`'s header semantics rather than introducing a third branch.
+ */
+export type NavVisibilityState = Exclude<NavState, "rail">;
 
 export type ForgeLayoutProps = {
   /** Layout children. */
@@ -42,11 +66,28 @@ export type ForgeLayoutProps = {
   mode?: Mode;
 
   /**
-   * Display state of the nav menu.
+   * Display state of the nav menu. Pass this to control the nav state.
+   * Use `defaultNavState` instead to leave the state uncontrolled.
    *
    * @default expanded
    */
   navState?: NavState;
+
+  /**
+   * Initial display state of the nav menu when left uncontrolled.
+   *
+   * @default expanded
+   */
+  defaultNavState?: NavState;
+
+  /**
+   * Called when the nav state changes, such as when a
+   * `ForgeLayout.NavToggle` is pressed.
+   *
+   * Persisting the nav state across sessions is left to the consuming
+   * application.
+   */
+  onNavStateChange?: (navState: NavState) => void;
 
   /**
    * Background decoration for layout.
@@ -63,7 +104,11 @@ export type ForgeLayoutContentProps = {
 
 export type ForgeLayoutContextType = {
   mode?: Mode;
-  navState?: NavState;
+  navState: NavState;
+  /** Sets the nav state, notifying `onNavStateChange` of the new value. */
+  setNavState: (navState: NavState) => void;
+  /** `id` of the nav element, for `aria-controls` on nav toggles. */
+  navId: string;
 };
 
 const ForgeLayoutContext = React.createContext<ForgeLayoutContextType | null>(
@@ -83,7 +128,7 @@ export const useForgeLayout = () => {
  *
  * @example
  * ```tsx
- * <ForgeLayout mode="test" navState="expanded">
+ * <ForgeLayout mode="test" defaultNavState="expanded">
  *   <ForgeLayout.Nav>
  *     <ForgeLayout.NavLink href="/1" iconSymbol={Icon}>
  *       Item 1
@@ -118,6 +163,7 @@ export const useForgeLayout = () => {
  *       </ForgeLayout.BreadcrumbsNavigation>
  *     </ForgeLayout.Controls>
  *     <ForgeLayout.Controls visibleWhenNavStateIs="expanded">
+ *       <ForgeLayout.NavToggle />
  *       <ForgeLayout.ModeSwitcher onModeChange={action("Mode changed!")} />
  *       <ForgeLayout.Search value={"search"} onChange={() => {}} />
  *     </ForgeLayout.Controls>
@@ -156,9 +202,17 @@ export function ForgeLayout(props: ForgeLayoutProps) {
   const {
     backgroundDecoration = "01",
     mode = "production",
-    navState = "expanded",
+    navState: controlledNavState,
+    defaultNavState = "expanded",
+    onNavStateChange,
     children,
   } = props;
+  const [navState, setNavState] = useNavState(
+    controlledNavState,
+    defaultNavState,
+    onNavStateChange,
+  );
+  const navId = useId();
   const className = classNames(
     styles.ForgeLayout,
     styles[variationName("mode", mode)],
@@ -169,8 +223,8 @@ export function ForgeLayout(props: ForgeLayoutProps) {
     styles[variationName("backgroundDecoration", backgroundDecoration)],
   );
   const context = useMemo(() => {
-    return { mode, navState };
-  }, [mode, navState]);
+    return { mode, navState, setNavState, navId };
+  }, [mode, navState, setNavState, navId]);
   return (
     <ForgeLayoutContext.Provider value={context}>
       <div className={bgClassName} />
@@ -179,6 +233,31 @@ export function ForgeLayout(props: ForgeLayoutProps) {
       </div>
     </ForgeLayoutContext.Provider>
   );
+}
+
+/**
+ * Resolves the nav state from either a controlled `navState` prop or internal
+ * state, always notifying `onNavStateChange` of requested changes.
+ */
+function useNavState(
+  controlledNavState: NavState | undefined,
+  defaultNavState: NavState,
+  onNavStateChange: ((navState: NavState) => void) | undefined,
+) {
+  const [uncontrolledNavState, setUncontrolledNavState] =
+    useState(defaultNavState);
+  const isControlled = controlledNavState !== undefined;
+  const navState = isControlled ? controlledNavState : uncontrolledNavState;
+  const setNavState = useCallback(
+    (nextNavState: NavState) => {
+      if (!isControlled) {
+        setUncontrolledNavState(nextNavState);
+      }
+      onNavStateChange?.(nextNavState);
+    },
+    [isControlled, onNavStateChange],
+  );
+  return [navState, setNavState] as const;
 }
 
 function ForgeLayoutBody(props: ForgeLayoutContentProps) {
@@ -220,6 +299,12 @@ ForgeLayout.Header = ForgeLayoutHeader;
  * Represents the controls of a `<ForgeLayout />`.
  */
 ForgeLayout.Controls = ForgeLayoutControls;
+
+/**
+ * Represents a control for toggling the nav between its expanded and rail
+ * states in a `<ForgeLayout />`.
+ */
+ForgeLayout.NavToggle = ForgeLayoutNavToggle;
 
 /**
  * Represents the breadcrumbs and navigation in a `<ForgeLayout />`.

--- a/easy-ui-react/src/ForgeLayout/ForgeLayoutControls.tsx
+++ b/easy-ui-react/src/ForgeLayout/ForgeLayoutControls.tsx
@@ -4,7 +4,7 @@ import ArrowBackIcon from "@easypost/easy-ui-icons/ArrowBack";
 import SearchIcon from "@easypost/easy-ui-icons/Search";
 import ExpandMoreIcon400 from "@easypost/easy-ui-icons/ExpandMore400";
 import { useForgeLayout } from "./ForgeLayout";
-import type { NavState } from "./ForgeLayout";
+import type { NavState, NavVisibilityState } from "./ForgeLayout";
 import { useForgeLayoutHeader } from "./ForgeLayoutHeader";
 import { UnstyledButton } from "../UnstyledButton";
 import type { UnstyledButtonProps } from "../UnstyledButton";
@@ -37,17 +37,28 @@ export type ForgeLayoutControlsProps = {
   /**
    * Display state of the nav menu for when these controls show.
    *
+   * A railed nav is treated as `expanded` here, since railing the nav is a
+   * nav-only concern and shouldn't change what the header holds.
+   *
    * @default expanded
    */
-  visibleWhenNavStateIs?: NavState;
+  visibleWhenNavStateIs?: NavVisibilityState;
 };
+
+/**
+ * Resolves a nav state down to the states controls can be gated on, so a
+ * railed nav keeps whatever the header shows when expanded.
+ */
+function toNavVisibilityState(navState: NavState): NavVisibilityState {
+  return navState === "rail" ? "expanded" : navState;
+}
 
 export function ForgeLayoutControls(props: ForgeLayoutControlsProps) {
   const { navState } = useForgeLayout();
   const { areControlsGrouped } = useForgeLayoutHeader();
   const { children, visibleWhenNavStateIs = "expanded" } = props;
 
-  if (navState !== visibleWhenNavStateIs) {
+  if (toNavVisibilityState(navState) !== visibleWhenNavStateIs) {
     return null;
   }
 

--- a/easy-ui-react/src/ForgeLayout/ForgeLayoutNav.module.scss
+++ b/easy-ui-react/src/ForgeLayout/ForgeLayoutNav.module.scss
@@ -13,6 +13,48 @@
   z-index: calc(#{design-token("z-index.nav")} + 1);
 }
 
+/**
+ * The rail takes no explicit width. With labels hidden, the logo narrowed to
+ * its glyph, and section titles replaced by rules, every child is one icon
+ * wide, so the card sizes itself to the icon plus its existing padding.
+ */
+.navRail {
+  flex: none;
+}
+
+/**
+ * Sizes the glyph to a nav icon, so it and the links form a single column and
+ * nothing is left to center within the rail. The glyph's `viewBox` is square to
+ * match, which scales the artwork uniformly, and carries the offset that centers
+ * the artwork within the box.
+ */
+.logoGlyph {
+  width: design-token("size.icon.md");
+  height: design-token("size.icon.md");
+}
+
+/**
+ * Stands in for the section title, which `visually-hidden` takes out of flow
+ * entirely. Matching the title's line height keeps the links below it at the
+ * same position across nav states.
+ */
+.divider {
+  align-self: stretch;
+  display: flex;
+  align-items: center;
+  height: design-token("font.style.overline.line_height");
+}
+
+.divider::before {
+  content: "";
+  flex: 1;
+  // Reaches halfway into the card's padding, so the rule reads as a break
+  // across the rail while staying clear of its border.
+  margin-inline: calc(#{design-token("space.1")} * -1);
+  height: design-token("shape.border_width.1");
+  background-color: design-token("color.neutral.200");
+}
+
 .link {
   display: inline-flex;
   align-items: center;
@@ -20,6 +62,30 @@
   color: design-token("color.primary.700");
   gap: design-token("space.1");
   outline: none;
+}
+
+.linkRail {
+  position: relative;
+  gap: 0;
+  justify-content: center;
+}
+
+.badgeContainer {
+  display: inline-flex;
+  /**
+   * The link's gap lands on the badge's anchor, and badges built to overlay
+   * something straddle that anchor rather than following it. A second step of
+   * the same size gives the label the clearance it has from its icon.
+   *
+   * Inert when railed, where the badge is placed off `right` instead.
+   */
+  margin-inline-start: design-token("space.1");
+}
+
+.badgeContainerRail {
+  position: absolute;
+  top: calc(#{design-token("space.0.5")} * -1);
+  right: calc(#{design-token("space.0.5")} * -1);
 }
 
 .focused {

--- a/easy-ui-react/src/ForgeLayout/ForgeLayoutNav.tsx
+++ b/easy-ui-react/src/ForgeLayout/ForgeLayoutNav.tsx
@@ -1,4 +1,12 @@
-import React, { ReactNode, useContext, useMemo, useRef } from "react";
+import { mergeRefs, useObjectRef } from "@react-aria/utils";
+import omit from "lodash/omit";
+import React, {
+  ReactNode,
+  forwardRef,
+  useContext,
+  useMemo,
+  useRef,
+} from "react";
 import {
   AriaLinkOptions,
   mergeProps,
@@ -6,14 +14,30 @@ import {
   useHover,
   useLink,
 } from "react-aria";
+import { omitReactAriaSpecificProps } from "../Button/utilities";
 import { Icon } from "../Icon";
 import { Text } from "../Text";
+import { Tooltip } from "../Tooltip";
 import { VerticalStack } from "../VerticalStack";
 import { IconSymbol } from "../types";
 import { classNames } from "../utilities/css";
+import type { NavState } from "./ForgeLayout";
+import { useForgeLayout } from "./ForgeLayout";
 
 import styles from "./ForgeLayoutNav.module.scss";
-import { useForgeLayout } from "./ForgeLayout";
+
+const RAIL_TOOLTIP_PLACEMENT = "right";
+
+const WORDMARK_WIDTH = 95;
+
+/**
+ * The mark's artwork spans x 0.036–21.036, sitting flush against the wordmark's
+ * left edge rather than centered in a box of its own. Both logo variants shift
+ * their viewBox window left by the remainder of an icon-sized column, halved, so
+ * the mark centers on the nav's icon column the way a nav icon does — and stays
+ * put when the nav rails.
+ */
+const MARK_CENTERING_OFFSET = 1.464;
 
 export type ForgeLayoutNavProps = {
   /**
@@ -26,12 +50,23 @@ export type ForgeLayoutNavProps = {
   /** Selected href of sidebar nav link. */
   selectedHref?: AriaLinkOptions["href"];
 
+  /**
+   * Renders the logo at the top of the nav. Receives the current nav state so
+   * a product can supply its own glyph for the `rail` state.
+   *
+   * Defaults to the EasyPost logo, narrowed to its glyph when railed.
+   */
+  renderLogo?: (args: { navState: NavState }) => ReactNode;
+
   /** Multipage container children. */
   children: ReactNode;
 };
 
 export type ForgeLayoutNavSectionProps = {
-  /** Sidebar nav section title. */
+  /**
+   * Sidebar nav section title. Rendered for assistive technology only when
+   * the nav is railed, where a divider takes its place visually.
+   */
   title: ReactNode;
 
   /** Sidebar nav section children. */
@@ -41,6 +76,25 @@ export type ForgeLayoutNavSectionProps = {
 export type ForgeLayoutNavLinkProps = {
   /** Nav link icon symbol. */
   iconSymbol: IconSymbol;
+
+  /**
+   * Plain text label for the link.
+   *
+   * Required for a tooltip when the nav is railed. Falls back to `children`
+   * when those are a plain string, so this is only needed for links whose
+   * children render more than text.
+   */
+  label?: string;
+
+  /**
+   * Renders a badge for the link. Badges stay visible when the nav is railed,
+   * overlaying the icon, so use this rather than embedding a badge in
+   * `children`.
+   *
+   * Receives the current nav state, so a product can trade a labeled badge for
+   * a plain dot once there's only an icon to sit on.
+   */
+  renderBadge?: (args: { navState: NavState }) => ReactNode;
 
   /** Nav link children. */
   children: ReactNode;
@@ -62,8 +116,8 @@ export const useForgeLayoutNav = () => {
 };
 
 export function ForgeLayoutNav(props: ForgeLayoutNavProps) {
-  const { navState = "expanded" } = useForgeLayout();
-  const { selectedHref, title = "Main", children } = props;
+  const { navState, navId } = useForgeLayout();
+  const { selectedHref, title = "Main", renderLogo, children } = props;
   const context = useMemo(() => {
     return { selectedHref };
   }, [selectedHref]);
@@ -72,11 +126,27 @@ export function ForgeLayoutNav(props: ForgeLayoutNavProps) {
     return null;
   }
 
+  const isRail = navState === "rail";
+
   return (
     <ForgeLayoutNavContext.Provider value={context}>
-      <div className={styles.nav}>
-        <VerticalStack as="nav" aria-label={title} gap="1" inlineAlign="start">
-          <Logo />
+      {/* The id lives on the container rather than the `nav` element because the
+          container is the region a nav toggle shows and hides. */}
+      <div
+        id={navId}
+        className={classNames(styles.nav, isRail && styles.navRail)}
+      >
+        <VerticalStack
+          as="nav"
+          aria-label={title}
+          gap="1"
+          inlineAlign={isRail ? "center" : "start"}
+        >
+          {renderLogo ? (
+            renderLogo({ navState })
+          ) : (
+            <Logo isGlyphOnly={isRail} />
+          )}
           {children}
         </VerticalStack>
       </div>
@@ -85,10 +155,15 @@ export function ForgeLayoutNav(props: ForgeLayoutNavProps) {
 }
 
 export function ForgeLayoutNavSection(props: ForgeLayoutNavSectionProps) {
+  const { navState } = useForgeLayout();
   const { title, children } = props;
+  const isRail = navState === "rail";
   return (
-    <VerticalStack gap="1" inlineAlign="start">
-      <Text variant="overline" color="primary.600">
+    <VerticalStack gap="1" inlineAlign={isRail ? "center" : "start"}>
+      {/* A rail has no room for the title, so a rule carries the grouping
+          visually while the title stays available to assistive technology. */}
+      {isRail && <div className={styles.divider} aria-hidden="true" />}
+      <Text variant="overline" color="primary.600" visuallyHidden={isRail}>
         {title}
       </Text>
       {children}
@@ -97,16 +172,55 @@ export function ForgeLayoutNavSection(props: ForgeLayoutNavSectionProps) {
 }
 
 export function ForgeLayoutNavLink(props: ForgeLayoutNavLinkProps) {
-  const { href, iconSymbol, children } = props;
-  const { selectedHref } = useForgeLayoutNav();
+  const { navState } = useForgeLayout();
+  const { label, children } = props;
 
-  const ref = useRef(null);
+  if (navState !== "rail") {
+    return <ForgeLayoutNavLinkAnchor {...props} />;
+  }
+
+  const tooltipContent =
+    label ?? (typeof children === "string" ? children : null);
+
+  // Without plain text to show, a tooltip would have nothing to render. The
+  // link keeps its accessible name either way.
+  if (!tooltipContent) {
+    return <ForgeLayoutNavLinkAnchor {...props} />;
+  }
+
+  return (
+    <Tooltip content={tooltipContent} placement={RAIL_TOOLTIP_PLACEMENT}>
+      <ForgeLayoutNavLinkAnchor {...props} />
+    </Tooltip>
+  );
+}
+
+/**
+ * The anchor behind a `ForgeLayoutNavLink`.
+ *
+ * @remarks
+ * Split out as a `forwardRef` component so `Tooltip` can attach its trigger
+ * ref without displacing the ref `useLink` needs.
+ */
+const ForgeLayoutNavLinkAnchor = forwardRef<
+  HTMLAnchorElement,
+  ForgeLayoutNavLinkProps
+>((props, inRef) => {
+  const { href, iconSymbol, label, renderBadge, children, ...restProps } =
+    props;
+  const { navState } = useForgeLayout();
+  const { selectedHref } = useForgeLayoutNav();
+  const isRail = navState === "rail";
+
+  const localRef = useRef(null);
+  const ref = useObjectRef(mergeRefs(localRef, inRef));
   const { linkProps } = useLink(props, ref);
   const { focusProps, isFocusVisible } = useFocusRing(props);
   const { hoverProps, isHovered } = useHover(props);
   const isSelected = href === selectedHref;
   const className = classNames(
     styles.link,
+    isRail && styles.linkRail,
     isFocusVisible && styles.focused,
     isHovered && styles.hovered,
     isSelected && styles.selected,
@@ -115,46 +229,142 @@ export function ForgeLayoutNavLink(props: ForgeLayoutNavLinkProps) {
     <a
       ref={ref}
       className={className}
-      {...mergeProps(hoverProps, focusProps, linkProps)}
+      {...mergeProps(
+        hoverProps,
+        focusProps,
+        linkProps,
+        omitNavLinkProps(restProps),
+      )}
       aria-current={isSelected ? "page" : undefined}
     >
       <Icon symbol={iconSymbol} />
-      <Text variant="subtitle2">{children}</Text>
+      {isRail ? (
+        // The label still names the link; the tooltip only makes it visible.
+        <Text visuallyHidden>{label ?? children}</Text>
+      ) : (
+        <Text variant="subtitle2">{children}</Text>
+      )}
+      {renderBadge && (
+        <div
+          className={classNames(
+            styles.badgeContainer,
+            isRail && styles.badgeContainerRail,
+          )}
+        >
+          {renderBadge({ navState })}
+        </div>
+      )}
     </a>
   );
+});
+
+ForgeLayoutNavLinkAnchor.displayName = "ForgeLayoutNavLinkAnchor";
+
+/**
+ * Every prop `useLink` folds into `linkProps` itself, plus its react-aria-only
+ * options.
+ */
+const USE_LINK_PROPS = [
+  // FocusableProps
+  "autoFocus",
+  "onFocus",
+  "onBlur",
+  "onFocusChange",
+  "onKeyDown",
+  "onKeyUp",
+  // LinkDOMProps
+  "href",
+  "hrefLang",
+  "target",
+  "rel",
+  "download",
+  "ping",
+  "referrerPolicy",
+  "routerOptions",
+  // AriaLinkOptions
+  "isDisabled",
+  "elementType",
+];
+
+/**
+ * Narrows the props forwarded to the anchor down to what `Tooltip` injects into
+ * its trigger, such as pointer handlers and `aria-describedby`.
+ *
+ * @remarks
+ * `useLink` already carries the rest, so forwarding them again would double up
+ * event handlers. Some, like `routerOptions`, aren't valid DOM attributes
+ * either.
+ */
+function omitNavLinkProps(props: object) {
+  return omit(omitReactAriaSpecificProps(props), USE_LINK_PROPS);
 }
 
-function Logo() {
+function Logo({ isGlyphOnly = false }: { isGlyphOnly?: boolean }) {
+  const glyph = (
+    <path
+      d="M21.036 17.22v-1.548l-10.037 5.851a.919.919 0 0 1-.927 0l-4.786-2.79v-2.448l4.786 2.79c.287.167.64.167.927 0l10.037-5.85v-2.448l-10.037 5.85a.919.919 0 0 1-.927 0l-4.786-2.79V11.39l4.786 2.79c.287.167.64.167.927 0l10.037-5.851V6.78a1.56 1.56 0 0 0-.772-1.35L11.308.209a1.528 1.528 0 0 0-1.543 0L.808 5.43a1.56 1.56 0 0 0-.772 1.35v10.44c0 .557.294 1.072.772 1.35l8.956 5.22a1.528 1.528 0 0 0 1.543 0l8.956-5.22a1.56 1.56 0 0 0 .772-1.35h.001z"
+      fill="url(#paint0_linear_1141_3360)"
+    />
+  );
+  const gradient = (
+    <linearGradient
+      id="paint0_linear_1141_3360"
+      x1="2.381"
+      y1="20.234"
+      x2="18.847"
+      y2="3.923"
+      gradientUnits="userSpaceOnUse"
+    >
+      <stop stopColor="#BC4543" />
+      <stop offset=".5" stopColor="#F95C59" />
+      <stop offset=".59" stopColor="#F86059" />
+      <stop offset=".68" stopColor="#F86C59" />
+      <stop offset=".78" stopColor="#F7815A" />
+      <stop offset=".87" stopColor="#F69E5B" />
+      <stop offset=".97" stopColor="#F4C35D" />
+      <stop offset="1" stopColor="#F4D35E" />
+    </linearGradient>
+  );
+
+  // The glyph occupies the leading units of the wordmark, so the rail reuses the
+  // same artwork with a narrowed viewBox rather than a separate asset. The
+  // viewBox is square so it shares the aspect ratio of the icon-sized box
+  // `.logoGlyph` gives it and the artwork scales uniformly.
+  if (isGlyphOnly) {
+    return (
+      <svg
+        className={styles.logoGlyph}
+        viewBox={`${-MARK_CENTERING_OFFSET} 0 24 24`}
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        {glyph}
+        <defs>{gradient}</defs>
+      </svg>
+    );
+  }
+
+  // Widening by the same offset keeps the window's right edge, and so the
+  // lockup's own spacing, exactly where it was.
   return (
-    <svg width="95" height="24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg
+      width={WORDMARK_WIDTH + MARK_CENTERING_OFFSET}
+      height="24"
+      viewBox={`${-MARK_CENTERING_OFFSET} 0 ${
+        WORDMARK_WIDTH + MARK_CENTERING_OFFSET
+      } 24`}
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
       <g clipPath="url(#clip0_1141_3360)">
-        <path
-          d="M21.036 17.22v-1.548l-10.037 5.851a.919.919 0 0 1-.927 0l-4.786-2.79v-2.448l4.786 2.79c.287.167.64.167.927 0l10.037-5.85v-2.448l-10.037 5.85a.919.919 0 0 1-.927 0l-4.786-2.79V11.39l4.786 2.79c.287.167.64.167.927 0l10.037-5.851V6.78a1.56 1.56 0 0 0-.772-1.35L11.308.209a1.528 1.528 0 0 0-1.543 0L.808 5.43a1.56 1.56 0 0 0-.772 1.35v10.44c0 .557.294 1.072.772 1.35l8.956 5.22a1.528 1.528 0 0 0 1.543 0l8.956-5.22a1.56 1.56 0 0 0 .772-1.35h.001z"
-          fill="url(#paint0_linear_1141_3360)"
-        />
+        {glyph}
         <path
           d="M33.126 8.058v2.762h3.907v1.788h-3.907v4.725H31V6.16h6.868v1.9h-4.742zm20.575 3.689c0 3.384-2.678 5.746-5.703 5.746-3.024 0-5.702-2.362-5.702-5.746C42.296 8.363 44.974 6 47.998 6c3.025 0 5.703 2.363 5.703 5.747zm-2.158 0c0-2.203-1.622-3.784-3.545-3.784-1.922 0-3.56 1.58-3.56 3.784 0 2.204 1.622 3.784 3.56 3.784 1.939 0 3.545-1.58 3.545-3.784zm13.642 5.586l-2.457-3.8h-1.827v3.8h-2.064V6.16h3.797c2.473 0 4.033 1.532 4.033 3.752 0 1.548-.757 2.698-2.048 3.257l2.757 4.167h-2.19l-.001-.002zm-4.286-5.604h1.622c1.245 0 2.08-.543 2.08-1.82 0-1.276-.835-1.82-2.08-1.82H60.9v3.64zm16.134 5.764c-3.089 0-5.702-2.362-5.702-5.746C71.33 8.363 74.008 6 77.033 6c1.434 0 2.725.48 3.685 1.324l-1.244 1.437c-.63-.48-1.465-.798-2.316-.798-2.064 0-3.687 1.58-3.687 3.784 0 2.204 1.544 3.784 3.592 3.784 1.528 0 2.71-.67 3.008-2.427h-2.756v-1.74h4.648c.457 3.816-1.986 6.13-4.932 6.13h.002zM94 15.402v1.932h-6.868V6.16h6.727v1.931h-4.664v2.682h3.545v1.883h-3.545v2.746H94z"
           fill="#061340"
         />
       </g>
       <defs>
-        <linearGradient
-          id="paint0_linear_1141_3360"
-          x1="2.381"
-          y1="20.234"
-          x2="18.847"
-          y2="3.923"
-          gradientUnits="userSpaceOnUse"
-        >
-          <stop stopColor="#BC4543" />
-          <stop offset=".5" stopColor="#F95C59" />
-          <stop offset=".59" stopColor="#F86059" />
-          <stop offset=".68" stopColor="#F86C59" />
-          <stop offset=".78" stopColor="#F7815A" />
-          <stop offset=".87" stopColor="#F69E5B" />
-          <stop offset=".97" stopColor="#F4C35D" />
-          <stop offset="1" stopColor="#F4D35E" />
-        </linearGradient>
+        {gradient}
         <clipPath id="clip0_1141_3360">
           <path fill="#fff" d="M0 0H95V24H0z" />
         </clipPath>

--- a/easy-ui-react/src/ForgeLayout/ForgeLayoutNav.tsx
+++ b/easy-ui-react/src/ForgeLayout/ForgeLayoutNav.tsx
@@ -1,12 +1,5 @@
-import { mergeRefs, useObjectRef } from "@react-aria/utils";
-import omit from "lodash/omit";
-import React, {
-  ReactNode,
-  forwardRef,
-  useContext,
-  useMemo,
-  useRef,
-} from "react";
+import { useObjectRef } from "@react-aria/utils";
+import React, { ReactNode, forwardRef, useContext, useMemo } from "react";
 import {
   AriaLinkOptions,
   mergeProps,
@@ -14,7 +7,6 @@ import {
   useHover,
   useLink,
 } from "react-aria";
-import { omitReactAriaSpecificProps } from "../Button/utilities";
 import { Icon } from "../Icon";
 import { Text } from "../Text";
 import { Tooltip } from "../Tooltip";
@@ -176,7 +168,7 @@ export function ForgeLayoutNavLink(props: ForgeLayoutNavLinkProps) {
   const { label, children } = props;
 
   if (navState !== "rail") {
-    return <ForgeLayoutNavLinkAnchor {...props} />;
+    return <ForgeLayoutNavLinkAnchor navLinkProps={props} />;
   }
 
   const tooltipContent =
@@ -185,12 +177,12 @@ export function ForgeLayoutNavLink(props: ForgeLayoutNavLinkProps) {
   // Without plain text to show, a tooltip would have nothing to render. The
   // link keeps its accessible name either way.
   if (!tooltipContent) {
-    return <ForgeLayoutNavLinkAnchor {...props} />;
+    return <ForgeLayoutNavLinkAnchor navLinkProps={props} />;
   }
 
   return (
     <Tooltip content={tooltipContent} placement={RAIL_TOOLTIP_PLACEMENT}>
-      <ForgeLayoutNavLinkAnchor {...props} />
+      <ForgeLayoutNavLinkAnchor navLinkProps={props} />
     </Tooltip>
   );
 }
@@ -201,22 +193,26 @@ export function ForgeLayoutNavLink(props: ForgeLayoutNavLinkProps) {
  * @remarks
  * Split out as a `forwardRef` component so `Tooltip` can attach its trigger
  * ref without displacing the ref `useLink` needs.
+ *
+ * The nav link's own props arrive under `navLinkProps` rather than spread, so
+ * that anything `Tooltip` injects into its trigger lands in `triggerProps`
+ * instead. Keeping the two apart means `useLink` owns the nav link's props
+ * outright and only the tooltip's props are forwarded to the anchor, so no
+ * handler can be applied twice.
  */
 const ForgeLayoutNavLinkAnchor = forwardRef<
   HTMLAnchorElement,
-  ForgeLayoutNavLinkProps
->((props, inRef) => {
-  const { href, iconSymbol, label, renderBadge, children, ...restProps } =
-    props;
+  { navLinkProps: ForgeLayoutNavLinkProps }
+>(({ navLinkProps, ...triggerProps }, inRef) => {
+  const { href, iconSymbol, label, renderBadge, children } = navLinkProps;
   const { navState } = useForgeLayout();
   const { selectedHref } = useForgeLayoutNav();
   const isRail = navState === "rail";
 
-  const localRef = useRef(null);
-  const ref = useObjectRef(mergeRefs(localRef, inRef));
-  const { linkProps } = useLink(props, ref);
-  const { focusProps, isFocusVisible } = useFocusRing(props);
-  const { hoverProps, isHovered } = useHover(props);
+  const ref = useObjectRef(inRef);
+  const { linkProps } = useLink(navLinkProps, ref);
+  const { focusProps, isFocusVisible } = useFocusRing(navLinkProps);
+  const { hoverProps, isHovered } = useHover(navLinkProps);
   const isSelected = href === selectedHref;
   const className = classNames(
     styles.link,
@@ -229,12 +225,7 @@ const ForgeLayoutNavLinkAnchor = forwardRef<
     <a
       ref={ref}
       className={className}
-      {...mergeProps(
-        hoverProps,
-        focusProps,
-        linkProps,
-        omitNavLinkProps(restProps),
-      )}
+      {...mergeProps(hoverProps, focusProps, linkProps, triggerProps)}
       aria-current={isSelected ? "page" : undefined}
     >
       <Icon symbol={iconSymbol} />
@@ -259,45 +250,6 @@ const ForgeLayoutNavLinkAnchor = forwardRef<
 });
 
 ForgeLayoutNavLinkAnchor.displayName = "ForgeLayoutNavLinkAnchor";
-
-/**
- * Every prop `useLink` folds into `linkProps` itself, plus its react-aria-only
- * options.
- */
-const USE_LINK_PROPS = [
-  // FocusableProps
-  "autoFocus",
-  "onFocus",
-  "onBlur",
-  "onFocusChange",
-  "onKeyDown",
-  "onKeyUp",
-  // LinkDOMProps
-  "href",
-  "hrefLang",
-  "target",
-  "rel",
-  "download",
-  "ping",
-  "referrerPolicy",
-  "routerOptions",
-  // AriaLinkOptions
-  "isDisabled",
-  "elementType",
-];
-
-/**
- * Narrows the props forwarded to the anchor down to what `Tooltip` injects into
- * its trigger, such as pointer handlers and `aria-describedby`.
- *
- * @remarks
- * `useLink` already carries the rest, so forwarding them again would double up
- * event handlers. Some, like `routerOptions`, aren't valid DOM attributes
- * either.
- */
-function omitNavLinkProps(props: object) {
-  return omit(omitReactAriaSpecificProps(props), USE_LINK_PROPS);
-}
 
 function Logo({ isGlyphOnly = false }: { isGlyphOnly?: boolean }) {
   const glyph = (

--- a/easy-ui-react/src/ForgeLayout/ForgeLayoutNavToggle.module.scss
+++ b/easy-ui-react/src/ForgeLayout/ForgeLayoutNavToggle.module.scss
@@ -1,0 +1,25 @@
+@use "../styles/common" as *;
+
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+
+  color: design-token("color.primary.600");
+  border-radius: design-token("shape.border_radius.md");
+  padding: design-token("space.0.5");
+  cursor: pointer;
+  outline: none;
+
+  // Sits above the header background decoration, matching the other controls.
+  z-index: design-token("z-index.nav");
+}
+
+.hovered {
+  background-color: design-token("color.neutral.050");
+}
+
+.focused {
+  @include native-focus-ring;
+}

--- a/easy-ui-react/src/ForgeLayout/ForgeLayoutNavToggle.tsx
+++ b/easy-ui-react/src/ForgeLayout/ForgeLayoutNavToggle.tsx
@@ -1,0 +1,87 @@
+import LeftPanelCloseIcon from "@easypost/easy-ui-icons/LeftPanelClose";
+import LeftPanelOpenIcon from "@easypost/easy-ui-icons/LeftPanelOpen";
+import React, { useCallback } from "react";
+import { mergeProps, useFocusRing, useHover } from "react-aria";
+import { Icon } from "../Icon";
+import { Text } from "../Text";
+import { UnstyledButton } from "../UnstyledButton";
+import type { UnstyledButtonProps } from "../UnstyledButton";
+import { classNames } from "../utilities/css";
+import { useForgeLayout } from "./ForgeLayout";
+
+import styles from "./ForgeLayoutNavToggle.module.scss";
+
+const COLLAPSE_LABEL = "Collapse navigation";
+const EXPAND_LABEL = "Expand navigation";
+
+export type ForgeLayoutNavToggleProps = Omit<
+  UnstyledButtonProps,
+  "children" | "href" | "className"
+> & {
+  /**
+   * Custom accessibility label describing the toggle. Defaults to
+   * "Collapse navigation" or "Expand navigation" depending on the nav state.
+   */
+  accessibilityLabel?: string;
+};
+
+/**
+ * Toggles a `<ForgeLayout />` nav between its `expanded` and `rail` states.
+ *
+ * @remarks
+ * This is a standalone primitive rather than something the layout renders on
+ * its own, so it can be placed wherever a product needs it—typically at the
+ * start of a `ForgeLayout.Controls`. It renders nothing when the nav is
+ * `collapsed`, since there is no nav to toggle.
+ *
+ * Nav state changes are reported through `ForgeLayout`'s `onNavStateChange`.
+ * Persisting the state across sessions is left to the consuming application.
+ *
+ * @example
+ * ```tsx
+ * <ForgeLayout.Controls visibleWhenNavStateIs="expanded">
+ *   <ForgeLayout.NavToggle />
+ *   <ForgeLayout.ModeSwitcher onModeChange={() => {}} />
+ * </ForgeLayout.Controls>
+ * ```
+ */
+export function ForgeLayoutNavToggle(props: ForgeLayoutNavToggleProps) {
+  const { accessibilityLabel, ...buttonProps } = props;
+  const { navState, setNavState, navId } = useForgeLayout();
+  const { focusProps, isFocusVisible } = useFocusRing(props);
+  const { hoverProps, isHovered } = useHover(props);
+  const isExpanded = navState === "expanded";
+
+  const handlePress = useCallback(() => {
+    setNavState(isExpanded ? "rail" : "expanded");
+  }, [isExpanded, setNavState]);
+
+  // There is no nav to toggle when it has been removed from the layout.
+  if (navState === "collapsed") {
+    return null;
+  }
+
+  const label =
+    accessibilityLabel ?? (isExpanded ? COLLAPSE_LABEL : EXPAND_LABEL);
+  const className = classNames(
+    styles.toggle,
+    isFocusVisible && styles.focused,
+    isHovered && styles.hovered,
+  );
+
+  return (
+    <UnstyledButton
+      // `mergeProps` chains handlers, so a supplied `onPress` runs alongside
+      // the state change rather than replacing it.
+      {...mergeProps(buttonProps, hoverProps, focusProps, {
+        onPress: handlePress,
+      })}
+      className={className}
+      aria-expanded={isExpanded}
+      aria-controls={navId}
+    >
+      <Text visuallyHidden>{label}</Text>
+      <Icon symbol={isExpanded ? LeftPanelCloseIcon : LeftPanelOpenIcon} />
+    </UnstyledButton>
+  );
+}


### PR DESCRIPTION
## Changes

<img width="auto" height="360" alt="image" src="https://github.com/user-attachments/assets/01c4cf01-3ce2-4ae0-a65f-6b9de77c5a6e" />

<img width="auto" height="360" alt="image" src="https://github.com/user-attachments/assets/df49dffa-efb1-441b-af23-a94fe72276db" />

Adds a third `navState`, `rail`, for a narrow icon-only nav. Design calls this state "Collapsed", but `collapsed` already means the nav is gone, so the new value takes a distinct name and leaves the existing two alone.

- `ForgeLayout.NavToggle` is a standalone control the consumer places wherever it wants, so nav-state persistence stays out of the library.
- `navState`/`defaultNavState`/`onNavStateChange` support both controlled and uncontrolled use.
- `ForgeLayout.NavLink` gains `label` for a railed tooltip and `renderBadge` so a badge survives the label going away.
- `ForgeLayout.Nav` gains `renderLogo`, letting a product supply its own glyph for the rail.
- `ForgeLayout.Controls` treats `rail` as `expanded`, so railing the nav doesn't disturb the header.

Adds LeftPanelClose and LeftPanelOpen icons for the toggle.

## ✅ Checklist

Easy UI has certain UX standards that must be met. In general, non-trivial changes should meet the following criteria:

- [x] Visuals match Design Specs in Figma
- [x] Stories accompany any component changes
- [x] Code is in accordance with our style guide
- [x] Design tokens are utilized
- [x] Unit tests accompany any component changes
- [x] TSDoc is written for any API surface area
- [x] Specs are up-to-date
- [x] Console is free from warnings
- [x] No accessibility violations are reported
- [x] Cross-browser check is performed (Chrome, Safari, Firefox)
- [x] Changeset is added

~Strikethrough~ any items that are not applicable to this pull request.
