### PR TITLE
fix(Modal): paint header and footer scroll shadows above body content

### DIFF
--- a/.changeset/soft-shadows-layer.md
+++ b/.changeset/soft-shadows-layer.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+Fix `Modal` and `Drawer` scroll shadows being painted underneath body content

--- a/easy-ui-react/src/Drawer/Drawer.module.scss
+++ b/easy-ui-react/src/Drawer/Drawer.module.scss
@@ -87,6 +87,13 @@
 
 .header {
   margin: 0;
+
+  // the body is positioned (for its intersection interceptor), which paints it
+  // above static siblings. position the header too, on a higher layer, so its
+  // scroll shadow lands on top of the body instead of under it
+  position: relative;
+  z-index: 1;
+
   &.stuck {
     box-shadow: design-token("shadow.stuck-from-top");
   }

--- a/easy-ui-react/src/Modal/Modal.module.scss
+++ b/easy-ui-react/src/Modal/Modal.module.scss
@@ -67,6 +67,13 @@
   padding: design-token("space.5");
   padding-bottom: design-token("space.2");
   color: design-token("color.primary.800");
+
+  // the body's content is positioned (for its intersection interceptors), which
+  // paints it above static siblings. position the header too, on a higher
+  // layer, so its scroll shadow lands on top of the body instead of under it
+  position: relative;
+  z-index: 1;
+
   &.stuck {
     box-shadow: design-token("shadow.stuck-from-top");
   }
@@ -100,6 +107,10 @@
 .footer {
   padding: design-token("space.5");
   padding-top: design-token("space.3");
+
+  // see `.header`—keeps the scroll shadow above the body's content
+  position: relative;
+  z-index: 1;
 
   &.stuck {
     box-shadow: design-token("shadow.stuck-from-bottom");

--- a/easy-ui-react/src/Modal/Modal.stories.tsx
+++ b/easy-ui-react/src/Modal/Modal.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react-vite";
-import React, { Key, useRef, useState } from "react";
+import React, { Key, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { action } from "storybook/actions";
 import { Button } from "../Button";
@@ -493,6 +493,65 @@ export const WithSelect: ModalStory = {
     </Modal.Trigger>
   ),
 };
+
+/**
+ * When the body scrolls, the header and footer grow a shadow to separate them
+ * from the scrolling content. Those shadows must paint *above* the body, which
+ * is easy to get wrong—the body's content is positioned, so it can cover them.
+ *
+ * This story fills the body with opaque, full-bleed content and opens
+ * mid-scroll, so both shadows are stuck at once and land directly over that
+ * content. The shadows should read as two unbroken lines; if the body paints
+ * over them, they disappear behind the gray blocks and the white `Select`.
+ */
+export const ScrollShadows: ModalStory = {
+  render: () => (
+    <Modal.Trigger defaultOpen>
+      <Button>Open modal</Button>
+      <Modal>
+        <Modal.Header>H4 Title</Modal.Header>
+        <Modal.Body>
+          <PlaceholderBox width="100%" height={300}>
+            Scroll up to bring the header shadow over this block
+          </PlaceholderBox>
+          <Select label="Select an option" placeholder="Select an option">
+            <Select.Option key="option1">Option 1</Select.Option>
+            <Select.Option key="option2">Option 2</Select.Option>
+          </Select>
+          <PlaceholderBox width="100%" height={300}>
+            <ScrollIntoView />
+            Both shadows should be visible over this block
+          </PlaceholderBox>
+          <Select label="Select an option" placeholder="Select an option">
+            <Select.Option key="option1">Option 1</Select.Option>
+            <Select.Option key="option2">Option 2</Select.Option>
+          </Select>
+          <PlaceholderBox width="100%" height={300}>
+            Scroll down to bring the footer shadow over this block
+          </PlaceholderBox>
+        </Modal.Body>
+        <Modal.Footer
+          primaryAction={{
+            content: "Button 1",
+            onAction: action("Button 1 clicked!"),
+          }}
+        />
+      </Modal>
+    </Modal.Trigger>
+  ),
+};
+
+/**
+ * Scrolls its scroll container so this point sits in the middle of it, putting
+ * the surrounding content under both the header and the footer.
+ */
+function ScrollIntoView() {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    ref.current?.scrollIntoView({ block: "center" });
+  }, []);
+  return <div ref={ref} />;
+}
 
 export const WithFooterSlot: ModalStory = {
   render: () => (


### PR DESCRIPTION
## 📝 Changes

Before:

<img width="823" height="237" alt="image" src="https://github.com/user-attachments/assets/4fa1ec67-8942-400b-9acc-7b12486ecc90" />

After:

<img width="845" height="230" alt="image" src="https://github.com/user-attachments/assets/b8a3e9b6-afbf-486e-9063-8858573bd1d3" />

The body's content wrapper is `position: relative` so it can anchor the intersection interceptors, which places the whole body subtree in the positioned paint layer—above the static header and footer. Since a `box-shadow` paints with its element's background, any opaque body content (a `Select`, a card) covered the stuck shadows.

Position the header and footer on a higher layer so their shadows land on top of the body. `Drawer` has the same defect, where the scrolling body itself is the positioned element, so it gets the same treatment.

Adds a `ScrollShadows` story that opens mid-scroll with opaque full-bleed body content, so both shadows are stuck at once and overlap it.

## ✅ Checklist

Easy UI has certain UX standards that must be met. In general, non-trivial changes should meet the following criteria:

- [x] Visuals match Design Specs in Figma
- [x] Stories accompany any component changes
- [x] Code is in accordance with our style guide
- [x] Design tokens are utilized
- [x] Unit tests accompany any component changes
- [x] TSDoc is written for any API surface area
- [x] Specs are up-to-date
- [x] Console is free from warnings
- [x] No accessibility violations are reported
- [x] Cross-browser check is performed (Chrome, Safari, Firefox)
- [x] Changeset is added

~Strikethrough~ any items that are not applicable to this pull request.
