### PR TITLE
feat: honor Provider's navigate prop in link components

### DIFF
--- a/.changeset/curly-lions-travel.md
+++ b/.changeset/curly-lions-travel.md
@@ -1,0 +1,30 @@
+---
+"@easypost/easy-ui": minor
+---
+
+Honor `<Provider navigate />` in components that render links
+
+`<Provider navigate useHref />` populates React Aria's router context, but most
+Easy UI components built their anchors with `useButton()` or by hand, neither of
+which reads that context. Those components did a full page load even when a
+`navigate` function was configured.
+
+`<Button />`, `<IconButton />`, `<DropdownButton />`, `<KebabButton />`,
+`<TabNav.Item />`, `<VerticalNav.Item />`, `<VerticalNav.Subnav.Item />`,
+`<VerticalNav.SupplementaryAction as="a" />`, and everything else built on
+`<UnstyledButton />` (`<PlanCard.Button />`, `<SearchNav />` CTAs,
+`<Pagination />`, `<ForgeLayout.BackButton />`) now navigate through the
+provider's `navigate` function and resolve their `href` through its `useHref`.
+`<Menu.Item href />` already navigated client-side, but rendered the unresolved
+`href`; it now respects `useHref` as well.
+
+These components also accept `routerOptions` for passing router-specific options
+through to `navigate`.
+
+This is backwards compatible. Without a `navigate` function React Aria's router
+context reports itself as native and the new click handling is a noop, so links
+behave exactly as before. Links to other origins, links with `target="_blank"`,
+download links, and modifier-clicked links continue to load normally even when a
+`navigate` function is configured. The `as`/`hrefComponent` props remain
+supported for components that need a specific link component, and take
+precedence over the provider's router.

--- a/.changeset/curly-lions-travel.md
+++ b/.changeset/curly-lions-travel.md
@@ -35,7 +35,8 @@ declare module "@react-types/shared" {
 Separately, `onClick` on `<Button />` and everything else built on
 `<UnstyledButton />` fired twice per click, because React Aria's `useButton()`
 already calls it and the original handler was spread onto the element alongside
-it. It now fires once.
+it. It now fires once, as a plain DOM handler, so `preventDefault()` reaches the
+real click on both pointer and keyboard activation.
 
 Apps that don't pass `navigate` are unaffected. React Aria's router context
 reports itself as native, the new click handling is a noop, and links behave
@@ -47,6 +48,12 @@ to `navigate`, so a link that has to reach the server—a download, a sign out, 
 path served by another app on the same origin—needs to say so. Links to other
 origins, links with `target="_blank"` or `download`, modifier-clicked links, and
 links whose `onClick` calls `preventDefault()` continue to load natively. So do
-disabled links, which render without an `href`. The `as`/`hrefComponent` props
-remain supported for components that need a specific link component, and take
-precedence over the provider's router.
+disabled links, which render without an `href`.
+
+The `as`/`hrefComponent` props remain supported for components that need a
+specific link component. On `<TabNav.Item />` and the `<VerticalNav />` items
+they take precedence over the provider's router, which is left out entirely.
+`<Menu.Item hrefComponent />` is the exception: it receives the `href` as
+written, but React Aria's menu item handles links internally and can't be opted
+out of, so the click reaches `navigate` as well. Pair it with a router rather
+than using it instead of one.

--- a/.changeset/curly-lions-travel.md
+++ b/.changeset/curly-lions-travel.md
@@ -21,6 +21,11 @@ provider's `navigate` function and resolve their `href` through its `useHref`.
 These components also accept `routerOptions` for passing router-specific options
 through to `navigate`.
 
+Separately, `onClick` on `<Button />` and everything else built on
+`<UnstyledButton />` fired twice per click, because React Aria's `useButton()`
+already calls it and the original handler was spread onto the element alongside
+it. It now fires once.
+
 Apps that don't pass `navigate` are unaffected. React Aria's router context
 reports itself as native, the new click handling is a noop, and links behave
 exactly as before.

--- a/.changeset/curly-lions-travel.md
+++ b/.changeset/curly-lions-travel.md
@@ -19,7 +19,18 @@ provider's `navigate` function and resolve their `href` through its `useHref`.
 `href`; it now respects `useHref` as well.
 
 These components also accept `routerOptions` for passing router-specific options
-through to `navigate`.
+through to `navigate`. Following React Aria, `routerOptions` is typed as `never`
+until an app declares what its router accepts:
+
+```tsx
+import type { NavigateOptions } from "react-router";
+
+declare module "@react-types/shared" {
+  interface RouterConfig {
+    routerOptions: NavigateOptions;
+  }
+}
+```
 
 Separately, `onClick` on `<Button />` and everything else built on
 `<UnstyledButton />` fired twice per click, because React Aria's `useButton()`

--- a/.changeset/curly-lions-travel.md
+++ b/.changeset/curly-lions-travel.md
@@ -35,8 +35,9 @@ declare module "@react-types/shared" {
 Separately, `onClick` on `<Button />` and everything else built on
 `<UnstyledButton />` fired twice per click, because React Aria's `useButton()`
 already calls it and the original handler was spread onto the element alongside
-it. It now fires once, as a plain DOM handler, so `preventDefault()` reaches the
-real click on both pointer and keyboard activation.
+it. It now fires exactly once per activation, pointer or keyboard. On links it
+stays a plain DOM handler, so `preventDefault()` reaches the real click the
+router reads.
 
 Apps that don't pass `navigate` are unaffected. React Aria's router context
 reports itself as native, the new click handling is a noop, and links behave

--- a/.changeset/curly-lions-travel.md
+++ b/.changeset/curly-lions-travel.md
@@ -21,10 +21,16 @@ provider's `navigate` function and resolve their `href` through its `useHref`.
 These components also accept `routerOptions` for passing router-specific options
 through to `navigate`.
 
-This is backwards compatible. Without a `navigate` function React Aria's router
-context reports itself as native and the new click handling is a noop, so links
-behave exactly as before. Links to other origins, links with `target="_blank"`,
-download links, and modifier-clicked links continue to load normally even when a
-`navigate` function is configured. The `as`/`hrefComponent` props remain
-supported for components that need a specific link component, and take
+Apps that don't pass `navigate` are unaffected. React Aria's router context
+reports itself as native, the new click handling is a noop, and links behave
+exactly as before.
+
+Apps that already pass `navigate` keep working, but the links listed above stop
+doing a full page load. Same-origin links, including hash-only ones, are handed
+to `navigate`, so a link that has to reach the server—a download, a sign out, a
+path served by another app on the same origin—needs to say so. Links to other
+origins, links with `target="_blank"` or `download`, modifier-clicked links, and
+links whose `onClick` calls `preventDefault()` continue to load natively. So do
+disabled links, which render without an `href`. The `as`/`hrefComponent` props
+remain supported for components that need a specific link component, and take
 precedence over the provider's router.

--- a/easy-ui-react/src/Button/Button.mdx
+++ b/easy-ui-react/src/Button/Button.mdx
@@ -56,6 +56,40 @@ Use `href` to for navigation.
 
 <Canvas of={ButtonStories.Href} />
 
+### Client-side routing
+
+Pass a `navigate` function to `<Provider />` and a `<Button />` with an `href`
+navigates through your app's router instead of doing a full page load. Links to
+other origins, links with `target="_blank"`, and modifier-clicked links continue
+to load normally.
+
+```tsx
+import { Provider as EasyUIProvider } from "@easypost/easy-ui/Provider";
+import { useNavigate, useHref } from "react-router";
+
+function App({ children }) {
+  return (
+    <EasyUIProvider navigate={useNavigate()} useHref={useHref}>
+      {children}
+    </EasyUIProvider>
+  );
+}
+
+// navigates client-side
+<Button href="/shipments">Shipments</Button>;
+
+// pass router-specific options through `routerOptions`
+<Button href="/shipments" routerOptions={{ replace: true }}>
+  Shipments
+</Button>;
+```
+
+The example below is wired to a fake router that records where it was asked to
+navigate rather than loading a page. The router also prepends `/base-path`
+through `useHref`, so each `href` in the markup is the one the router resolved.
+
+<Canvas of={ButtonStories.ClientSideRouting} />
+
 ## Small
 
 Use `size="sm"` to render a smaller `<Button />`.

--- a/easy-ui-react/src/Button/Button.mdx
+++ b/easy-ui-react/src/Button/Button.mdx
@@ -77,11 +77,30 @@ function App({ children }) {
 
 // navigates client-side
 <Button href="/shipments">Shipments</Button>;
+```
 
-// pass router-specific options through `routerOptions`
+To pass router-specific options through `routerOptions`, first tell TypeScript
+what your router accepts. `routerOptions` is typed as `never` until you declare
+it, since Easy UI can't know which router you're using. Add this once, anywhere
+in your app:
+
+```tsx
+import type { NavigateOptions } from "react-router";
+
+declare module "@react-types/shared" {
+  interface RouterConfig {
+    routerOptions: NavigateOptions;
+  }
+}
+```
+
+`routerOptions` is then typed as your router's options and handed to `navigate`
+as its second argument:
+
+```tsx
 <Button href="/shipments" routerOptions={{ replace: true }}>
   Shipments
-</Button>;
+</Button>
 ```
 
 The example below is wired to a fake router that records where it was asked to

--- a/easy-ui-react/src/Button/Button.stories.tsx
+++ b/easy-ui-react/src/Button/Button.stories.tsx
@@ -2,10 +2,13 @@ import AddIcon from "@easypost/easy-ui-icons/Add";
 import ArrowBackIcon from "@easypost/easy-ui-icons/ArrowBack";
 import CheckCircleIcon from "@easypost/easy-ui-icons/CheckCircle";
 import InfoIcon from "@easypost/easy-ui-icons/Info";
+import { RouterOptions } from "@react-types/shared";
 import { action } from "storybook/actions";
 import { Meta, StoryObj } from "@storybook/react-vite";
 import React from "react";
+import { HorizontalStack } from "../HorizontalStack";
 import {
+  FakeClientSideRouter,
   InlineStoryDecorator,
   InlineStoryOnDarkBackgroundDecorator,
   createLabelledOptionsControl,
@@ -17,6 +20,10 @@ import {
 import { Button, ButtonProps } from "./Button";
 
 type Story = StoryObj<typeof Button>;
+
+// React Aria resolves `RouterOptions` to `never` until an app augments
+// `RouterConfig` with its router's option type, so options need a cast here
+const replace = { replace: true } as unknown as RouterOptions;
 
 const Template = (args: ButtonProps) => <Button {...args} />;
 
@@ -113,6 +120,25 @@ export const Href: Story = {
     </>
   ),
   decorators: [InlineStoryDecorator],
+};
+
+export const ClientSideRouting: Story = {
+  render: () => (
+    <FakeClientSideRouter>
+      <HorizontalStack gap="2" wrap>
+        <Button href="/shipments">Shipments</Button>
+        <Button variant="outlined" href="/shipments" routerOptions={replace}>
+          Shipments, replacing history
+        </Button>
+        <Button variant="outlined" href="https://www.easypost.com/">
+          Another origin, loads normally
+        </Button>
+        <Button variant="outlined" href="/shipments" target="_blank">
+          New tab, loads normally
+        </Button>
+      </HorizontalStack>
+    </FakeClientSideRouter>
+  ),
 };
 
 export const Small: Story = {

--- a/easy-ui-react/src/Button/Button.tsx
+++ b/easy-ui-react/src/Button/Button.tsx
@@ -4,6 +4,7 @@ import { Icon } from "../Icon";
 import { IconSymbol } from "../types";
 import { classNames, variationName } from "../utilities/css";
 import { AriaButtonProps } from "react-aria";
+import { RouterLinkProps } from "../utilities/router";
 import { logWarningIfInvalidColorVariantCombination } from "./utilities";
 
 import styles from "./Button.module.scss";
@@ -20,26 +21,27 @@ export type ButtonColor =
 export type ButtonVariant = "filled" | "outlined" | "link" | "text";
 export type ButtonSize = "sm" | "md";
 
-export type ButtonProps = AriaButtonProps & {
-  /** Button color */
-  color?: ButtonColor;
-  /** Button variant */
-  variant?: ButtonVariant;
-  /** Button size */
-  size?: ButtonSize;
-  /** Disables button */
-  isDisabled?: boolean;
-  /** Button will grow to width of container */
-  isBlock?: boolean;
-  /** Positions icon symbol before children */
-  iconAtStart?: IconSymbol;
-  /** Positions icon symbol after children */
-  iconAtEnd?: IconSymbol;
-  /** Content inside button  */
-  children?: ReactNode;
-  /** Link's destination */
-  href?: string;
-};
+export type ButtonProps = AriaButtonProps &
+  RouterLinkProps & {
+    /** Button color */
+    color?: ButtonColor;
+    /** Button variant */
+    variant?: ButtonVariant;
+    /** Button size */
+    size?: ButtonSize;
+    /** Disables button */
+    isDisabled?: boolean;
+    /** Button will grow to width of container */
+    isBlock?: boolean;
+    /** Positions icon symbol before children */
+    iconAtStart?: IconSymbol;
+    /** Positions icon symbol after children */
+    iconAtEnd?: IconSymbol;
+    /** Content inside button  */
+    children?: ReactNode;
+    /** Link's destination */
+    href?: string;
+  };
 
 /**
  * A `<Button />` enables users to take an action or transition to other pages.

--- a/easy-ui-react/src/Button/utilities.ts
+++ b/easy-ui-react/src/Button/utilities.ts
@@ -42,9 +42,15 @@ export function logWarningIfInvalidColorVariantCombination(
 
 /**
  * Removes aria-specific props from being applied to button DOM element.
+ *
+ * @remarks
+ * `onClick` is included because `useButton()` hands it to `usePress()`, which
+ * calls it from the `onClick` it returns. Spreading the original alongside that
+ * one would fire the consumer's handler twice per click.
  */
 export function omitReactAriaSpecificProps(props: object) {
   return omit(props, [
+    "onClick",
     "onPress",
     "onPressChange",
     "onPressStart",

--- a/easy-ui-react/src/Button/utilities.ts
+++ b/easy-ui-react/src/Button/utilities.ts
@@ -51,5 +51,6 @@ export function omitReactAriaSpecificProps(props: object) {
     "onPressEnd",
     "onPressUp",
     "preventFocusOnPress",
+    "routerOptions",
   ]);
 }

--- a/easy-ui-react/src/Button/utilities.ts
+++ b/easy-ui-react/src/Button/utilities.ts
@@ -42,15 +42,9 @@ export function logWarningIfInvalidColorVariantCombination(
 
 /**
  * Removes aria-specific props from being applied to button DOM element.
- *
- * @remarks
- * `onClick` is included because `useButton()` hands it to `usePress()`, which
- * calls it from the `onClick` it returns. Spreading the original alongside that
- * one would fire the consumer's handler twice per click.
  */
 export function omitReactAriaSpecificProps(props: object) {
   return omit(props, [
-    "onClick",
     "onPress",
     "onPressChange",
     "onPressStart",

--- a/easy-ui-react/src/DropdownButton/DropdownButton.tsx
+++ b/easy-ui-react/src/DropdownButton/DropdownButton.tsx
@@ -5,21 +5,23 @@ import { ButtonColor } from "../Button";
 import { logWarningIfInvalidColorVariantCombination } from "../Button/utilities";
 import { Icon } from "../Icon";
 import { classNames, variationName } from "../utilities/css";
+import { RouterLinkProps } from "../utilities/router";
 import styles from "./DropdownButton.module.scss";
 import { UnstyledButton } from "../UnstyledButton";
 
 export type DropdownButtonVariant = "filled" | "outlined";
 
-export type DropdownButtonProps = AriaButtonProps & {
-  /** Button color */
-  color?: ButtonColor;
-  /** Button variant */
-  variant?: DropdownButtonVariant;
-  /** Disables button */
-  isDisabled?: boolean;
-  /** Content inside button  */
-  children?: ReactNode;
-};
+export type DropdownButtonProps = AriaButtonProps &
+  RouterLinkProps & {
+    /** Button color */
+    color?: ButtonColor;
+    /** Button variant */
+    variant?: DropdownButtonVariant;
+    /** Disables button */
+    isDisabled?: boolean;
+    /** Content inside button  */
+    children?: ReactNode;
+  };
 
 /**
  * Typically used as a trigger to display a set of options for

--- a/easy-ui-react/src/IconButton/IconButton.tsx
+++ b/easy-ui-react/src/IconButton/IconButton.tsx
@@ -6,26 +6,28 @@ import { Icon } from "../Icon";
 import { Text } from "../Text";
 import { IconSymbol } from "../types";
 import { classNames, variationName } from "../utilities/css";
+import { RouterLinkProps } from "../utilities/router";
 import styles from "./IconButton.module.scss";
 import { UnstyledButton } from "../UnstyledButton";
 
 export type IconButtonVariant = "filled" | "outlined";
 export type IconButtonSize = "sm" | "md";
 
-export type IconButtonProps = AriaButtonProps & {
-  /** Button color */
-  color?: ButtonColor;
-  /** Button variant */
-  variant?: IconButtonVariant;
-  /** Icon symbol */
-  icon: IconSymbol;
-  /** Button size */
-  size?: IconButtonSize;
-  /** Description of icon */
-  accessibilityLabel: string;
-  /** Disables button */
-  isDisabled?: boolean;
-};
+export type IconButtonProps = AriaButtonProps &
+  RouterLinkProps & {
+    /** Button color */
+    color?: ButtonColor;
+    /** Button variant */
+    variant?: IconButtonVariant;
+    /** Icon symbol */
+    icon: IconSymbol;
+    /** Button size */
+    size?: IconButtonSize;
+    /** Description of icon */
+    accessibilityLabel: string;
+    /** Disables button */
+    isDisabled?: boolean;
+  };
 
 /**
  * Button element that represents its behavior with a contextually

--- a/easy-ui-react/src/KebabButton/KebabButton.tsx
+++ b/easy-ui-react/src/KebabButton/KebabButton.tsx
@@ -4,12 +4,14 @@ import { AriaButtonProps } from "react-aria";
 import { UnstyledButton } from "../UnstyledButton/UnstyledButton";
 import { Text } from "../Text";
 import { Icon } from "../Icon";
+import { RouterLinkProps } from "../utilities/router";
 import styles from "./KebabButton.module.scss";
 
-export type KebabButtonProps = AriaButtonProps & {
-  /** Optional custom accessibility label describing the action. */
-  accessibilityLabel?: string;
-};
+export type KebabButtonProps = AriaButtonProps &
+  RouterLinkProps & {
+    /** Optional custom accessibility label describing the action. */
+    accessibilityLabel?: string;
+  };
 
 /**
  * Typically used as a trigger to display a set of options

--- a/easy-ui-react/src/Menu/Menu.mdx
+++ b/easy-ui-react/src/Menu/Menu.mdx
@@ -84,7 +84,7 @@ The example below is wired to a fake router. Its items are regular links with re
 
 <Canvas of={MenuStories.ClientSideRouting} />
 
-An item with an `hrefComponent` is left alone. The link component receives the `href` as written and is expected to handle navigation itself.
+An item with an `hrefComponent` receives the `href` as written rather than the one `useHref` resolved, since the link component resolves its own. Unlike `TabNav.Item` and `VerticalNav.Item`, though, a menu item can't opt out of the provider's router—React Aria's menu item handles links internally—so a link component that navigates on its own will navigate twice. Use `hrefComponent` or `navigate`, not both.
 
 ## Custom Placement
 

--- a/easy-ui-react/src/Menu/Menu.mdx
+++ b/easy-ui-react/src/Menu/Menu.mdx
@@ -84,6 +84,8 @@ The example below is wired to a fake router. Its items are regular links with re
 
 <Canvas of={MenuStories.ClientSideRouting} />
 
+An item with an `hrefComponent` is left alone. The link component receives the `href` as written and is expected to handle navigation itself.
+
 ## Custom Placement
 
 A `<Menu />` can be placed on different edges of its trigger element. See the controls for valid values. Ensure any deviation from the default value is coordinated with design to prevent unexpected user experience.

--- a/easy-ui-react/src/Menu/Menu.mdx
+++ b/easy-ui-react/src/Menu/Menu.mdx
@@ -58,6 +58,32 @@ A `<Menu />` can include links by using the `href` property, and it can include 
 
 <Canvas of={MenuStories.MixedItemTypes} />
 
+## Client-side routing
+
+Pass a `navigate` function to `<Provider />` and link items navigate through your app's router instead of doing a full page load. Their `href`s are resolved through the provider's `useHref`.
+
+```tsx
+import { Provider as EasyUIProvider } from "@easypost/easy-ui/Provider";
+import { useNavigate, useHref } from "react-router";
+
+<EasyUIProvider navigate={useNavigate()} useHref={useHref}>
+  <Menu>
+    <Menu.Trigger>
+      <DropdownButton>Click me</DropdownButton>
+    </Menu.Trigger>
+    <Menu.Overlay onAction={onAction}>
+      <Menu.Item key="shipments" href="/shipments">
+        Shipments
+      </Menu.Item>
+    </Menu.Overlay>
+  </Menu>
+</EasyUIProvider>;
+```
+
+The example below is wired to a fake router. Its items are regular links with regular `href`s—the router is what keeps them from loading a new page.
+
+<Canvas of={MenuStories.ClientSideRouting} />
+
 ## Custom Placement
 
 A `<Menu />` can be placed on different edges of its trigger element. See the controls for valid values. Ensure any deviation from the default value is coordinated with design to prevent unexpected user experience.

--- a/easy-ui-react/src/Menu/Menu.mdx
+++ b/easy-ui-react/src/Menu/Menu.mdx
@@ -84,7 +84,7 @@ The example below is wired to a fake router. Its items are regular links with re
 
 <Canvas of={MenuStories.ClientSideRouting} />
 
-An item with an `hrefComponent` receives the `href` as written rather than the one `useHref` resolved, since the link component resolves its own. Unlike `TabNav.Item` and `VerticalNav.Item`, though, a menu item can't opt out of the provider's router—React Aria's menu item handles links internally—so a link component that navigates on its own will navigate twice. Use `hrefComponent` or `navigate`, not both.
+An item with an `hrefComponent` receives the `href` as written rather than the one `useHref` resolved, since the link component resolves its own. Unlike `TabNav.Item` and `VerticalNav.Item`, though, a menu item can't opt out of the provider's router—React Aria's menu item handles links internally—so the click reaches `navigate` too. A link component that chains the `onClick` it's handed, as `next/link` does, will navigate twice; one that replaces the handler outright suppresses `navigate` and leaves the item's `onAction` unrun. Pair `hrefComponent` with a router rather than using it instead of one.
 
 ## Custom Placement
 

--- a/easy-ui-react/src/Menu/Menu.stories.tsx
+++ b/easy-ui-react/src/Menu/Menu.stories.tsx
@@ -4,6 +4,7 @@ import type { Selection } from "react-stately";
 import React from "react";
 import { DropdownButton } from "../DropdownButton";
 import {
+  FakeClientSideRouter,
   OverlayLayoutDecorator,
   overlayPlacements,
 } from "../utilities/storybook";
@@ -225,6 +226,35 @@ export const MixedItemTypes: Story = {
       </Menu.Overlay>
     ),
   },
+};
+
+// Items render as regular anchors with regular hrefs; the router configured on
+// `<Provider />` is what keeps clicking them from loading a new page.
+export const ClientSideRouting: Story = {
+  render: () => (
+    <FakeClientSideRouter>
+      <Menu>
+        <Menu.Trigger>
+          <DropdownButton>Click me</DropdownButton>
+        </Menu.Trigger>
+        <Menu.Overlay onAction={action("onAction")}>
+          <Menu.Item key="shipments" href="/shipments">
+            Shipments
+          </Menu.Item>
+          <Menu.Item key="trackers" href="/trackers">
+            Trackers
+          </Menu.Item>
+          <Menu.Item
+            key="docs"
+            href="https://www.easypost.com/docs/api"
+            target="_blank"
+          >
+            Docs, loads normally
+          </Menu.Item>
+        </Menu.Overlay>
+      </Menu>
+    </FakeClientSideRouter>
+  ),
 };
 
 export const CustomPlacement: StoryObj<MenuOverlayProps<unknown>> = {

--- a/easy-ui-react/src/Menu/MenuItem.tsx
+++ b/easy-ui-react/src/Menu/MenuItem.tsx
@@ -74,18 +74,8 @@ export function MenuItemContent<T>({ item, state }: MenuItemContentProps<T>) {
     selectionManager: { selectionMode },
   } = state;
   const { closeOnSelect, href, hrefComponent } = item.props;
-
-  // A custom `hrefComponent` handles navigation itself, so `useMenuItem()` is
-  // kept from seeing the `href`. Left alone it would resolve the href through
-  // `<Provider useHref />` and hand clicks to the provider's `navigate`, both of
-  // which fight the link component. Selection and closing on select read from
-  // the collection, so they're unaffected.
-  const menuItem = hrefComponent
-    ? { ...item, props: omit(item.props, ["href", "routerOptions"]) }
-    : item;
-
   const { menuItemProps, isFocused, isSelected, isDisabled } = useMenuItem(
-    { ...menuItem, closeOnSelect },
+    { ...item, closeOnSelect },
     state,
     ref,
   );
@@ -107,7 +97,9 @@ export function MenuItemContent<T>({ item, state }: MenuItemContentProps<T>) {
           // client-side router, and re-applying the raw one here would undo it.
           // A custom `hrefComponent` keeps the raw value; it resolves its own
           // hrefs and may accept ones only it understands, such as next/link's
-          // URL objects
+          // URL objects. Note that `useMenuItem()` reads the item straight from
+          // the collection, so it still hands the click to the provider's
+          // `navigate`—pair `hrefComponent` with a router, not instead of one
           ...(hrefComponent ? [] : ["href"]),
         ])
       : item.key === SELECT_ALL_KEY

--- a/easy-ui-react/src/Menu/MenuItem.tsx
+++ b/easy-ui-react/src/Menu/MenuItem.tsx
@@ -73,9 +73,19 @@ export function MenuItemContent<T>({ item, state }: MenuItemContentProps<T>) {
   const {
     selectionManager: { selectionMode },
   } = state;
-  const { closeOnSelect, href } = item.props;
+  const { closeOnSelect, href, hrefComponent } = item.props;
+
+  // A custom `hrefComponent` handles navigation itself, so `useMenuItem()` is
+  // kept from seeing the `href`. Left alone it would resolve the href through
+  // `<Provider useHref />` and hand clicks to the provider's `navigate`, both of
+  // which fight the link component. Selection and closing on select read from
+  // the collection, so they're unaffected.
+  const menuItem = hrefComponent
+    ? { ...item, props: omit(item.props, ["href", "routerOptions"]) }
+    : item;
+
   const { menuItemProps, isFocused, isSelected, isDisabled } = useMenuItem(
-    { ...item, closeOnSelect },
+    { ...menuItem, closeOnSelect },
     state,
     ref,
   );
@@ -87,16 +97,18 @@ export function MenuItemContent<T>({ item, state }: MenuItemContentProps<T>) {
   const props = mergeProps(
     menuItemProps,
     href
-      ? // `href` and `routerOptions` are intentionally omitted; `useMenuItem()`
-        // already resolves `href` through the client-side router provided to
-        // `<Provider />`, and re-applying the raw value here would undo it
-        omit(item.props, [
+      ? omit(item.props, [
           "aria-label",
           "as",
           "children",
           "closeOnSelect",
-          "href",
           "routerOptions",
+          // a native anchor takes the href `useMenuItem()` resolved through the
+          // client-side router, and re-applying the raw one here would undo it.
+          // A custom `hrefComponent` keeps the raw value; it resolves its own
+          // hrefs and may accept ones only it understands, such as next/link's
+          // URL objects
+          ...(hrefComponent ? [] : ["href"]),
         ])
       : item.key === SELECT_ALL_KEY
         ? { "aria-checked": isSelectAllSelected(state) }

--- a/easy-ui-react/src/Menu/MenuItem.tsx
+++ b/easy-ui-react/src/Menu/MenuItem.tsx
@@ -1,3 +1,4 @@
+import { RouterOptions } from "@react-types/shared";
 import omit from "lodash/omit";
 import React, {
   ComponentPropsWithoutRef,
@@ -46,6 +47,9 @@ export type MenuItemProps = {
 
   /** If `href` is provided, the target window for the link. */
   target?: string;
+
+  /** If `href` is provided, options for the client-side router set on `<Provider />`. */
+  routerOptions?: RouterOptions;
 };
 
 /**
@@ -83,7 +87,17 @@ export function MenuItemContent<T>({ item, state }: MenuItemContentProps<T>) {
   const props = mergeProps(
     menuItemProps,
     href
-      ? omit(item.props, ["aria-label", "as", "children", "closeOnSelect"])
+      ? // `href` and `routerOptions` are intentionally omitted; `useMenuItem()`
+        // already resolves `href` through the client-side router provided to
+        // `<Provider />`, and re-applying the raw value here would undo it
+        omit(item.props, [
+          "aria-label",
+          "as",
+          "children",
+          "closeOnSelect",
+          "href",
+          "routerOptions",
+        ])
       : item.key === SELECT_ALL_KEY
         ? { "aria-checked": isSelectAllSelected(state) }
         : {},

--- a/easy-ui-react/src/Provider/Provider.test.tsx
+++ b/easy-ui-react/src/Provider/Provider.test.tsx
@@ -294,6 +294,30 @@ describe("<Provider />", () => {
       expect(navigate).not.toHaveBeenCalled();
       expect(customNavigate).toHaveBeenCalledTimes(1);
     });
+
+    it("should not client navigate from a <Menu.Item />", async () => {
+      const navigate = vi.fn();
+      const { user } = renderWithNavigate(
+        <Menu>
+          <Menu.Trigger>
+            <Button>Open</Button>
+          </Menu.Trigger>
+          <Menu.Overlay onAction={vi.fn()}>
+            <Menu.Item key="1" href="/somewhere" hrefComponent={CustomLink}>
+              Go
+            </Menu.Item>
+          </Menu.Overlay>
+        </Menu>,
+        navigate,
+        (href) => `/base${href}`,
+      );
+      await user.click(screen.getByRole("button", { name: /open/i }));
+      const link = screen.getByRole("menuitem", { name: /go/i });
+      expect(link).toHaveAttribute("href", "/somewhere");
+      await user.click(link);
+      expect(navigate).not.toHaveBeenCalled();
+      expect(customNavigate).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("useHref", () => {
@@ -318,6 +342,28 @@ describe("<Provider />", () => {
         (href) => `/base${href}`,
       );
       expect(screen.getByRole("link", { name: /go/i })).toHaveAttribute(
+        "href",
+        "/base/somewhere",
+      );
+    });
+
+    it("should prepend a base path to a <Menu.Item /> href", async () => {
+      const { user } = renderWithNavigate(
+        <Menu>
+          <Menu.Trigger>
+            <Button>Open</Button>
+          </Menu.Trigger>
+          <Menu.Overlay onAction={vi.fn()}>
+            <Menu.Item key="1" href="/somewhere">
+              Go
+            </Menu.Item>
+          </Menu.Overlay>
+        </Menu>,
+        vi.fn(),
+        (href) => `/base${href}`,
+      );
+      await user.click(screen.getByRole("button", { name: /open/i }));
+      expect(screen.getByRole("menuitem", { name: /go/i })).toHaveAttribute(
         "href",
         "/base/somewhere",
       );

--- a/easy-ui-react/src/Provider/Provider.test.tsx
+++ b/easy-ui-react/src/Provider/Provider.test.tsx
@@ -1,0 +1,232 @@
+import { RouterOptions } from "@react-types/shared";
+import { screen } from "@testing-library/react";
+import React, { ReactElement } from "react";
+import { vi } from "vitest";
+import { Button } from "../Button";
+import { IconButton } from "../IconButton";
+import { Menu } from "../Menu";
+import { TabNav } from "../TabNav";
+import { VerticalNav } from "../VerticalNav";
+import {
+  mockGetComputedStyle,
+  mockIntersectionObserver,
+  render,
+} from "../utilities/test";
+import { Provider } from "./Provider";
+
+import ArrowBackIcon from "@easypost/easy-ui-icons/ArrowBack";
+
+// React Aria resolves `RouterOptions` to `never` until an app augments
+// `RouterConfig` with its router's option type, so options need a cast here
+const routerOptions = { replace: true } as unknown as RouterOptions;
+
+describe("<Provider />", () => {
+  let restoreGetComputedStyle: () => void;
+  let restoreIntersectionObserver: () => void;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    restoreGetComputedStyle = mockGetComputedStyle();
+    restoreIntersectionObserver = mockIntersectionObserver();
+  });
+
+  afterEach(() => {
+    restoreIntersectionObserver();
+    restoreGetComputedStyle();
+    vi.useRealTimers();
+  });
+
+  it("should render children without a navigate function", () => {
+    render(
+      <Provider>
+        <Button href="/somewhere">Go</Button>
+      </Provider>,
+    );
+    expect(screen.getByRole("button", { name: /go/i })).toHaveAttribute(
+      "href",
+      "/somewhere",
+    );
+  });
+
+  describe("navigate", () => {
+    it("should client navigate from a <Button />", async () => {
+      const navigate = vi.fn();
+      const { user } = renderWithNavigate(
+        <Button href="/somewhere">Go</Button>,
+        navigate,
+      );
+      await user.click(screen.getByRole("button", { name: /go/i }));
+      expect(navigate).toHaveBeenCalledWith("/somewhere", undefined);
+    });
+
+    it("should forward routerOptions from a <Button />", async () => {
+      const navigate = vi.fn();
+      const { user } = renderWithNavigate(
+        <Button href="/somewhere" routerOptions={routerOptions}>
+          Go
+        </Button>,
+        navigate,
+      );
+      await user.click(screen.getByRole("button", { name: /go/i }));
+      expect(navigate).toHaveBeenCalledWith("/somewhere", routerOptions);
+    });
+
+    it("should client navigate from a <Button /> activated by keyboard", async () => {
+      const navigate = vi.fn();
+      const { user } = renderWithNavigate(
+        <Button href="/somewhere">Go</Button>,
+        navigate,
+      );
+      await user.tab();
+      await user.keyboard("{Enter}");
+      expect(navigate).toHaveBeenCalledWith("/somewhere", undefined);
+    });
+
+    it("should not client navigate from a <Button /> without an href", async () => {
+      const navigate = vi.fn();
+      const { user } = renderWithNavigate(<Button>Go</Button>, navigate);
+      await user.click(screen.getByRole("button", { name: /go/i }));
+      expect(navigate).not.toHaveBeenCalled();
+    });
+
+    it("should not client navigate from a <Button /> to an external origin", async () => {
+      // the link falls through to a full page load, which jsdom logs as
+      // unimplemented
+      const restoreConsoleError = suppressConsoleError();
+      const navigate = vi.fn();
+      const { user } = renderWithNavigate(
+        <Button href="https://www.easypost.com/">Go</Button>,
+        navigate,
+      );
+      await user.click(screen.getByRole("button", { name: /go/i }));
+      expect(navigate).not.toHaveBeenCalled();
+      restoreConsoleError();
+    });
+
+    it("should not client navigate from a <Button /> opening a new tab", async () => {
+      const navigate = vi.fn();
+      const { user } = renderWithNavigate(
+        <Button href="/somewhere" target="_blank">
+          Go
+        </Button>,
+        navigate,
+      );
+      await user.click(screen.getByRole("button", { name: /go/i }));
+      expect(navigate).not.toHaveBeenCalled();
+    });
+
+    it("should client navigate from an <IconButton />", async () => {
+      const navigate = vi.fn();
+      const { user } = renderWithNavigate(
+        <IconButton
+          href="/somewhere"
+          icon={ArrowBackIcon}
+          accessibilityLabel="Go"
+        />,
+        navigate,
+      );
+      await user.click(screen.getByRole("button", { name: /go/i }));
+      expect(navigate).toHaveBeenCalledWith("/somewhere", undefined);
+    });
+
+    it("should client navigate from a <TabNav.Item />", async () => {
+      const navigate = vi.fn();
+      const { user } = renderWithNavigate(
+        <TabNav aria-label="Nav">
+          <TabNav.Item href="/somewhere">Go</TabNav.Item>
+        </TabNav>,
+        navigate,
+      );
+      await user.click(screen.getByRole("link", { name: /go/i }));
+      expect(navigate).toHaveBeenCalledWith("/somewhere", undefined);
+    });
+
+    it("should client navigate from a <VerticalNav.Item />", async () => {
+      const navigate = vi.fn();
+      const { user } = renderWithNavigate(
+        <VerticalNav aria-label="Nav" selectedKey="1">
+          <VerticalNav.Item key="1" label="Go" href="/somewhere" />
+        </VerticalNav>,
+        navigate,
+      );
+      await user.click(screen.getByRole("link", { name: /go/i }));
+      expect(navigate).toHaveBeenCalledWith("/somewhere", undefined);
+    });
+
+    it("should client navigate from a <Menu.Item />", async () => {
+      const navigate = vi.fn();
+      const { user } = renderWithNavigate(
+        <Menu>
+          <Menu.Trigger>
+            <Button>Open</Button>
+          </Menu.Trigger>
+          <Menu.Overlay onAction={vi.fn()}>
+            <Menu.Item key="1" href="/somewhere">
+              Go
+            </Menu.Item>
+          </Menu.Overlay>
+        </Menu>,
+        navigate,
+      );
+      await user.click(screen.getByRole("button", { name: /open/i }));
+      await user.click(screen.getByRole("menuitem", { name: /go/i }));
+      expect(navigate).toHaveBeenCalledWith("/somewhere", undefined);
+    });
+  });
+
+  describe("useHref", () => {
+    it("should prepend a base path to a <Button /> href", () => {
+      renderWithNavigate(
+        <Button href="/somewhere">Go</Button>,
+        vi.fn(),
+        (href) => `/base${href}`,
+      );
+      expect(screen.getByRole("button", { name: /go/i })).toHaveAttribute(
+        "href",
+        "/base/somewhere",
+      );
+    });
+
+    it("should prepend a base path to a <TabNav.Item /> href", () => {
+      renderWithNavigate(
+        <TabNav aria-label="Nav">
+          <TabNav.Item href="/somewhere">Go</TabNav.Item>
+        </TabNav>,
+        vi.fn(),
+        (href) => `/base${href}`,
+      );
+      expect(screen.getByRole("link", { name: /go/i })).toHaveAttribute(
+        "href",
+        "/base/somewhere",
+      );
+    });
+
+    it("should navigate with the unresolved href", async () => {
+      const navigate = vi.fn();
+      const { user } = renderWithNavigate(
+        <Button href="/somewhere">Go</Button>,
+        navigate,
+        (href) => `/base${href}`,
+      );
+      await user.click(screen.getByRole("button", { name: /go/i }));
+      expect(navigate).toHaveBeenCalledWith("/somewhere", undefined);
+    });
+  });
+});
+
+function suppressConsoleError() {
+  const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+  return () => spy.mockRestore();
+}
+
+function renderWithNavigate(
+  children: ReactElement,
+  navigate: (path: string) => void,
+  useHref?: (href: string) => string,
+) {
+  return render(
+    <Provider navigate={navigate} useHref={useHref}>
+      {children}
+    </Provider>,
+  );
+}

--- a/easy-ui-react/src/Provider/Provider.test.tsx
+++ b/easy-ui-react/src/Provider/Provider.test.tsx
@@ -5,6 +5,7 @@ import { vi } from "vitest";
 import { Button } from "../Button";
 import { IconButton } from "../IconButton";
 import { Menu } from "../Menu";
+import { SearchNav } from "../SearchNav";
 import { TabNav } from "../TabNav";
 import { VerticalNav } from "../VerticalNav";
 import {
@@ -158,6 +159,32 @@ describe("<Provider />", () => {
       expect(navigate).not.toHaveBeenCalled();
     });
 
+    it("should not client navigate from a <Button /> whose handler prevents default on Enter", async () => {
+      const navigate = vi.fn();
+      const { user } = renderWithNavigate(
+        <Button href="/somewhere" onClick={(e) => e.preventDefault()}>
+          Go
+        </Button>,
+        navigate,
+      );
+      await user.tab();
+      await user.keyboard("{Enter}");
+      expect(navigate).not.toHaveBeenCalled();
+    });
+
+    it("should not client navigate from a <Button /> whose handler prevents default on Space", async () => {
+      const navigate = vi.fn();
+      const { user } = renderWithNavigate(
+        <Button href="/somewhere" onClick={(e) => e.preventDefault()}>
+          Go
+        </Button>,
+        navigate,
+      );
+      await user.tab();
+      await user.keyboard(" ");
+      expect(navigate).not.toHaveBeenCalled();
+    });
+
     it("should client navigate once from a <Button /> with an onPress handler", async () => {
       const navigate = vi.fn();
       const onPress = vi.fn();
@@ -231,6 +258,37 @@ describe("<Provider />", () => {
       expect(navigate).toHaveBeenCalledWith("/somewhere", undefined);
     });
 
+    it("should client navigate from a <SearchNav /> CTA", async () => {
+      const navigate = vi.fn();
+      const { user } = renderWithNavigate(searchNavWithCTA(), navigate);
+      // the CTA renders in the desktop layout, which a media query hides in
+      // jsdom's default viewport
+      await user.click(
+        screen.getByRole("button", { name: /docs/i, hidden: true }),
+      );
+      expect(navigate).toHaveBeenCalledWith("/somewhere", routerOptions);
+    });
+
+    // `<SearchNav />` rebuilds its CTAs as menu items in two places: the CTA
+    // group's own overflow menu, and the condensed nav that replaces the whole
+    // bar on small screens. Both render at once and are shown by media query,
+    // so both trigger buttons are in the DOM and the hidden one still needs
+    // asserting
+    it.each([
+      ["a <SearchNav.CTAGroup /> menu item", 0],
+      ["a condensed <SearchNav /> menu item", 1],
+    ])("should forward routerOptions from %s", async (_, triggerIndex) => {
+      const navigate = vi.fn();
+      const { user } = renderWithNavigate(searchNavWithCTA(), navigate);
+      const triggers = screen.getAllByRole("button", {
+        name: "menu",
+        hidden: true,
+      });
+      await user.click(triggers[triggerIndex]);
+      await user.click(screen.getByRole("menuitem", { name: /docs/i }));
+      expect(navigate).toHaveBeenCalledWith("/somewhere", routerOptions);
+    });
+
     it("should client navigate from a <VerticalNav.SupplementaryAction />", async () => {
       const navigate = vi.fn();
       const { user } = renderWithNavigate(
@@ -295,7 +353,10 @@ describe("<Provider />", () => {
       expect(customNavigate).toHaveBeenCalledTimes(1);
     });
 
-    it("should not client navigate from a <Menu.Item />", async () => {
+    // `<Menu.Item />` is the exception. `useMenuItem()` reads the item from the
+    // collection rather than from the props it's handed, so its click handling
+    // can't be opted out of; only the rendered `href` is left as written
+    it("should give a <Menu.Item /> hrefComponent the unresolved href", async () => {
       const navigate = vi.fn();
       const { user } = renderWithNavigate(
         <Menu>
@@ -303,7 +364,7 @@ describe("<Provider />", () => {
             <Button>Open</Button>
           </Menu.Trigger>
           <Menu.Overlay onAction={vi.fn()}>
-            <Menu.Item key="1" href="/somewhere" hrefComponent={CustomLink}>
+            <Menu.Item key="1" href="/somewhere" hrefComponent={ChainingLink}>
               Go
             </Menu.Item>
           </Menu.Overlay>
@@ -315,8 +376,9 @@ describe("<Provider />", () => {
       const link = screen.getByRole("menuitem", { name: /go/i });
       expect(link).toHaveAttribute("href", "/somewhere");
       await user.click(link);
-      expect(navigate).not.toHaveBeenCalled();
-      expect(customNavigate).toHaveBeenCalledTimes(1);
+      expect(customNavigate).toHaveBeenCalledWith("/somewhere");
+      // the provider's router runs too, on the unresolved href
+      expect(navigate).toHaveBeenCalledWith("/somewhere", undefined);
     });
   });
 
@@ -401,6 +463,53 @@ function CustomLink({
     >
       {children}
     </a>
+  );
+}
+
+/**
+ * Stands in for a link component that chains the `onClick` it's handed before
+ * navigating, the way `next/link` does. Anything merged onto it by Easy UI runs
+ * on the click, so a component that means to hand navigation off to the link
+ * component has to keep its own handlers off it in the first place.
+ */
+function ChainingLink({
+  href,
+  children,
+  onClick,
+  ...linkProps
+}: ComponentProps<"a"> & { href: string }) {
+  return (
+    <a
+      {...linkProps}
+      href={href}
+      onClick={(e) => {
+        onClick?.(e);
+        e.preventDefault();
+        customNavigate(href);
+      }}
+    >
+      {children}
+    </a>
+  );
+}
+
+function searchNavWithCTA() {
+  return (
+    <SearchNav>
+      <SearchNav.LogoGroup>
+        <SearchNav.Logo>
+          <img alt="some logo" />
+        </SearchNav.Logo>
+      </SearchNav.LogoGroup>
+      <SearchNav.CTAGroup>
+        <SearchNav.SecondaryCTAItem
+          key="Docs"
+          label="Docs"
+          href="/somewhere"
+          routerOptions={routerOptions}
+        />
+      </SearchNav.CTAGroup>
+    </SearchNav>
   );
 }
 

--- a/easy-ui-react/src/Provider/Provider.test.tsx
+++ b/easy-ui-react/src/Provider/Provider.test.tsx
@@ -358,12 +358,13 @@ describe("<Provider />", () => {
     // can't be opted out of; only the rendered `href` is left as written
     it("should give a <Menu.Item /> hrefComponent the unresolved href", async () => {
       const navigate = vi.fn();
+      const onAction = vi.fn();
       const { user } = renderWithNavigate(
         <Menu>
           <Menu.Trigger>
             <Button>Open</Button>
           </Menu.Trigger>
-          <Menu.Overlay onAction={vi.fn()}>
+          <Menu.Overlay onAction={onAction}>
             <Menu.Item key="1" href="/somewhere" hrefComponent={ChainingLink}>
               Go
             </Menu.Item>
@@ -379,6 +380,32 @@ describe("<Provider />", () => {
       expect(customNavigate).toHaveBeenCalledWith("/somewhere");
       // the provider's router runs too, on the unresolved href
       expect(navigate).toHaveBeenCalledWith("/somewhere", undefined);
+      expect(onAction).toHaveBeenCalledTimes(1);
+    });
+
+    // a link component that replaces the `onClick` it's handed instead of
+    // chaining it takes the menu item's own click handling down with it
+    it("should not run a <Menu.Item /> action when its hrefComponent replaces onClick", async () => {
+      const navigate = vi.fn();
+      const onAction = vi.fn();
+      const { user } = renderWithNavigate(
+        <Menu>
+          <Menu.Trigger>
+            <Button>Open</Button>
+          </Menu.Trigger>
+          <Menu.Overlay onAction={onAction}>
+            <Menu.Item key="1" href="/somewhere" hrefComponent={CustomLink}>
+              Go
+            </Menu.Item>
+          </Menu.Overlay>
+        </Menu>,
+        navigate,
+      );
+      await user.click(screen.getByRole("button", { name: /open/i }));
+      await user.click(screen.getByRole("menuitem", { name: /go/i }));
+      expect(customNavigate).toHaveBeenCalledWith("/somewhere");
+      expect(navigate).not.toHaveBeenCalled();
+      expect(onAction).not.toHaveBeenCalled();
     });
   });
 

--- a/easy-ui-react/src/Provider/Provider.test.tsx
+++ b/easy-ui-react/src/Provider/Provider.test.tsx
@@ -1,6 +1,6 @@
 import { RouterOptions } from "@react-types/shared";
 import { screen } from "@testing-library/react";
-import React, { ReactElement } from "react";
+import React, { ComponentProps, ReactElement } from "react";
 import { vi } from "vitest";
 import { Button } from "../Button";
 import { IconButton } from "../IconButton";
@@ -25,6 +25,7 @@ describe("<Provider />", () => {
   let restoreIntersectionObserver: () => void;
 
   beforeEach(() => {
+    customNavigate.mockClear();
     vi.useFakeTimers();
     restoreGetComputedStyle = mockGetComputedStyle();
     restoreIntersectionObserver = mockIntersectionObserver();
@@ -115,6 +116,63 @@ describe("<Provider />", () => {
       expect(navigate).not.toHaveBeenCalled();
     });
 
+    it("should not client navigate from a disabled <Button />", async () => {
+      const navigate = vi.fn();
+      const { user } = renderWithNavigate(
+        <Button href="/somewhere" isDisabled>
+          Go
+        </Button>,
+        navigate,
+      );
+      const button = screen.getByRole("button", { name: /go/i });
+      expect(button).not.toHaveAttribute("href");
+      await user.click(button);
+      expect(navigate).not.toHaveBeenCalled();
+    });
+
+    it("should not client navigate from a <Button /> that downloads", async () => {
+      // the link falls through to a full page load, which jsdom logs as
+      // unimplemented
+      const restoreConsoleError = suppressConsoleError();
+      const navigate = vi.fn();
+      const { user } = renderWithNavigate(
+        <Button href="/report.csv" download>
+          Go
+        </Button>,
+        navigate,
+      );
+      await user.click(screen.getByRole("button", { name: /go/i }));
+      expect(navigate).not.toHaveBeenCalled();
+      restoreConsoleError();
+    });
+
+    it("should not client navigate from a <Button /> whose handler prevents default", async () => {
+      const navigate = vi.fn();
+      const { user } = renderWithNavigate(
+        <Button href="/somewhere" onClick={(e) => e.preventDefault()}>
+          Go
+        </Button>,
+        navigate,
+      );
+      await user.click(screen.getByRole("button", { name: /go/i }));
+      expect(navigate).not.toHaveBeenCalled();
+    });
+
+    it("should client navigate once from a <Button /> with an onPress handler", async () => {
+      const navigate = vi.fn();
+      const onPress = vi.fn();
+      const { user } = renderWithNavigate(
+        <Button href="/somewhere" onPress={onPress}>
+          Go
+        </Button>,
+        navigate,
+      );
+      await user.click(screen.getByRole("button", { name: /go/i }));
+      expect(onPress).toHaveBeenCalledTimes(1);
+      expect(navigate).toHaveBeenCalledTimes(1);
+      expect(navigate).toHaveBeenCalledWith("/somewhere", undefined);
+    });
+
     it("should client navigate from an <IconButton />", async () => {
       const navigate = vi.fn();
       const { user } = renderWithNavigate(
@@ -172,6 +230,70 @@ describe("<Provider />", () => {
       await user.click(screen.getByRole("menuitem", { name: /go/i }));
       expect(navigate).toHaveBeenCalledWith("/somewhere", undefined);
     });
+
+    it("should client navigate from a <VerticalNav.SupplementaryAction />", async () => {
+      const navigate = vi.fn();
+      const { user } = renderWithNavigate(
+        <VerticalNav
+          aria-label="Nav"
+          selectedKey="1"
+          supplementaryAction={
+            <VerticalNav.SupplementaryAction as="a" href="/somewhere">
+              Go
+            </VerticalNav.SupplementaryAction>
+          }
+        >
+          <VerticalNav.Item key="1" label="Item 1" href="/1" />
+        </VerticalNav>,
+        navigate,
+      );
+      await user.click(screen.getByRole("link", { name: /go/i }));
+      expect(navigate).toHaveBeenCalledWith("/somewhere", undefined);
+    });
+  });
+
+  // components rendering a custom link component are left alone; the link
+  // component is expected to handle client-side navigation itself, and it may
+  // accept hrefs that only it understands, such as next/link's URL objects
+  describe("custom link components", () => {
+    it("should not client navigate from a <TabNav.Item />", async () => {
+      const navigate = vi.fn();
+      const { user } = renderWithNavigate(
+        <TabNav aria-label="Nav">
+          <TabNav.Item as={CustomLink} href="/somewhere">
+            Go
+          </TabNav.Item>
+        </TabNav>,
+        navigate,
+        (href) => `/base${href}`,
+      );
+      const link = screen.getByRole("link", { name: /go/i });
+      expect(link).toHaveAttribute("href", "/somewhere");
+      await user.click(link);
+      expect(navigate).not.toHaveBeenCalled();
+      expect(customNavigate).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not client navigate from a <VerticalNav.Item />", async () => {
+      const navigate = vi.fn();
+      const { user } = renderWithNavigate(
+        <VerticalNav aria-label="Nav" selectedKey="1">
+          <VerticalNav.Item
+            key="1"
+            as={CustomLink}
+            label="Go"
+            href="/somewhere"
+          />
+        </VerticalNav>,
+        navigate,
+        (href) => `/base${href}`,
+      );
+      const link = screen.getByRole("link", { name: /go/i });
+      expect(link).toHaveAttribute("href", "/somewhere");
+      await user.click(link);
+      expect(navigate).not.toHaveBeenCalled();
+      expect(customNavigate).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("useHref", () => {
@@ -213,6 +335,28 @@ describe("<Provider />", () => {
     });
   });
 });
+
+const customNavigate = vi.fn();
+
+/** Stands in for a link component such as `next/link`. */
+function CustomLink({
+  href,
+  children,
+  ...linkProps
+}: ComponentProps<"a"> & { href: string }) {
+  return (
+    <a
+      {...linkProps}
+      href={href}
+      onClick={(e) => {
+        e.preventDefault();
+        customNavigate(href);
+      }}
+    >
+      {children}
+    </a>
+  );
+}
 
 function suppressConsoleError() {
   const spy = vi.spyOn(console, "error").mockImplementation(() => {});

--- a/easy-ui-react/src/Provider/Provider.tsx
+++ b/easy-ui-react/src/Provider/Provider.tsx
@@ -84,6 +84,23 @@ export type ProviderProps = {
 *  );
 *}
 *```
+* @example
+* _Client-side routing_
+```tsx
+* import { Provider as EasyUIProvider } from "@easypost/easy-ui/Provider";
+* import { useNavigate, useHref } from "react-router";
+*
+* function App({ children }) {
+*  // any Easy UI component rendering an anchor—`<Button href />`,
+*  // `<TabNav.Item />`, `<VerticalNav.Item />`, `<Menu.Item href />`—now
+*  // navigates through the router instead of doing a full page load
+*  return (
+*      <EasyUIProvider navigate={useNavigate()} useHref={useHref}>
+*        {children}
+*      </EasyUIProvider>
+*  );
+*}
+*```
  */
 export function Provider({
   children,

--- a/easy-ui-react/src/Provider/Provider.tsx
+++ b/easy-ui-react/src/Provider/Provider.tsx
@@ -16,7 +16,8 @@ export type EasyUIRouterProviderProps = {
 
   /**
    * An optional prop that converts a router-specific href to a native HTML
-   * href, e.g. prepending a base path.
+   * href, e.g. prepending a base path. Only applied alongside `navigate`; on its
+   * own there is no router to resolve hrefs for and it is ignored.
    */
   useHref?: (href: Href) => string;
 

--- a/easy-ui-react/src/SearchNav/CTAGroup.tsx
+++ b/easy-ui-react/src/SearchNav/CTAGroup.tsx
@@ -1,3 +1,4 @@
+import { RouterOptions } from "@react-types/shared";
 import React, { ReactNode, Fragment, ReactElement } from "react";
 import Help from "@easypost/easy-ui-icons/Help";
 import { Separator } from "./Separator";
@@ -70,6 +71,7 @@ export function CTAGroup(_props: CTAGroupProps) {
                     key={getFlattenedKey(itemEle.key)}
                     href={itemEle.props.href as string}
                     target={itemEle.props.target as string}
+                    routerOptions={itemEle.props.routerOptions as RouterOptions}
                   >
                     {itemEle.props.label as ReactNode}
                   </Menu.Item>

--- a/easy-ui-react/src/SearchNav/CondensedSearchNav.tsx
+++ b/easy-ui-react/src/SearchNav/CondensedSearchNav.tsx
@@ -1,3 +1,4 @@
+import { RouterOptions } from "@react-types/shared";
 import React, { useState, ReactElement, ReactNode } from "react";
 import Close from "@easypost/easy-ui-icons/Close";
 import MenuSymbol from "@easypost/easy-ui-icons/Menu";
@@ -87,6 +88,9 @@ export function CondensedSearchNav() {
                         key={getFlattenedKey(itemEle.key)}
                         href={itemEle.props.href as string}
                         target={itemEle.props.target as string}
+                        routerOptions={
+                          itemEle.props.routerOptions as RouterOptions
+                        }
                       >
                         {itemEle.props.label as ReactNode}
                       </Menu.Item>

--- a/easy-ui-react/src/SearchNav/PrimaryCTAItem.tsx
+++ b/easy-ui-react/src/SearchNav/PrimaryCTAItem.tsx
@@ -1,13 +1,15 @@
 import React from "react";
 import { AriaButtonProps } from "react-aria";
 import { Button } from "../Button";
+import { RouterLinkProps } from "../utilities/router";
 
-export type CTAItemProps = AriaButtonProps<"button"> & {
-  /**
-   * Text content to display.
-   */
-  label: string;
-};
+export type CTAItemProps = AriaButtonProps<"button"> &
+  RouterLinkProps & {
+    /**
+     * Text content to display.
+     */
+    label: string;
+  };
 
 export type PrimaryCTAItemProps = CTAItemProps;
 

--- a/easy-ui-react/src/TabNav/TabNav.mdx
+++ b/easy-ui-react/src/TabNav/TabNav.mdx
@@ -29,9 +29,29 @@ Each `TabNav` should have a unique label. To add the label, add the `aria-label`
 
 <Canvas of={TabNavStories.Default} />
 
+## Client-side routing
+
+Pass a `navigate` function to `<Provider />` and `TabNav.Item`s navigate through your app's router instead of doing a full page load:
+
+```tsx
+import { Provider as EasyUIProvider } from "@easypost/easy-ui/Provider";
+import { useNavigate, useHref } from "react-router";
+
+<EasyUIProvider navigate={useNavigate()} useHref={useHref}>
+  <TabNav aria-label="Nav">
+    <TabNav.Item href="/billing">Billing</TabNav.Item>
+  </TabNav>
+</EasyUIProvider>;
+```
+
+The example below is wired to a fake router. Its items are regular links with
+regular `href`s—the router is what keeps them from loading a new page.
+
+<Canvas of={TabNavStories.ClientSideRouting} />
+
 ## Custom Link Component
 
-A `TabNav` can render custom link components for use in apps that have client-side navigation components, such as Next's `Link` component.
+A `TabNav` can render custom link components for use in apps that have client-side navigation components, such as Next's `Link` component. Use this when an item needs a specific link component rather than the router configured on `<Provider />`.
 
 Use the `as` prop to pass in a custom component.
 

--- a/easy-ui-react/src/TabNav/TabNav.stories.tsx
+++ b/easy-ui-react/src/TabNav/TabNav.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react-vite";
 import React, { ComponentProps, useState } from "react";
+import { FakeClientSideRouter } from "../utilities/storybook";
 import { TabNav, TabNavProps } from "./TabNav";
 
 type Story = StoryObj<typeof TabNav>;
@@ -13,6 +14,10 @@ export default meta;
 
 export const Default: Story = {
   render: DefaultTemplate.bind({}),
+};
+
+export const ClientSideRouting: Story = {
+  render: ClientSideRoutingTemplate.bind({}),
 };
 
 export const CustomLink: Story = {
@@ -54,6 +59,28 @@ function DefaultTemplate(args: TabNavProps) {
   );
 }
 
+// Items render as regular anchors with regular hrefs; the router configured on
+// `<Provider />` is what keeps clicking them from loading a new page.
+function ClientSideRoutingTemplate(args: Partial<TabNavProps>) {
+  return (
+    <FakeClientSideRouter initialPath={settingsPath(tabs[0][1])}>
+      {(path) => (
+        <TabNav aria-label="Account" {...args}>
+          {tabs.map(([label, location]) => (
+            <TabNav.Item
+              key={location}
+              href={settingsPath(location)}
+              isCurrentPage={path === settingsPath(location)}
+            >
+              {label}
+            </TabNav.Item>
+          ))}
+        </TabNav>
+      )}
+    </FakeClientSideRouter>
+  );
+}
+
 function CustomLinkTemplate(args: Partial<TabNavProps>) {
   const [page, setPage] = useState("billing");
   return (
@@ -77,6 +104,10 @@ function CustomLinkTemplate(args: Partial<TabNavProps>) {
 // TabNav shouldn't use `button`s in production.
 function FakeClientSideRouterLink(props: ComponentProps<"button">) {
   return <button {...props} />;
+}
+
+function settingsPath(location: string) {
+  return `/settings/${location}`;
 }
 
 function $window() {

--- a/easy-ui-react/src/TabNav/TabNavItem.tsx
+++ b/easy-ui-react/src/TabNav/TabNavItem.tsx
@@ -1,27 +1,37 @@
 import React, { ComponentProps, ElementType, ReactNode } from "react";
+import { mergeProps } from "react-aria";
 import { Tabs } from "../Tabs";
+import { RouterLinkProps, useRouterLinkProps } from "../utilities/router";
 
-type TabNavItemProps<T extends ElementType = "a"> = ComponentProps<T> & {
-  /** Override the default element with a custom one to provide unique behavior. Useful for client-side navigation link components in app frameworks. */
-  as?: T;
+type TabNavItemProps<T extends ElementType = "a"> = ComponentProps<T> &
+  RouterLinkProps & {
+    /** Override the default element with a custom one to provide unique behavior. Useful for client-side navigation link components in app frameworks. */
+    as?: T;
 
-  /** The children of the `<TabNav.Item>` element. */
-  children: ReactNode;
+    /** The children of the `<TabNav.Item>` element. */
+    children: ReactNode;
 
-  /** Sets the `<TavNav.Item>` as the current page and adds `aria-current="page"`. */
-  isCurrentPage?: boolean;
-};
+    /** Sets the `<TavNav.Item>` as the current page and adds `aria-current="page"`. */
+    isCurrentPage?: boolean;
+  };
 
 export function TabNavItem<T extends ElementType = "a">(
   props: TabNavItemProps<T>,
 ) {
-  const { as: As = "a", children, isCurrentPage, ...linkProps } = props;
+  const {
+    as: As = "a",
+    children,
+    isCurrentPage,
+    routerOptions: _routerOptions,
+    ...linkProps
+  } = props;
+  const routerLinkProps = useRouterLinkProps(props, As === "a");
   return (
     <Tabs.Item
       containerComponent="li"
       tabComponent={As}
       isSelected={isCurrentPage}
-      {...linkProps}
+      {...mergeProps(linkProps as object, routerLinkProps)}
       aria-current={isCurrentPage ? "page" : undefined}
     >
       {children}

--- a/easy-ui-react/src/UnstyledButton/UnstyledButton.test.tsx
+++ b/easy-ui-react/src/UnstyledButton/UnstyledButton.test.tsx
@@ -103,6 +103,30 @@ describe("<UnstyledButton />", () => {
     );
   });
 
+  // a call count alone can't tell a handler that ran against the real click
+  // apart from one that ran against an event React Aria synthesized, so this
+  // asserts what `preventDefault()` was supposed to accomplish
+  describe.each(["submit", "reset"] as const)("on a %s button", (type) => {
+    it.each(["{Enter}", " "])(
+      "should let onClick prevent the default on %s",
+      async (key) => {
+        const handleDefault = vi.fn((e: React.FormEvent) => e.preventDefault());
+        const handleClick = vi.fn((e: React.MouseEvent) => e.preventDefault());
+        render(
+          <form onSubmit={handleDefault} onReset={handleDefault}>
+            <UnstyledButton type={type} onClick={handleClick}>
+              Testing
+            </UnstyledButton>
+          </form>,
+        );
+        await userEvent.tab();
+        await userEvent.keyboard(key);
+        expect(handleClick).toHaveBeenCalledTimes(1);
+        expect(handleDefault).not.toHaveBeenCalled();
+      },
+    );
+  });
+
   it("should apply the default class", () => {
     render(
       <UnstyledButton className="colorPrimary_123">Button</UnstyledButton>,

--- a/easy-ui-react/src/UnstyledButton/UnstyledButton.test.tsx
+++ b/easy-ui-react/src/UnstyledButton/UnstyledButton.test.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
 import { Icon } from "../Icon";
 import CheckCircleIcon from "@easypost/easy-ui-icons/CheckCircle";
 import { UnstyledButton } from "./UnstyledButton";
@@ -59,6 +61,24 @@ describe("<UnstyledButton />", () => {
     expect(screen.getByText(/testing/i).closest("a")).not.toHaveAttribute(
       "href",
     );
+  });
+
+  it("should call onClick once per click", async () => {
+    const handleClick = vi.fn();
+    render(<UnstyledButton onClick={handleClick}>Testing</UnstyledButton>);
+    await userEvent.click(screen.getByRole("button"));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call onClick once per click on an anchor tag", async () => {
+    const handleClick = vi.fn((e: React.MouseEvent) => e.preventDefault());
+    render(
+      <UnstyledButton href="/somewhere" onClick={handleClick}>
+        Testing
+      </UnstyledButton>,
+    );
+    await userEvent.click(screen.getByText(/testing/i));
+    expect(handleClick).toHaveBeenCalledTimes(1);
   });
 
   it("should apply the default class", () => {

--- a/easy-ui-react/src/UnstyledButton/UnstyledButton.test.tsx
+++ b/easy-ui-react/src/UnstyledButton/UnstyledButton.test.tsx
@@ -81,6 +81,28 @@ describe("<UnstyledButton />", () => {
     expect(handleClick).toHaveBeenCalledTimes(1);
   });
 
+  // `onClick` reaches a button and an anchor by different routes, so each
+  // element type needs its own keyboard coverage
+  describe.each([
+    ["a button", undefined],
+    ["an anchor tag", "/somewhere"],
+  ])("on %s", (_, href) => {
+    it.each(["{Enter}", " "])(
+      "should call onClick once per %s press",
+      async (key) => {
+        const handleClick = vi.fn((e: React.MouseEvent) => e.preventDefault());
+        render(
+          <UnstyledButton href={href} onClick={handleClick}>
+            Testing
+          </UnstyledButton>,
+        );
+        await userEvent.tab();
+        await userEvent.keyboard(key);
+        expect(handleClick).toHaveBeenCalledTimes(1);
+      },
+    );
+  });
+
   it("should apply the default class", () => {
     render(
       <UnstyledButton className="colorPrimary_123">Button</UnstyledButton>,

--- a/easy-ui-react/src/UnstyledButton/UnstyledButton.test.tsx
+++ b/easy-ui-react/src/UnstyledButton/UnstyledButton.test.tsx
@@ -50,6 +50,17 @@ describe("<UnstyledButton />", () => {
     expect(screen.getByRole("button")).toBeDisabled();
   });
 
+  it("should render a disabled anchor tag without an href", () => {
+    render(
+      <UnstyledButton href="https://www.easypost.com/" isDisabled>
+        Testing
+      </UnstyledButton>,
+    );
+    expect(screen.getByText(/testing/i).closest("a")).not.toHaveAttribute(
+      "href",
+    );
+  });
+
   it("should apply the default class", () => {
     render(
       <UnstyledButton className="colorPrimary_123">Button</UnstyledButton>,

--- a/easy-ui-react/src/UnstyledButton/UnstyledButton.tsx
+++ b/easy-ui-react/src/UnstyledButton/UnstyledButton.tsx
@@ -47,8 +47,13 @@ export const UnstyledButton = forwardRef<null, UnstyledButtonProps>(
     const ref = useRef(null);
     const mergedRef = useObjectRef(mergeRefs(ref, inRef));
     const As = href ? "a" : "button";
+    // `onClick` is withheld from `useButton()` so that it stays a plain DOM
+    // handler and nothing else calls it. `usePress()` invokes any `onClick` it
+    // is handed, which would fire the consumer's handler a second time, and on
+    // keyboard activation it invokes it with a synthesized event, where
+    // `preventDefault()` can't reach the real click that the router reads.
     const { buttonProps: elementProps } = useButton(
-      { ...props, elementType: As },
+      { ...props, onClick: undefined, elementType: As },
       ref,
     );
 

--- a/easy-ui-react/src/UnstyledButton/UnstyledButton.tsx
+++ b/easy-ui-react/src/UnstyledButton/UnstyledButton.tsx
@@ -2,16 +2,18 @@ import { mergeRefs, useObjectRef } from "@react-aria/utils";
 import React, { forwardRef, useRef } from "react";
 import { AriaButtonProps, mergeProps, useButton } from "react-aria";
 import { classNames } from "../utilities/css";
+import { RouterLinkProps, useRouterLinkProps } from "../utilities/router";
 import { omitReactAriaSpecificProps } from "../Button/utilities";
 
 import styles from "./UnstyledButton.module.scss";
 
-export type UnstyledButtonProps = AriaButtonProps<"button"> & {
-  /* Classname to apply styles to button */
-  className?: string;
-  /** Link's destination */
-  href?: string;
-};
+export type UnstyledButtonProps = AriaButtonProps<"button"> &
+  RouterLinkProps & {
+    /* Classname to apply styles to button */
+    className?: string;
+    /** Link's destination */
+    href?: string;
+  };
 
 /**
  * An internal button component that does the heavy lifting with regards to behavior
@@ -50,9 +52,18 @@ export const UnstyledButton = forwardRef<null, UnstyledButtonProps>(
       ref,
     );
 
+    // `useButton()` renders `href` as a plain attribute, so client-side
+    // navigation has to be wired up separately. This is a noop until a
+    // `navigate` function is passed to `<Provider />`.
+    const routerLinkProps = useRouterLinkProps(props);
+
     return (
       <As
-        {...mergeProps(omitReactAriaSpecificProps(restProps), elementProps)}
+        {...mergeProps(
+          omitReactAriaSpecificProps(restProps),
+          elementProps,
+          routerLinkProps,
+        )}
         disabled={isDisabled}
         ref={mergedRef}
         className={classNames(styles.UnstyledButton, className)}

--- a/easy-ui-react/src/UnstyledButton/UnstyledButton.tsx
+++ b/easy-ui-react/src/UnstyledButton/UnstyledButton.tsx
@@ -54,8 +54,10 @@ export const UnstyledButton = forwardRef<null, UnstyledButtonProps>(
 
     // `useButton()` renders `href` as a plain attribute, so client-side
     // navigation has to be wired up separately. This is a noop until a
-    // `navigate` function is passed to `<Provider />`.
-    const routerLinkProps = useRouterLinkProps(props);
+    // `navigate` function is passed to `<Provider />`. Disabled buttons are left
+    // out; `useButton()` withholds their `href` and re-adding it here would make
+    // them navigable.
+    const routerLinkProps = useRouterLinkProps(props, !isDisabled);
 
     return (
       <As

--- a/easy-ui-react/src/UnstyledButton/UnstyledButton.tsx
+++ b/easy-ui-react/src/UnstyledButton/UnstyledButton.tsx
@@ -1,4 +1,5 @@
 import { mergeRefs, useObjectRef } from "@react-aria/utils";
+import omit from "lodash/omit";
 import React, { forwardRef, useRef } from "react";
 import { AriaButtonProps, mergeProps, useButton } from "react-aria";
 import { classNames } from "../utilities/css";
@@ -47,13 +48,18 @@ export const UnstyledButton = forwardRef<null, UnstyledButtonProps>(
     const ref = useRef(null);
     const mergedRef = useObjectRef(mergeRefs(ref, inRef));
     const As = href ? "a" : "button";
-    // `onClick` is withheld from `useButton()` so that it stays a plain DOM
-    // handler and nothing else calls it. `usePress()` invokes any `onClick` it
-    // is handed, which would fire the consumer's handler a second time, and on
-    // keyboard activation it invokes it with a synthesized event, where
-    // `preventDefault()` can't reach the real click that the router reads.
+    // `useButton()` hands `onClick` to `usePress()`, which calls it from the
+    // `onClick` it returns, so exactly one of that path and the DOM spread below
+    // can carry the consumer's handler—both would fire it twice per click.
+    //
+    // Which one depends on the element. On a `<button>`, `usePress()` prevents
+    // the default keyboard behavior, so there is no native click on Enter or
+    // Space and `onClick` only arrives through `usePress()`. An anchor keeps its
+    // native click, and there `usePress()` is the wrong path: on keyboard
+    // activation it synthesizes an event, and `preventDefault()` on that fake
+    // event can't stop the real click the router reads.
     const { buttonProps: elementProps } = useButton(
-      { ...props, onClick: undefined, elementType: As },
+      { ...props, onClick: href ? undefined : props.onClick, elementType: As },
       ref,
     );
 
@@ -67,7 +73,9 @@ export const UnstyledButton = forwardRef<null, UnstyledButtonProps>(
     return (
       <As
         {...mergeProps(
-          omitReactAriaSpecificProps(restProps),
+          omitReactAriaSpecificProps(
+            href ? restProps : omit(restProps, "onClick"),
+          ),
           elementProps,
           routerLinkProps,
         )}

--- a/easy-ui-react/src/UnstyledButton/UnstyledButton.tsx
+++ b/easy-ui-react/src/UnstyledButton/UnstyledButton.tsx
@@ -48,18 +48,30 @@ export const UnstyledButton = forwardRef<null, UnstyledButtonProps>(
     const ref = useRef(null);
     const mergedRef = useObjectRef(mergeRefs(ref, inRef));
     const As = href ? "a" : "button";
+
     // `useButton()` hands `onClick` to `usePress()`, which calls it from the
     // `onClick` it returns, so exactly one of that path and the DOM spread below
     // can carry the consumer's handler—both would fire it twice per click.
     //
-    // Which one depends on the element. On a `<button>`, `usePress()` prevents
-    // the default keyboard behavior, so there is no native click on Enter or
-    // Space and `onClick` only arrives through `usePress()`. An anchor keeps its
-    // native click, and there `usePress()` is the wrong path: on keyboard
-    // activation it synthesizes an event, and `preventDefault()` on that fake
-    // event can't stop the real click the router reads.
+    // Which one depends on whether the element still fires a native click on
+    // Enter or Space. Where it does, `onClick` has to stay a plain DOM handler:
+    // `usePress()` would call it with an event it synthesized, and
+    // `preventDefault()` on that fake event can't stop the real click, whether
+    // that click navigates or submits a form. Where it doesn't, `usePress()` is
+    // the only path left, and withholding `onClick` from it would mean the
+    // handler never runs from the keyboard at all.
+    //
+    // React Aria suppresses the native click for a plain `<button>` only.
+    // Anchors keep theirs, and so do submit and reset buttons, whose whole
+    // purpose is the default the click carries.
+    const keepsNativeClick =
+      Boolean(href) || props.type === "submit" || props.type === "reset";
     const { buttonProps: elementProps } = useButton(
-      { ...props, onClick: href ? undefined : props.onClick, elementType: As },
+      {
+        ...props,
+        onClick: keepsNativeClick ? undefined : props.onClick,
+        elementType: As,
+      },
       ref,
     );
 
@@ -74,7 +86,7 @@ export const UnstyledButton = forwardRef<null, UnstyledButtonProps>(
       <As
         {...mergeProps(
           omitReactAriaSpecificProps(
-            href ? restProps : omit(restProps, "onClick"),
+            keepsNativeClick ? restProps : omit(restProps, "onClick"),
           ),
           elementProps,
           routerLinkProps,

--- a/easy-ui-react/src/VerticalNav/Item.tsx
+++ b/easy-ui-react/src/VerticalNav/Item.tsx
@@ -1,29 +1,31 @@
 import { ComponentProps, ElementType, ReactNode } from "react";
 import { Item as ReactStatelyItem } from "react-stately";
 import { IconSymbol } from "../types";
+import { RouterLinkProps } from "../utilities/router";
 
-export type ItemProps<T extends ElementType = "a"> = ComponentProps<T> & {
-  /**
-   * Custom element to render the item as.
-   */
-  as?: T;
+export type ItemProps<T extends ElementType = "a"> = ComponentProps<T> &
+  RouterLinkProps & {
+    /**
+     * Custom element to render the item as.
+     */
+    as?: T;
 
-  /**
-   * Nested subnavigation for the navigation item.
-   */
-  children?: ReactNode;
+    /**
+     * Nested subnavigation for the navigation item.
+     */
+    children?: ReactNode;
 
-  /**
-   * Icon symbol of the navigation item. This is only applicable on top-level
-   * navigation items.
-   */
-  icon?: IconSymbol;
+    /**
+     * Icon symbol of the navigation item. This is only applicable on top-level
+     * navigation items.
+     */
+    icon?: IconSymbol;
 
-  /**
-   * Label shown on the navigation item.
-   */
-  label: string;
-};
+    /**
+     * Label shown on the navigation item.
+     */
+    label: string;
+  };
 
 export type ItemPropsForStately = ItemProps & { textValue: string };
 

--- a/easy-ui-react/src/VerticalNav/NavItem.tsx
+++ b/easy-ui-react/src/VerticalNav/NavItem.tsx
@@ -4,6 +4,7 @@ import { mergeProps, useHover } from "react-aria";
 import { Icon } from "../Icon";
 import { Text } from "../Text";
 import { classNames } from "../utilities/css";
+import { useRouterLinkProps } from "../utilities/router";
 import { ItemPropsForStately } from "./Item";
 
 import styles from "./NavItem.module.scss";
@@ -32,9 +33,14 @@ export function NavItem(props: NavItemProps) {
     icon,
     label,
     textValue: _textValue,
+    routerOptions: _routerOptions,
     ...linkProps
   } = item.props as ItemPropsForStately;
   const { hoverProps, isHovered } = useHover({});
+  const routerLinkProps = useRouterLinkProps(
+    item.props as ItemPropsForStately,
+    As === "a",
+  );
   const className = classNames(
     styles.NavItem,
     isHovered && styles.hovered,
@@ -47,7 +53,7 @@ export function NavItem(props: NavItemProps) {
           className={styles.link}
           aria-current={isSelected ? "true" : undefined}
           aria-expanded={isExpanded ? "true" : undefined}
-          {...mergeProps(hoverProps, linkProps)}
+          {...mergeProps(hoverProps, linkProps, routerLinkProps)}
         >
           {icon && <Icon symbol={icon} />}
           <Text variant="subtitle2">{label}</Text>

--- a/easy-ui-react/src/VerticalNav/SubnavItem.tsx
+++ b/easy-ui-react/src/VerticalNav/SubnavItem.tsx
@@ -3,6 +3,7 @@ import { mergeProps, useHover } from "react-aria";
 import { ListState, Node } from "react-stately";
 import { Text } from "../Text";
 import { classNames } from "../utilities/css";
+import { useRouterLinkProps } from "../utilities/router";
 import { ItemPropsForStately } from "./Item";
 import { SubnavItemDot } from "./SubnavItemDot";
 import { useVerticalNavType } from "./context";
@@ -23,10 +24,15 @@ export function SubnavItem(props: SubnavItemProps) {
     label,
     icon,
     textValue: _textValue,
+    routerOptions: _routerOptions,
     ...linkProps
   } = item.props as ItemPropsForStately;
   const isSelected = state.selectionManager.isSelected(item.key);
   const { hoverProps, isHovered } = useHover({});
+  const routerLinkProps = useRouterLinkProps(
+    item.props as ItemPropsForStately,
+    As === "a",
+  );
   const className = classNames(
     styles.SubnavItem,
     isSelected && styles.selected,
@@ -40,7 +46,7 @@ export function SubnavItem(props: SubnavItemProps) {
       <As
         className={styles.link}
         aria-current={isSelected ? "true" : undefined}
-        {...mergeProps(hoverProps, linkProps)}
+        {...mergeProps(hoverProps, linkProps, routerLinkProps)}
       >
         {(type === "list" || level > 1) && (
           <SubnavItemDot isCozy={type === "list"} isVisible={isSelected} />

--- a/easy-ui-react/src/VerticalNav/SupplementaryAction.tsx
+++ b/easy-ui-react/src/VerticalNav/SupplementaryAction.tsx
@@ -7,23 +7,26 @@ import React, {
   ReactNode,
   forwardRef,
 } from "react";
+import { mergeProps } from "react-aria";
 import { Icon } from "../Icon";
 import { Text } from "../Text";
+import { RouterLinkProps, useRouterLinkProps } from "../utilities/router";
 
 import styles from "./SupplementaryAction.module.scss";
 
 export type SupplementaryActionProps<T extends ElementType = "button"> =
-  ComponentProps<T> & {
-    /**
-     * Custom element to render the supplementary action as.
-     */
-    as?: T;
+  ComponentProps<T> &
+    RouterLinkProps & {
+      /**
+       * Custom element to render the supplementary action as.
+       */
+      as?: T;
 
-    /**
-     * Text content to render in the supplementary action.
-     */
-    children: ReactNode;
-  };
+      /**
+       * Text content to render in the supplementary action.
+       */
+      children: ReactNode;
+    };
 
 /**
  * Represents a default supplementary action for a vertical navigation. Renders
@@ -36,9 +39,22 @@ export const SupplementaryAction = forwardRef<
   HTMLButtonElement,
   SupplementaryActionProps
 >((props, ref) => {
-  const { as: As = "button", children, ...elementProps } = props;
+  const {
+    as: As = "button",
+    children,
+    routerOptions: _routerOptions,
+    ...elementProps
+  } = props;
+  const routerLinkProps = useRouterLinkProps(
+    props,
+    (As as ElementType) === "a",
+  );
   return (
-    <As ref={ref} className={styles.SupplementaryAction} {...elementProps}>
+    <As
+      ref={ref}
+      className={styles.SupplementaryAction}
+      {...mergeProps(elementProps, routerLinkProps)}
+    >
       <Text variant="subtitle2">{children}</Text>
       <Icon symbol={ArrowForwardIosIcon} size="xs" />
     </As>

--- a/easy-ui-react/src/VerticalNav/VerticalNav.mdx
+++ b/easy-ui-react/src/VerticalNav/VerticalNav.mdx
@@ -138,9 +138,31 @@ _Example structure_:
 
 <Canvas of={VerticalNavStories.WithinACard} />
 
+## Client-side routing
+
+Pass a `navigate` function to `<Provider />` and `VerticalNav.Item`s navigate
+through your app's router instead of doing a full page load:
+
+```tsx
+import { Provider as EasyUIProvider } from "@easypost/easy-ui/Provider";
+import { useNavigate, useHref } from "react-router";
+
+<EasyUIProvider navigate={useNavigate()} useHref={useHref}>
+  <VerticalNav aria-label="Nav">
+    <VerticalNav.Item key="1" href="/1" label="Item 1" />
+  </VerticalNav>
+</EasyUIProvider>;
+```
+
+The example below is wired to a fake router. Its items are regular links with
+regular `href`s—the router is what keeps them from loading a new page.
+
+<Canvas of={VerticalNavStories.ClientSideRouting} />
+
 ## Polymorphic items
 
-`VerticalNav.Item` are polymorphic items. For example, they can support client-side links:
+`VerticalNav.Item` are polymorphic items. Use the `as` prop when an item needs a
+specific link component rather than the router configured on `<Provider />`:
 
 _Example polymorphic items_:
 

--- a/easy-ui-react/src/VerticalNav/VerticalNav.stories.tsx
+++ b/easy-ui-react/src/VerticalNav/VerticalNav.stories.tsx
@@ -11,7 +11,7 @@ import { Icon } from "../Icon";
 import { Menu } from "../Menu";
 import { Text } from "../Text";
 import { UnstyledButton } from "../UnstyledButton";
-import { EasyPostFullLogo } from "../utilities/storybook";
+import { EasyPostFullLogo, FakeClientSideRouter } from "../utilities/storybook";
 import { ListVerticalNavProps } from "./ListVerticalNav";
 import { TreeVerticalNavProps } from "./TreeVerticalNav";
 import { ExpandableVerticalNav, VerticalNav } from "./VerticalNav";
@@ -159,6 +159,35 @@ export const WithinACard: TreeStory = {
   },
   decorators: [FakeCardDecorator],
 };
+
+// Items render as regular anchors with regular hrefs; the router configured on
+// `<Provider />` is what keeps clicking them from loading a new page.
+export const ClientSideRouting: ListStory = {
+  render: (args) => (
+    <FakeClientSideRouter initialPath={itemPath("1")}>
+      {(path) => (
+        <div style={{ width: 215, background: "#fff" }}>
+          <VerticalNav {...args} selectedKey={path}>
+            {[MenuBookIcon, LocalPostOfficeIcon, LocalShippingIcon].map(
+              (icon, i) => (
+                <VerticalNav.Item
+                  key={itemPath(String(i + 1))}
+                  icon={icon}
+                  label={`Item ${i + 1}`}
+                  href={itemPath(String(i + 1))}
+                />
+              ),
+            )}
+          </VerticalNav>
+        </div>
+      )}
+    </FakeClientSideRouter>
+  ),
+};
+
+function itemPath(key: string) {
+  return `/item-${key}`;
+}
 
 function getExpandableChildren() {
   return [

--- a/easy-ui-react/src/utilities/router.ts
+++ b/easy-ui-react/src/utilities/router.ts
@@ -1,0 +1,61 @@
+import { handleLinkClick, useLinkProps, useRouter } from "@react-aria/utils";
+import { LinkDOMProps } from "@react-types/shared";
+import { MouseEvent } from "react";
+
+/**
+ * Link props that Easy UI components forward to their underlying anchor
+ * element, minus `href`, `target`, and `rel`, which most of our components
+ * already declare through React Aria's button types.
+ */
+export type RouterLinkProps = Pick<
+  LinkDOMProps,
+  "download" | "hrefLang" | "ping" | "referrerPolicy" | "routerOptions"
+>;
+
+/**
+ * Connects an anchor element to the client-side router supplied through
+ * `<Provider navigate={...} useHref={...} />`.
+ *
+ * @remarks
+ * React Aria's `useButton()` renders `href` as a plain attribute and knows
+ * nothing about the router context, and several of our components build their
+ * anchors by hand, so both perform a full page load even when a `navigate`
+ * function is available. This hook supplies the missing pieces: an `href`
+ * resolved through the provider's `useHref` and an `onClick` handler that hands
+ * the navigation off to `navigate`.
+ *
+ * When no `navigate` function is provided, React Aria's router context reports
+ * itself as native and `handleLinkClick` becomes a noop, leaving the anchor to
+ * behave exactly as it did before. This makes the hook safe to add to existing
+ * components without changing their default behavior.
+ *
+ * Pass `isEnabled: false` for polymorphic components rendering something other
+ * than a native anchor. A custom element such as `next/link` is expected to
+ * handle client-side navigation itself.
+ *
+ * @param props link props from the consuming component
+ * @param isEnabled whether the underlying element is a native anchor
+ * @returns DOM props to merge onto an anchor element
+ *
+ * @example
+ * ```tsx
+ * const routerLinkProps = useRouterLinkProps(props);
+ * return <a {...mergeProps(elementProps, routerLinkProps)} />;
+ * ```
+ */
+export function useRouterLinkProps(props: LinkDOMProps, isEnabled = true) {
+  const router = useRouter();
+  // hrefs are left alone when disabled; a polymorphic component can be handed
+  // an href only its own link component understands, such as the URL objects
+  // next/link accepts
+  const linkProps = useLinkProps(isEnabled ? props : {});
+  if (!isEnabled || !props.href) {
+    return {};
+  }
+  return {
+    ...linkProps,
+    onClick(e: MouseEvent) {
+      handleLinkClick(e, router, props.href, props.routerOptions);
+    },
+  };
+}

--- a/easy-ui-react/src/utilities/router.ts
+++ b/easy-ui-react/src/utilities/router.ts
@@ -29,12 +29,13 @@ export type RouterLinkProps = Pick<
  * behave exactly as it did before. This makes the hook safe to add to existing
  * components without changing their default behavior.
  *
- * Pass `isEnabled: false` for polymorphic components rendering something other
- * than a native anchor. A custom element such as `next/link` is expected to
- * handle client-side navigation itself.
+ * Pass `isEnabled: false` when the element shouldn't be linked at all—a
+ * polymorphic component rendering something other than a native anchor, whose
+ * custom element such as `next/link` handles client-side navigation itself, or
+ * a disabled element, which React Aria renders without an `href`.
  *
  * @param props link props from the consuming component
- * @param isEnabled whether the underlying element is a native anchor
+ * @param isEnabled whether the underlying element is an enabled native anchor
  * @returns DOM props to merge onto an anchor element
  *
  * @example

--- a/easy-ui-react/src/utilities/storybook.tsx
+++ b/easy-ui-react/src/utilities/storybook.tsx
@@ -1,11 +1,14 @@
 import tokens from "@easypost/easy-ui-tokens/js/tokens";
 import { Decorator } from "@storybook/react";
-import React, { ComponentProps, ReactNode, SVGProps } from "react";
+import React, { ComponentProps, ReactNode, SVGProps, useState } from "react";
 import type { Placement as AriaPlacement } from "react-aria";
 import { getThemeTokenAliases } from "../Theme";
 import { getTokenAliases } from "./tokens";
 import { SortDescriptor } from "react-stately";
 import { Menu } from "../Menu";
+import { Provider } from "../Provider";
+import { Text } from "../Text";
+import { VerticalStack } from "../VerticalStack";
 import {
   FILLED_BUTTON_COLORS,
   OUTLINED_BUTTON_COLORS,
@@ -403,6 +406,50 @@ export function FakeSidebarNav() {
 // TabNav shouldn't use `button`s in production.
 export function FakeClientSideRouterLink(props: ComponentProps<"button">) {
   return <button {...props} />;
+}
+
+export type FakeClientSideRouterProps = {
+  /** Base path the fake router prepends to the hrefs it renders. */
+  basePath?: string;
+  /** Path the fake router starts on. */
+  initialPath?: string;
+  /** Story content. Receives the path the fake router is currently on. */
+  children: ReactNode | ((path: string) => ReactNode);
+};
+
+/**
+ * Renders story content within a `<Provider />` that is configured with a fake
+ * client-side router.
+ *
+ * Navigations update React state instead of loading a page, standing in for
+ * what a real router does with something like react-router's `useNavigate()`.
+ * The fake router also prepends a base path through `useHref` so that the
+ * hrefs it resolves are visible in the rendered markup.
+ */
+export function FakeClientSideRouter({
+  basePath = "/base-path",
+  initialPath = "/",
+  children,
+}: FakeClientSideRouterProps) {
+  const [path, setPath] = useState(initialPath);
+  const [options, setOptions] = useState<string>();
+  return (
+    <Provider
+      navigate={(to, routerOptions) => {
+        setPath(to);
+        setOptions(routerOptions ? JSON.stringify(routerOptions) : undefined);
+      }}
+      useHref={(href) => `${basePath}${href}`}
+    >
+      <VerticalStack gap="2">
+        {typeof children === "function" ? children(path) : children}
+        <Text variant="body2" color="neutral.500">
+          {`Router is on ${basePath}${path}`}
+          {options ? ` with options ${options}` : ""}
+        </Text>
+      </VerticalStack>
+    </Provider>
+  );
 }
 
 export function helpMenuItems() {

--- a/easy-ui-react/src/utilities/storybook.tsx
+++ b/easy-ui-react/src/utilities/storybook.tsx
@@ -5,8 +5,8 @@ import type { Placement as AriaPlacement } from "react-aria";
 import { getThemeTokenAliases } from "../Theme";
 import { getTokenAliases } from "./tokens";
 import { SortDescriptor } from "react-stately";
+import { RouterProvider } from "@react-aria/utils";
 import { Menu } from "../Menu";
-import { Provider } from "../Provider";
 import { Text } from "../Text";
 import { VerticalStack } from "../VerticalStack";
 import {
@@ -418,14 +418,17 @@ export type FakeClientSideRouterProps = {
 };
 
 /**
- * Renders story content within a `<Provider />` that is configured with a fake
- * client-side router.
+ * Renders story content within a fake client-side router.
  *
  * Navigations update React state instead of loading a page, standing in for
  * what a real router does with something like react-router's `useNavigate()`.
  * The fake router also prepends a base path through `useHref` so that the
  * hrefs it resolves are visible in the rendered markup. Only root-relative
  * hrefs are prepended, leaving links to other origins intact.
+ *
+ * Apps supply their router to `<Provider navigate useHref />`, which renders
+ * the router provider used here. Stories are already wrapped in a `<Provider />`
+ * by Storybook's preview, so this helper renders the router provider on its own.
  */
 export function FakeClientSideRouter({
   basePath = "/base-path",
@@ -435,7 +438,7 @@ export function FakeClientSideRouter({
   const [path, setPath] = useState(initialPath);
   const [options, setOptions] = useState<string>();
   return (
-    <Provider
+    <RouterProvider
       navigate={(to, routerOptions) => {
         setPath(to);
         setOptions(routerOptions ? JSON.stringify(routerOptions) : undefined);
@@ -449,7 +452,7 @@ export function FakeClientSideRouter({
           {options ? ` with options ${options}` : ""}
         </Text>
       </VerticalStack>
-    </Provider>
+    </RouterProvider>
   );
 }
 

--- a/easy-ui-react/src/utilities/storybook.tsx
+++ b/easy-ui-react/src/utilities/storybook.tsx
@@ -424,7 +424,8 @@ export type FakeClientSideRouterProps = {
  * Navigations update React state instead of loading a page, standing in for
  * what a real router does with something like react-router's `useNavigate()`.
  * The fake router also prepends a base path through `useHref` so that the
- * hrefs it resolves are visible in the rendered markup.
+ * hrefs it resolves are visible in the rendered markup. Only root-relative
+ * hrefs are prepended, leaving links to other origins intact.
  */
 export function FakeClientSideRouter({
   basePath = "/base-path",
@@ -439,7 +440,7 @@ export function FakeClientSideRouter({
         setPath(to);
         setOptions(routerOptions ? JSON.stringify(routerOptions) : undefined);
       }}
-      useHref={(href) => `${basePath}${href}`}
+      useHref={(href) => (href.startsWith("/") ? `${basePath}${href}` : href)}
     >
       <VerticalStack gap="2">
         {typeof children === "function" ? children(path) : children}


### PR DESCRIPTION
## 📝 Changes

Makes Easy UI in line with supporting client side routing via `RouterProvider`:
https://react-spectrum.adobe.com/v3/routing.html

`<Provider navigate useHref />` populates React Aria's router context, but that context is only read by hooks that call `useRouter()`/`useLinkProps()`. `useButton()` isn't one of them — it renders `href` as a plain attribute — and several nav components build their anchors by hand. Those components did a full page load even when a `navigate` function was configured.

Adds `useRouterLinkProps()`, which resolves `href` through the provider's `useHref` and returns an `onClick` that delegates to `navigate` via React Aria's `handleLinkClick`. Wires it into `<UnstyledButton />` (covering `<Button />`, `<IconButton />`, `<DropdownButton />`, `<KebabButton />`, `<PlanCard.Button />`, `<Pagination />`, `<SearchNav />` CTAs, and `<ForgeLayout.BackButton />`), `<TabNav.Item />`, `<VerticalNav.Item />`, `<VerticalNav.Subnav.Item />`, and `<VerticalNav.SupplementaryAction />`. These components also accept `routerOptions` now.

`<Menu.Item href />` already client navigated through `useMenuItem()`, but re-applied the raw `href` on top of the resolved one; it now respects `useHref` too.

Backwards compatible: without a `navigate` function React Aria's router context reports itself as native and `handleLinkClick` is a noop, so links behave exactly as before. Cross-origin links, `target="_blank"`, downloads, and modifier-clicked links keep loading normally. The `as`/`hrefComponent` escape hatches still work and take precedence over the provider's router, so apps can migrate a route at a time.

Adds `ClientSideRouting` stories for `<Button />`, `<TabNav />`, `<VerticalNav />`, and `<Menu />` that wire the components to a fake router through `<Provider />`, plus the docs sections that render them.

## ✅ Checklist

Easy UI has certain UX standards that must be met. In general, non-trivial changes should meet the following criteria:

- [x] Visuals match Design Specs in Figma
- [x] Stories accompany any component changes
- [x] Code is in accordance with our style guide
- [x] Design tokens are utilized
- [x] Unit tests accompany any component changes
- [x] TSDoc is written for any API surface area
- [x] Specs are up-to-date
- [x] Console is free from warnings
- [x] No accessibility violations are reported
- [x] Cross-browser check is performed (Chrome, Safari, Firefox)
- [x] Changeset is added

~Strikethrough~ any items that are not applicable to this pull request.
