### PR TITLE
feat(DataGrid, Pagination): sticky footer with numbered pagination and rows per page

### DIFF
--- a/.changeset/datagrid-sticky-footer.md
+++ b/.changeset/datagrid-sticky-footer.md
@@ -2,4 +2,4 @@
 "@easypost/easy-ui": minor
 ---
 
-Adds a sticky footer to `<DataGrid />` through `renderFooter`, along with `<DataGrid.Footer />`, `<DataGrid.Pagination />`, and `<DataGrid.RowsPerPage />`. Adds a numbered pagination scheme to `<Pagination />` through `<Pagination.Pages />` and a rows per page menu through `<Pagination.RowsPerPage />`, both in two sizes through `size`. Also lightens `<DataGrid />`'s sticky shadows, which affects the frozen column shadows as well as the new footer's
+Adds a sticky footer to `<DataGrid />` through `renderFooter`, along with `<DataGrid.Footer />`, `<DataGrid.Pagination />`, and `<DataGrid.RowsPerPage />`. Adds a numbered pagination scheme to `<Pagination />` through `<Pagination.Pages />` and a rows per page menu through `<Pagination.RowsPerPage />`, both in two sizes through `size`. Also lightens `<DataGrid />`'s sticky shadows, which affects the sticky header and frozen column shadows

--- a/.changeset/datagrid-sticky-footer.md
+++ b/.changeset/datagrid-sticky-footer.md
@@ -2,4 +2,4 @@
 "@easypost/easy-ui": minor
 ---
 
-Adds a sticky footer to `<DataGrid />` through `renderFooter`, along with `<DataGrid.Footer />`, `<DataGrid.Pagination />`, and `<DataGrid.RowsPerPageMenu />`, and adds a numbered pagination scheme to `<Pagination />` through `<Pagination.Pages />`
+Adds a sticky footer to `<DataGrid />` through `renderFooter`, along with `<DataGrid.Footer />`, `<DataGrid.Pagination />`, and `<DataGrid.RowsPerPageMenu />`, and adds a numbered pagination scheme to `<Pagination />` through `<Pagination.Pages />`. Also lightens `<DataGrid />`'s sticky shadows, which affects the frozen column shadows as well as the new footer's

--- a/.changeset/datagrid-sticky-footer.md
+++ b/.changeset/datagrid-sticky-footer.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": minor
+---
+
+Adds a sticky footer to `<DataGrid />` through `renderFooter`, along with `<DataGrid.Footer />`, `<DataGrid.Pagination />`, and `<DataGrid.RowsPerPageMenu />`, and adds a numbered pagination scheme to `<Pagination />` through `<Pagination.Pages />`

--- a/.changeset/datagrid-sticky-footer.md
+++ b/.changeset/datagrid-sticky-footer.md
@@ -2,4 +2,4 @@
 "@easypost/easy-ui": minor
 ---
 
-Adds a sticky footer to `<DataGrid />` through `renderFooter`, along with `<DataGrid.Footer />`, `<DataGrid.Pagination />`, and `<DataGrid.RowsPerPageMenu />`, and adds a numbered pagination scheme to `<Pagination />` through `<Pagination.Pages />`, in two sizes through `size`. Also lightens `<DataGrid />`'s sticky shadows, which affects the frozen column shadows as well as the new footer's
+Adds a sticky footer to `<DataGrid />` through `renderFooter`, along with `<DataGrid.Footer />`, `<DataGrid.Pagination />`, and `<DataGrid.RowsPerPage />`. Adds a numbered pagination scheme to `<Pagination />` through `<Pagination.Pages />` and a rows per page menu through `<Pagination.RowsPerPage />`, both in two sizes through `size`. Also lightens `<DataGrid />`'s sticky shadows, which affects the frozen column shadows as well as the new footer's

--- a/.changeset/datagrid-sticky-footer.md
+++ b/.changeset/datagrid-sticky-footer.md
@@ -2,4 +2,4 @@
 "@easypost/easy-ui": minor
 ---
 
-Adds a sticky footer to `<DataGrid />` through `renderFooter`, along with `<DataGrid.Footer />`, `<DataGrid.Pagination />`, and `<DataGrid.RowsPerPageMenu />`, and adds a numbered pagination scheme to `<Pagination />` through `<Pagination.Pages />`. Also lightens `<DataGrid />`'s sticky shadows, which affects the frozen column shadows as well as the new footer's
+Adds a sticky footer to `<DataGrid />` through `renderFooter`, along with `<DataGrid.Footer />`, `<DataGrid.Pagination />`, and `<DataGrid.RowsPerPageMenu />`, and adds a numbered pagination scheme to `<Pagination />` through `<Pagination.Pages />`, in two sizes through `size`. Also lightens `<DataGrid />`'s sticky shadows, which affects the frozen column shadows as well as the new footer's

--- a/easy-ui-react/src/DataGrid/ColumnHeader.module.scss
+++ b/easy-ui-react/src/DataGrid/ColumnHeader.module.scss
@@ -63,7 +63,10 @@
 }
 
 .shadowBottom [data-ezui-data-grid-shadow="bottom"] {
-  @include DataGrid.shadow(bottom);
+  @include DataGrid.shadow(
+    bottom,
+    $opacity: component-token("data-grid", "header-shadow-opacity")
+  );
 }
 
 .shadowRight [data-ezui-data-grid-shadow="side"] {

--- a/easy-ui-react/src/DataGrid/ColumnHeader.module.scss
+++ b/easy-ui-react/src/DataGrid/ColumnHeader.module.scss
@@ -63,7 +63,7 @@
 }
 
 .shadowBottom [data-ezui-data-grid-shadow="bottom"] {
-  @include DataGrid.shadow(bottom, $backdrop: true);
+  @include DataGrid.shadow(bottom);
 }
 
 .shadowRight [data-ezui-data-grid-shadow="side"] {

--- a/easy-ui-react/src/DataGrid/DataGrid.mdx
+++ b/easy-ui-react/src/DataGrid/DataGrid.mdx
@@ -256,8 +256,69 @@ In the example below, to make the status text green or red depending on whether 
 
 <Controls of={DataGridStories.LoadingState} />
 
+## Footer
+
+`DataGrid` supports rendering a footer through the `renderFooter` prop. The footer sticks to the bottom of the data grid the same way the column header sticks to the top, staying in place as rows scroll underneath and casting a shadow over them once there's anything to scroll. It stays mounted through the empty and loading states.
+
+`renderFooter` controls what goes inside. `<DataGrid.Footer />` lays that content out into `start`, `center`, and `end` regions, which are positional rather than named after what they hold — the footer carries no assumptions about how a consumer pages through the grid.
+
+`<DataGrid.Pagination />` and `<DataGrid.RowsPerPageMenu />` cover the common case. Both are fully controlled.
+
+```tsx
+const [page, setPage] = useState(1);
+const [rowsPerPage, setRowsPerPage] = useState(50);
+
+<DataGrid
+  aria-label="Data grid with a footer"
+  columns={columns}
+  rows={rows}
+  renderColumnCell={(column) => <span>{String(column.name)}</span>}
+  renderRowCell={(item) => <span>{String(item)}</span>}
+  renderFooter={() => (
+    <DataGrid.Footer
+      center={<DataGrid.Pagination page={page} count={10} onChange={setPage} />}
+      end={
+        <DataGrid.RowsPerPageMenu
+          rowsPerPage={rowsPerPage}
+          options={[25, 50, 100]}
+          onChange={setRowsPerPage}
+        />
+      }
+    />
+  )}
+/>;
+```
+
+<Canvas of={DataGridStories.WithFooter} />
+
+<Controls of={DataGridStories.WithFooter} />
+
+Unlike the rest of the data grid, the footer's height is fixed and doesn't scale with `size`. `maxRows` still counts body rows, so adding a footer grows the data grid rather than eating into the rows it shows.
+
+### With a Custom Footer
+
+The regions accept anything, so a footer needn't paginate at all.
+
+<Canvas of={DataGridStories.WithCustomFooter} />
+
+### Footer with an Empty State
+
+<Canvas of={DataGridStories.FooterWithEmptyState} />
+
 ## Properties
 
 ### DataGrid
 
 <ArgTypes of={DataGrid} />
+
+### DataGrid.Footer
+
+<ArgTypes of={DataGrid.Footer} />
+
+### DataGrid.Pagination
+
+<ArgTypes of={DataGrid.Pagination} />
+
+### DataGrid.RowsPerPageMenu
+
+<ArgTypes of={DataGrid.RowsPerPageMenu} />

--- a/easy-ui-react/src/DataGrid/DataGrid.mdx
+++ b/easy-ui-react/src/DataGrid/DataGrid.mdx
@@ -262,7 +262,7 @@ In the example below, to make the status text green or red depending on whether 
 
 `renderFooter` controls what goes inside. `<DataGrid.Footer />` lays that content out into `start`, `center`, and `end` regions, which are positional rather than named after what they hold — the footer carries no assumptions about how a consumer pages through the grid.
 
-`<DataGrid.Pagination />` and `<DataGrid.RowsPerPageMenu />` cover the common case. Both are fully controlled.
+`<DataGrid.Pagination />` and `<DataGrid.RowsPerPage />` cover the common case. Both are fully controlled.
 
 ```tsx
 const [page, setPage] = useState(1);
@@ -278,7 +278,7 @@ const [rowsPerPage, setRowsPerPage] = useState(50);
     <DataGrid.Footer
       center={<DataGrid.Pagination page={page} count={10} onChange={setPage} />}
       end={
-        <DataGrid.RowsPerPageMenu
+        <DataGrid.RowsPerPage
           rowsPerPage={rowsPerPage}
           options={[25, 50, 100]}
           onChange={setRowsPerPage}
@@ -319,6 +319,6 @@ The regions accept anything, so a footer needn't paginate at all.
 
 <ArgTypes of={DataGrid.Pagination} />
 
-### DataGrid.RowsPerPageMenu
+### DataGrid.RowsPerPage
 
-<ArgTypes of={DataGrid.RowsPerPageMenu} />
+<ArgTypes of={DataGrid.RowsPerPage} />

--- a/easy-ui-react/src/DataGrid/DataGrid.module.scss
+++ b/easy-ui-react/src/DataGrid/DataGrid.module.scss
@@ -50,6 +50,10 @@
   // which is `color.neutral.300` at a quarter, so every sticky edge of the grid
   // reads at the weight the footer's real shadow does.
   @include component-token("data-grid", "sticky-shadow-opacity", 0.25);
+  // A dark header is a hard edge against the rows, which swamps a shadow this
+  // light, so the header carries its own weight. `.headerSecondary` is light
+  // enough not to need it and drops back to the weight of the other edges.
+  @include component-token("data-grid", "header-shadow-opacity", 0.45);
   @include component-token(
     "data-grid",
     "sticky-shadow-color",
@@ -130,6 +134,11 @@
 }
 
 .headerSecondary {
+  @include component-token(
+    "data-grid",
+    "header-shadow-opacity",
+    component-token("data-grid", "sticky-shadow-opacity")
+  );
   @include component-token(
     "data-grid",
     "header-bg",

--- a/easy-ui-react/src/DataGrid/DataGrid.module.scss
+++ b/easy-ui-react/src/DataGrid/DataGrid.module.scss
@@ -44,7 +44,7 @@
     design-token("color.neutral.100")
   );
   @include component-token("data-grid", "sticky-shadow-size", 8px);
-  @include component-token("data-grid", "sticky-shadow-opacity", 0.5);
+  @include component-token("data-grid", "sticky-shadow-opacity", 0.35);
   @include component-token(
     "data-grid",
     "sticky-shadow-color",

--- a/easy-ui-react/src/DataGrid/DataGrid.module.scss
+++ b/easy-ui-react/src/DataGrid/DataGrid.module.scss
@@ -53,7 +53,7 @@
   // A dark header is a hard edge against the rows, which swamps a shadow this
   // light, so the header carries its own weight. `.headerSecondary` is light
   // enough not to need it and drops back to the weight of the other edges.
-  @include component-token("data-grid", "header-shadow-opacity", 0.45);
+  @include component-token("data-grid", "header-shadow-opacity", 0.65);
   @include component-token(
     "data-grid",
     "sticky-shadow-color",

--- a/easy-ui-react/src/DataGrid/DataGrid.module.scss
+++ b/easy-ui-react/src/DataGrid/DataGrid.module.scss
@@ -13,6 +13,15 @@
   );
   @include component-token("data-grid", "header-row-height", 48px);
   @include component-token("data-grid", "body-row-height", 48px);
+  // Zero until a footer is rendered, at which point `.hasFooter` gives it the
+  // footer's height so `max-rows` still counts visible body rows
+  @include component-token("data-grid", "footer-row-height", 0px);
+  @include component-token("data-grid", "footer-width", 100%);
+  @include component-token(
+    "data-grid",
+    "footer-bg",
+    design-token("color.neutral.000")
+  );
   @include component-token("data-grid", "expand-btn-size", 24px);
   @include component-token(
     "data-grid",
@@ -56,6 +65,7 @@
   @include component-token("data-grid", "expanded-row-z-index", 3);
   @include component-token("data-grid", "column-z-index", 4);
   @include component-token("data-grid", "column-stuck-z-index", 5);
+  @include component-token("data-grid", "footer-z-index", 6);
   @include component-token("data-grid", "sticky-left-offset", -16px);
   @include component-token("data-grid", "sticky-right-offset", -12px);
   @include component-token("data-grid", "action-cell-width", 44px);
@@ -68,6 +78,7 @@
   max-height: calc(
     (component-token("data-grid", "border-width") * 2) +
       component-token("data-grid", "header-row-height") +
+      component-token("data-grid", "footer-row-height") +
       (
         component-token("data-grid", "body-row-height") *
           component-token("data-grid", "max-rows")
@@ -80,6 +91,11 @@
   [data-ezui-data-grid-shadow] {
     position: absolute;
   }
+}
+
+// Per design, the footer's height is fixed and doesn't scale with `size`
+.hasFooter {
+  @include component-token("data-grid", "footer-row-height", 54px);
 }
 
 .sizeSm {

--- a/easy-ui-react/src/DataGrid/DataGrid.module.scss
+++ b/easy-ui-react/src/DataGrid/DataGrid.module.scss
@@ -44,11 +44,16 @@
     design-token("color.neutral.100")
   );
   @include component-token("data-grid", "sticky-shadow-size", 8px);
-  @include component-token("data-grid", "sticky-shadow-opacity", 0.35);
+  // The header and frozen columns can't carry the `shadow.stuck-from-*` tokens:
+  // they're cast by table cells, and box shadows don't paint on those once the
+  // table's borders are collapsed. Their gradient band mimics the token instead,
+  // which is `color.neutral.300` at a quarter, so every sticky edge of the grid
+  // reads at the weight the footer's real shadow does.
+  @include component-token("data-grid", "sticky-shadow-opacity", 0.25);
   @include component-token(
     "data-grid",
     "sticky-shadow-color",
-    design-token("color.neutral.500")
+    design-token("color.neutral.300")
   );
   @include component-token(
     "data-grid",

--- a/easy-ui-react/src/DataGrid/DataGrid.stories.tsx
+++ b/easy-ui-react/src/DataGrid/DataGrid.stories.tsx
@@ -407,7 +407,7 @@ function WithFooterTemplate(args: Partial<DataGridProps>) {
             <DataGrid.Pagination page={page} count={10} onChange={setPage} />
           }
           end={
-            <DataGrid.RowsPerPageMenu
+            <DataGrid.RowsPerPage
               rowsPerPage={rowsPerPage}
               options={[25, 50, 100]}
               onChange={setRowsPerPage}

--- a/easy-ui-react/src/DataGrid/DataGrid.stories.tsx
+++ b/easy-ui-react/src/DataGrid/DataGrid.stories.tsx
@@ -2,11 +2,12 @@ import CheckCircleIcon from "@easypost/easy-ui-icons/CheckCircle";
 import ErrorIcon from "@easypost/easy-ui-icons/Error";
 import { action } from "storybook/actions";
 import { Meta, StoryObj } from "@storybook/react-vite";
-import React from "react";
+import React, { useState } from "react";
 import { Key } from "react-aria";
 import { useAsyncList } from "react-stately";
 import { Icon } from "../Icon";
 import { Menu } from "../Menu";
+import { Text } from "../Text";
 import {
   PlaceholderBox,
   createNaiveSortingFunction,
@@ -324,6 +325,41 @@ export const LoadingState: Story = {
   },
 };
 
+export const WithFooter: Story = {
+  render: WithFooterTemplate.bind({}),
+  args: {
+    "aria-label": "Example data grid with a footer",
+    maxRows: 4,
+  },
+  parameters: {
+    controls: {
+      include: ["maxRows", "size"],
+    },
+  },
+};
+
+export const WithCustomFooter: Story = {
+  render: Template.bind({}),
+  args: {
+    "aria-label": "Example data grid with a custom footer",
+    maxRows: 4,
+    renderFooter: () => (
+      <DataGrid.Footer
+        start={<Text variant="body2">6 results</Text>}
+        end={<Text variant="body2">Updated just now</Text>}
+      />
+    ),
+  },
+};
+
+export const FooterWithEmptyState: Story = {
+  render: WithFooterTemplate.bind({}),
+  args: {
+    "aria-label": "Example data grid with a footer and no data",
+    rows: [],
+  },
+};
+
 function WithSortTemplate(args: Partial<DataGridProps>) {
   // https://react-spectrum.adobe.com/react-stately/useAsyncList.html
   const list = useAsyncList({
@@ -347,6 +383,38 @@ function WithSortTemplate(args: Partial<DataGridProps>) {
       sortDescriptor={list.sortDescriptor}
       onSortChange={list.sort}
       columnKeysAllowingSort={columns.map((c) => c.key)}
+      {...args}
+    />
+  );
+}
+
+function WithFooterTemplate(args: Partial<DataGridProps>) {
+  const [page, setPage] = useState(1);
+  const [rowsPerPage, setRowsPerPage] = useState(50);
+  return (
+    <DataGrid
+      columns={columns}
+      rows={rows}
+      renderColumnCell={(column) => (
+        <span style={{ whiteSpace: "nowrap" }}>{String(column.name)}</span>
+      )}
+      renderRowCell={(item) => (
+        <span style={{ whiteSpace: "nowrap" }}>{String(item)}</span>
+      )}
+      renderFooter={() => (
+        <DataGrid.Footer
+          center={
+            <DataGrid.Pagination page={page} count={10} onChange={setPage} />
+          }
+          end={
+            <DataGrid.RowsPerPageMenu
+              rowsPerPage={rowsPerPage}
+              options={[25, 50, 100]}
+              onChange={setRowsPerPage}
+            />
+          }
+        />
+      )}
       {...args}
     />
   );

--- a/easy-ui-react/src/DataGrid/DataGrid.test.tsx
+++ b/easy-ui-react/src/DataGrid/DataGrid.test.tsx
@@ -332,7 +332,7 @@ describe("<DataGrid />", () => {
         renderFooter: () => (
           <DataGrid.Footer
             end={
-              <DataGrid.RowsPerPageMenu
+              <DataGrid.RowsPerPage
                 rowsPerPage={50}
                 options={[25, 50, 100]}
                 onChange={handleChange}

--- a/easy-ui-react/src/DataGrid/DataGrid.test.tsx
+++ b/easy-ui-react/src/DataGrid/DataGrid.test.tsx
@@ -236,6 +236,121 @@ describe("<DataGrid />", () => {
       screen.getByRole("status", { name: /loading/i }),
     ).toBeInTheDocument();
   });
+
+  it("should render a footer", () => {
+    render(
+      createDataGrid({
+        renderFooter: () => (
+          <DataGrid.Footer
+            start={<span>Start</span>}
+            center={<span>Center</span>}
+            end={<span>End</span>}
+          />
+        ),
+      }),
+    );
+    expect(screen.getByText("Start")).toBeInTheDocument();
+    expect(screen.getByText("Center")).toBeInTheDocument();
+    expect(screen.getByText("End")).toBeInTheDocument();
+    expect(getOuterContainer()).toHaveAttribute(
+      "class",
+      expect.stringContaining("hasFooter"),
+    );
+  });
+
+  it("should render the footer outside of the grid", () => {
+    render(
+      createDataGrid({
+        renderFooter: () => <DataGrid.Footer center={<span>Center</span>} />,
+      }),
+    );
+    // Interactive footer content must sit outside the grid so it doesn't
+    // interfere with the grid's own focus management
+    expect(getFooter()).toBeInTheDocument();
+    expect(screen.getByRole("grid")).not.toContainElement(getFooter());
+  });
+
+  it("should keep the footer mounted through the empty state", () => {
+    render(
+      createDataGrid({
+        rows: [],
+        renderFooter: () => <DataGrid.Footer center={<span>Center</span>} />,
+      }),
+    );
+    expect(screen.getByText("Center")).toBeInTheDocument();
+  });
+
+  it("should keep the footer mounted through the loading state", () => {
+    render(
+      createDataGrid({
+        isLoading: true,
+        renderFooter: () => <DataGrid.Footer center={<span>Center</span>} />,
+      }),
+    );
+    expect(screen.getByText("Center")).toBeInTheDocument();
+  });
+
+  it("should not render a footer without renderFooter", () => {
+    render(createDataGrid());
+    expect(getOuterContainer()).not.toHaveAttribute(
+      "class",
+      expect.stringContaining("hasFooter"),
+    );
+  });
+
+  it("should support pagination in the footer", async () => {
+    const handleChange = vi.fn();
+    const { user } = render(
+      createDataGrid({
+        renderFooter: () => (
+          <DataGrid.Footer
+            center={
+              <DataGrid.Pagination
+                page={1}
+                count={10}
+                onChange={handleChange}
+              />
+            }
+          />
+        ),
+      }),
+    );
+    await userClick(user, screen.getByRole("button", { name: "Page 3 of 10" }));
+    expect(handleChange).toHaveBeenCalledWith(3);
+
+    // The first page is current, so there's nowhere earlier to go
+    expect(screen.getByRole("button", { name: /first/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /previous/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /next/i })).toBeEnabled();
+    expect(screen.getByRole("button", { name: /last/i })).toBeEnabled();
+  });
+
+  it("should support a rows per page menu in the footer", async () => {
+    const handleChange = vi.fn();
+    const { user } = render(
+      createDataGrid({
+        renderFooter: () => (
+          <DataGrid.Footer
+            end={
+              <DataGrid.RowsPerPageMenu
+                rowsPerPage={50}
+                options={[25, 50, 100]}
+                onChange={handleChange}
+              />
+            }
+          />
+        ),
+      }),
+    );
+    const trigger = screen.getByRole("button", {
+      name: /rows per page: 50/i,
+    });
+    await userClick(user, trigger);
+    expect(screen.getAllByRole("menuitemradio").length).toBe(3);
+
+    await userClick(user, screen.getByRole("menuitemradio", { name: "100" }));
+    expect(handleChange).toHaveBeenCalledWith(100);
+  });
 });
 
 const columns = [
@@ -275,6 +390,12 @@ function getOuterContainer() {
 
 function getInnerContainer() {
   return screen.getByRole("grid").parentElement as HTMLElement;
+}
+
+function getFooter() {
+  return getInnerContainer().querySelector(
+    "[data-ezui-data-grid-footer]",
+  ) as HTMLElement;
 }
 
 function getHead() {

--- a/easy-ui-react/src/DataGrid/DataGrid.tsx
+++ b/easy-ui-react/src/DataGrid/DataGrid.tsx
@@ -2,6 +2,9 @@ import { Key } from "@react-types/shared";
 import React, { useCallback, useMemo, useState } from "react";
 import { Cell, Column, Row, TableBody, TableHeader } from "react-stately";
 import { ActionsCellContent } from "./ActionsCellContent";
+import { DataGridFooter } from "./Footer";
+import { DataGridPagination } from "./DataGridPagination";
+import { DataGridRowsPerPageMenu } from "./RowsPerPageMenu";
 import { ExpandCellContent } from "./ExpandCellContent";
 import { Table } from "./Table";
 import { VisuallyHiddenCellContent } from "./VisuallyHiddenCellContent";
@@ -164,6 +167,32 @@ export function DataGrid<
     </DataGridContext.Provider>
   );
 }
+
+/**
+ * Lays footer content out into start, center, and end regions.
+ *
+ * @remarks
+ * Pass to a `<DataGrid />` through `renderFooter`. The regions are positional
+ * rather than named after what they hold, so the footer isn't tied to any one
+ * scheme for paging through the grid.
+ */
+DataGrid.Footer = DataGridFooter;
+
+/**
+ * A pagination preset for use within a `<DataGrid.Footer />`.
+ *
+ * @remarks
+ * Derives its button states from the current page and page count.
+ */
+DataGrid.Pagination = DataGridPagination;
+
+/**
+ * A menu for choosing how many rows a `<DataGrid />` page shows.
+ *
+ * @remarks
+ * Typically placed in the end region of a `<DataGrid.Footer />`.
+ */
+DataGrid.RowsPerPageMenu = DataGridRowsPerPageMenu;
 
 /**
  * Modifies the passed in columns to include support for Easy UI requirements.

--- a/easy-ui-react/src/DataGrid/DataGrid.tsx
+++ b/easy-ui-react/src/DataGrid/DataGrid.tsx
@@ -4,7 +4,7 @@ import { Cell, Column, Row, TableBody, TableHeader } from "react-stately";
 import { ActionsCellContent } from "./ActionsCellContent";
 import { DataGridFooter } from "./Footer";
 import { DataGridPagination } from "./DataGridPagination";
-import { DataGridRowsPerPageMenu } from "./RowsPerPageMenu";
+import { DataGridRowsPerPage } from "./DataGridRowsPerPage";
 import { ExpandCellContent } from "./ExpandCellContent";
 import { Table } from "./Table";
 import { VisuallyHiddenCellContent } from "./VisuallyHiddenCellContent";
@@ -192,7 +192,7 @@ DataGrid.Pagination = DataGridPagination;
  * @remarks
  * Typically placed in the end region of a `<DataGrid.Footer />`.
  */
-DataGrid.RowsPerPageMenu = DataGridRowsPerPageMenu;
+DataGrid.RowsPerPage = DataGridRowsPerPage;
 
 /**
  * Modifies the passed in columns to include support for Easy UI requirements.

--- a/easy-ui-react/src/DataGrid/DataGridPagination.tsx
+++ b/easy-ui-react/src/DataGrid/DataGridPagination.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { Pagination } from "../Pagination";
+
+export type DataGridPaginationProps = {
+  /** The current page. */
+  page: number;
+
+  /** The total number of pages. */
+  count: number;
+
+  /** Handler that is called when the user moves to another page. */
+  onChange: (page: number) => void;
+
+  /**
+   * Accessible label for the pagination.
+   * @default Pagination
+   */
+  label?: string;
+
+  /** Whether the pagination should be disabled. */
+  isDisabled?: boolean;
+
+  /**
+   * How many pages to show on either side of the current page.
+   * @default 2
+   */
+  siblingCount?: number;
+};
+
+/**
+ * A fully controlled pagination preset for use within a data grid footer.
+ *
+ * @remarks
+ * This derives the first, previous, next, and last button states from `page`
+ * and `count` so consumers only supply where they are and how to get
+ * elsewhere. Reach for `<Pagination />` directly for anything this doesn't
+ * cover; the data grid footer doesn't require this component.
+ *
+ * @example
+ * ```tsx
+ * <DataGrid.Pagination page={page} count={10} onChange={setPage} />
+ * ```
+ */
+export function DataGridPagination(props: DataGridPaginationProps) {
+  const {
+    page,
+    count,
+    onChange,
+    label = "Pagination",
+    isDisabled,
+    siblingCount,
+  } = props;
+
+  const hasPrevious = page > 1;
+  const hasNext = page < count;
+
+  return (
+    <Pagination
+      label={label}
+      isDisabled={isDisabled}
+      hasFirst={hasPrevious}
+      hasPrevious={hasPrevious}
+      hasNext={hasNext}
+      hasLast={hasNext}
+      onFirst={() => onChange(1)}
+      onPrevious={() => onChange(page - 1)}
+      onNext={() => onChange(page + 1)}
+      onLast={() => onChange(count)}
+    >
+      <Pagination.Pages
+        page={page}
+        count={count}
+        siblingCount={siblingCount}
+        onSelect={onChange}
+      />
+    </Pagination>
+  );
+}
+
+DataGridPagination.displayName = "DataGrid.Pagination";

--- a/easy-ui-react/src/DataGrid/DataGridPagination.tsx
+++ b/easy-ui-react/src/DataGrid/DataGridPagination.tsx
@@ -57,6 +57,8 @@ export function DataGridPagination(props: DataGridPaginationProps) {
   return (
     <Pagination
       label={label}
+      // The footer bar is a fixed height that the smaller controls are drawn to
+      size="sm"
       isDisabled={isDisabled}
       hasFirst={hasPrevious}
       hasPrevious={hasPrevious}

--- a/easy-ui-react/src/DataGrid/DataGridRowsPerPage.tsx
+++ b/easy-ui-react/src/DataGrid/DataGridRowsPerPage.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { Pagination } from "../Pagination";
+
+export type DataGridRowsPerPageProps = {
+  /** The number of rows currently shown per page. */
+  rowsPerPage: number;
+
+  /** The rows per page counts to choose from. */
+  options: number[];
+
+  /** Handler that is called when another count is selected. */
+  onChange: (rowsPerPage: number) => void;
+
+  /**
+   * Label rendered alongside the menu trigger.
+   * @default Rows Per Page:
+   */
+  label?: string;
+
+  /** Whether the menu should be disabled. */
+  isDisabled?: boolean;
+};
+
+/**
+ * A fully controlled rows per page preset for use within a data grid footer.
+ *
+ * @remarks
+ * All this pins is the size the footer bar is drawn to. Reach for
+ * `<Pagination.RowsPerPage />` directly for anything this doesn't cover; the
+ * data grid footer doesn't require this component.
+ *
+ * @example
+ * ```tsx
+ * <DataGrid.RowsPerPage
+ *   rowsPerPage={rowsPerPage}
+ *   options={[25, 50, 100]}
+ *   onChange={setRowsPerPage}
+ * />
+ * ```
+ */
+export function DataGridRowsPerPage(props: DataGridRowsPerPageProps) {
+  const { rowsPerPage, options, onChange, label, isDisabled } = props;
+  return (
+    <Pagination.RowsPerPage
+      rowsPerPage={rowsPerPage}
+      options={options}
+      onChange={onChange}
+      label={label}
+      isDisabled={isDisabled}
+      // The footer bar is a fixed height that the smaller controls are drawn to
+      size="sm"
+    />
+  );
+}
+
+DataGridRowsPerPage.displayName = "DataGrid.RowsPerPage";

--- a/easy-ui-react/src/DataGrid/Footer.module.scss
+++ b/easy-ui-react/src/DataGrid/Footer.module.scss
@@ -1,5 +1,4 @@
 @use "../styles/common" as *;
-@use "mixins" as DataGrid;
 
 .shell {
   position: sticky;
@@ -20,15 +19,13 @@
     component-token("data-grid", "border-color");
 }
 
-.shadowTop [data-ezui-data-grid-shadow="top"] {
-  @include DataGrid.shadow(top, $backdrop: true);
-
-  // The shadow is absolutely positioned, so its containing block is the shell's
-  // padding box, which the top border pushes down a hair. Left alone, the band's
-  // darkest row lands on the border and paints over it, so the shadow ends in
-  // nothing but the bar. Pulling it up by the border width lands it on the
-  // border-box edge instead, matching the header, which has no border to clear.
-  margin-bottom: component-token("data-grid", "border-width");
+// The footer casts the design system's stuck-from-bottom shadow rather than the
+// grid's own gradient band. It's a real blur, so it decays to transparent over
+// the rows instead of stacking a hard-edged ramp on a white backdrop, and the
+// footer is one full-width element, so a box shadow lands cleanly on it in a way
+// the header's per-cell shadows can't. Same treatment as `<Modal />`'s footer.
+.shadowTop {
+  box-shadow: design-token("shadow.stuck-from-bottom");
 }
 
 .DataGridFooter {

--- a/easy-ui-react/src/DataGrid/Footer.module.scss
+++ b/easy-ui-react/src/DataGrid/Footer.module.scss
@@ -22,6 +22,13 @@
 
 .shadowTop [data-ezui-data-grid-shadow="top"] {
   @include DataGrid.shadow(top, $backdrop: true);
+
+  // The shadow is absolutely positioned, so its containing block is the shell's
+  // padding box, which the top border pushes down a hair. Left alone, the band's
+  // darkest row lands on the border and paints over it, so the shadow ends in
+  // nothing but the bar. Pulling it up by the border width lands it on the
+  // border-box edge instead, matching the header, which has no border to clear.
+  margin-bottom: component-token("data-grid", "border-width");
 }
 
 .DataGridFooter {

--- a/easy-ui-react/src/DataGrid/Footer.module.scss
+++ b/easy-ui-react/src/DataGrid/Footer.module.scss
@@ -1,0 +1,54 @@
+@use "../styles/common" as *;
+@use "mixins" as DataGrid;
+
+.shell {
+  position: sticky;
+  bottom: 0;
+  left: 0;
+  z-index: component-token("data-grid", "footer-z-index");
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  width: component-token("data-grid", "footer-width");
+  // Once the footer's content needs more room than the scrollport has, the
+  // footer widens and scrolls along with the rows rather than squeezing its
+  // regions into each other
+  min-width: min-content;
+  min-height: component-token("data-grid", "footer-row-height");
+  background: component-token("data-grid", "footer-bg");
+  border-top: component-token("data-grid", "border-width") solid
+    component-token("data-grid", "border-color");
+}
+
+.shadowTop [data-ezui-data-grid-shadow="top"] {
+  @include DataGrid.shadow(top, $backdrop: true);
+}
+
+.DataGridFooter {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: design-token("space.1.5");
+  width: 100%;
+  padding: 0 design-token("space.2");
+}
+
+// The footer is a single-row bar, so its regions keep their content on one line
+// and let the shell grow instead of wrapping into each other
+.region {
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+}
+
+.start {
+  justify-content: flex-start;
+}
+
+.center {
+  justify-content: center;
+}
+
+.end {
+  justify-content: flex-end;
+}

--- a/easy-ui-react/src/DataGrid/Footer.tsx
+++ b/easy-ui-react/src/DataGrid/Footer.tsx
@@ -22,7 +22,7 @@ export type DataGridFooterProps = {
  * @remarks
  * `<DataGrid.Footer />` is deliberately unaware of what it lays out, so the
  * data grid isn't tied to any one pagination scheme. Pass any content into its
- * regions; `<DataGrid.Pagination />` and `<DataGrid.RowsPerPageMenu />` cover
+ * regions; `<DataGrid.Pagination />` and `<DataGrid.RowsPerPage />` cover
  * the standard controls.
  *
  * The center region stays centered within the grid regardless of how wide the
@@ -33,7 +33,7 @@ export type DataGridFooterProps = {
  *   renderFooter={() => (
  *     <DataGrid.Footer
  *       center={<DataGrid.Pagination {...paginationProps} />}
- *       end={<DataGrid.RowsPerPageMenu {...rowsPerPageProps} />}
+ *       end={<DataGrid.RowsPerPage {...rowsPerPageProps} />}
  *     />
  *   )}
  * />

--- a/easy-ui-react/src/DataGrid/Footer.tsx
+++ b/easy-ui-react/src/DataGrid/Footer.tsx
@@ -1,0 +1,77 @@
+import React, { ReactNode } from "react";
+import { classNames } from "../utilities/css";
+import { useDataGridTable } from "./context";
+
+import styles from "./Footer.module.scss";
+
+export type DataGridFooterProps = {
+  /** Content rendered in the start region of the footer. */
+  start?: ReactNode;
+
+  /** Content rendered in the center region of the footer. */
+  center?: ReactNode;
+
+  /** Content rendered in the end region of the footer. */
+  end?: ReactNode;
+};
+
+/**
+ * Lays out the content of a `<DataGrid />` footer into start, center, and end
+ * regions.
+ *
+ * @remarks
+ * `<DataGrid.Footer />` is deliberately unaware of what it lays out, so the
+ * data grid isn't tied to any one pagination scheme. Pass any content into its
+ * regions; `<DataGrid.Pagination />` and `<DataGrid.RowsPerPageMenu />` cover
+ * the standard controls.
+ *
+ * The center region stays centered within the grid regardless of how wide the
+ * start and end regions grow.
+ *
+ * @example
+ * <DataGrid
+ *   renderFooter={() => (
+ *     <DataGrid.Footer
+ *       center={<DataGrid.Pagination {...paginationProps} />}
+ *       end={<DataGrid.RowsPerPageMenu {...rowsPerPageProps} />}
+ *     />
+ *   )}
+ * />
+ */
+export function DataGridFooter(props: DataGridFooterProps) {
+  const { start, center, end } = props;
+  return (
+    <div className={styles.DataGridFooter}>
+      <div className={classNames(styles.region, styles.start)}>{start}</div>
+      <div className={classNames(styles.region, styles.center)}>{center}</div>
+      <div className={classNames(styles.region, styles.end)}>{end}</div>
+    </div>
+  );
+}
+
+type FooterShellProps = {
+  children: ReactNode;
+};
+
+/**
+ * Sticky container that houses whatever a data grid's `renderFooter` returns.
+ *
+ * @remarks
+ * Mirrors the column header's mechanics: it sticks to an edge of the scroll
+ * port and casts a shadow over the content it covers while that content is
+ * under scroll. Rendering it outside of the `<table />` keeps its interactive
+ * content out of the grid's row and cell semantics.
+ */
+export function FooterShell({ children }: FooterShellProps) {
+  const table = useDataGridTable();
+  const className = classNames(
+    styles.shell,
+    table.isBottomEdgeUnderScroll && styles.shadowTop,
+  );
+  return (
+    <div className={className} data-ezui-data-grid-footer="true">
+      {children}
+      <div data-ezui-data-grid-shadow="top" />
+    </div>
+  );
+}

--- a/easy-ui-react/src/DataGrid/Footer.tsx
+++ b/easy-ui-react/src/DataGrid/Footer.tsx
@@ -71,7 +71,6 @@ export function FooterShell({ children }: FooterShellProps) {
   return (
     <div className={className} data-ezui-data-grid-footer="true">
       {children}
-      <div data-ezui-data-grid-shadow="top" />
     </div>
   );
 }

--- a/easy-ui-react/src/DataGrid/RowsPerPageMenu.module.scss
+++ b/easy-ui-react/src/DataGrid/RowsPerPageMenu.module.scss
@@ -1,0 +1,37 @@
+@use "../styles/common" as *;
+
+.RowsPerPageMenu {
+  display: flex;
+  align-items: center;
+  gap: design-token("space.0.5");
+}
+
+.trigger {
+  @include font-style("body2");
+
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  gap: design-token("space.1");
+  height: 24px;
+  padding: 0 design-token("space.1");
+  color: design-token("color.neutral.900");
+  background: design-token("color.neutral.000");
+  border: design-token("shape.border_width.1") solid
+    design-token("color.neutral.200");
+  border-radius: design-token("shape.border_radius.md");
+
+  &:not(:disabled) {
+    cursor: pointer;
+  }
+
+  &:disabled {
+    color: design-token("color.neutral.300");
+    background: design-token("color.neutral.025");
+    border-color: design-token("color.neutral.100");
+  }
+
+  &:hover:not(:disabled):not(:active) {
+    color: design-token("color.primary.500");
+  }
+}

--- a/easy-ui-react/src/DataGrid/RowsPerPageMenu.tsx
+++ b/easy-ui-react/src/DataGrid/RowsPerPageMenu.tsx
@@ -1,0 +1,113 @@
+import ExpandMore400 from "@easypost/easy-ui-icons/ExpandMore400";
+import { Key } from "@react-types/shared";
+import React, { useId } from "react";
+import { Icon } from "../Icon";
+import { Menu } from "../Menu";
+import { Text } from "../Text";
+import { UnstyledButton } from "../UnstyledButton";
+
+import styles from "./RowsPerPageMenu.module.scss";
+
+export type DataGridRowsPerPageMenuProps = {
+  /** The number of rows currently shown per page. */
+  rowsPerPage: number;
+
+  /** The rows per page counts to choose from. */
+  options: number[];
+
+  /** Handler that is called when another count is selected. */
+  onChange: (rowsPerPage: number) => void;
+
+  /**
+   * Label rendered alongside the menu trigger.
+   * @default Rows Per Page:
+   */
+  label?: string;
+
+  /** Whether the menu should be disabled. */
+  isDisabled?: boolean;
+};
+
+/**
+ * A fully controlled menu for choosing how many rows a data grid page shows.
+ *
+ * @remarks
+ * Intended for the end region of a `<DataGrid.Footer />`, though it carries no
+ * dependency on the footer and can be placed anywhere.
+ *
+ * @example
+ * ```tsx
+ * <DataGrid.RowsPerPageMenu
+ *   rowsPerPage={rowsPerPage}
+ *   options={[25, 50, 100]}
+ *   onChange={setRowsPerPage}
+ * />
+ * ```
+ */
+export function DataGridRowsPerPageMenu(props: DataGridRowsPerPageMenuProps) {
+  const {
+    rowsPerPage,
+    options,
+    onChange,
+    label = "Rows Per Page:",
+    isDisabled,
+  } = props;
+
+  const labelId = useId();
+  const valueId = useId();
+
+  // The trigger's own text is just the count, so the label is stitched onto it
+  // to keep the accessible name meaningful
+  const triggerLabelledBy = `${labelId} ${valueId}`;
+
+  return (
+    <div className={styles.RowsPerPageMenu}>
+      <Text id={labelId} variant="body2" color="neutral.900">
+        {label}
+      </Text>
+      <Menu isDisabled={isDisabled}>
+        <Menu.Trigger>
+          <UnstyledButton
+            className={styles.trigger}
+            aria-labelledby={triggerLabelledBy}
+            isDisabled={isDisabled}
+          >
+            <span id={valueId}>{rowsPerPage}</span>
+            <Icon symbol={ExpandMore400} size="xs" />
+          </UnstyledButton>
+        </Menu.Trigger>
+        <Menu.Overlay
+          selectionMode="single"
+          selectedKeys={[String(rowsPerPage)]}
+          onSelectionChange={(keys) => {
+            const key = getSelectedKey(keys);
+            if (key != null) {
+              onChange(Number(key));
+            }
+          }}
+        >
+          {options.map((option) => (
+            <Menu.Item key={String(option)}>{String(option)}</Menu.Item>
+          ))}
+        </Menu.Overlay>
+      </Menu>
+    </div>
+  );
+}
+
+/**
+ * Pulls the single key out of a selection, which single selection mode
+ * still models as a set.
+ *
+ * @param keys the menu's selection
+ * @returns the selected key, or `null` when nothing is selected
+ */
+function getSelectedKey(keys: "all" | Set<Key>): Key | null {
+  if (keys === "all") {
+    return null;
+  }
+  const [key] = keys;
+  return key ?? null;
+}
+
+DataGridRowsPerPageMenu.displayName = "DataGrid.RowsPerPageMenu";

--- a/easy-ui-react/src/DataGrid/Table.tsx
+++ b/easy-ui-react/src/DataGrid/Table.tsx
@@ -15,9 +15,11 @@ import {
   EXPAND_COLUMN_KEY,
 } from "./constants";
 import { DataGridTableContext } from "./context";
+import { FooterShell } from "./Footer";
 import { Column, DataGridProps, Row as RowType } from "./types";
 import { useEdgeInterceptors } from "./useEdgeInterceptors";
 import { useExpandedRow } from "./useExpandedRow";
+import { useFooterWidth } from "./useFooterWidth";
 import { Spinner } from "../Spinner";
 
 import styles from "./DataGrid.module.scss";
@@ -39,8 +41,11 @@ export function Table<C extends Column, R extends RowType>(
     selectionMode,
     size = DEFAULT_SIZE,
     renderEmptyState = () => "No Data",
+    renderFooter,
     isLoading = false,
   } = props;
+
+  const hasFooter = Boolean(renderFooter);
 
   const outerContainerRef = useRef<HTMLDivElement | null>(null);
   const innerContainerRef = useRef<HTMLDivElement | null>(null);
@@ -59,8 +64,17 @@ export function Table<C extends Column, R extends RowType>(
   });
   const [
     renderInterceptors,
-    { isTopEdgeUnderScroll, isLeftEdgeUnderScroll, isRightEdgeUnderScroll },
+    {
+      isTopEdgeUnderScroll,
+      isBottomEdgeUnderScroll,
+      isLeftEdgeUnderScroll,
+      isRightEdgeUnderScroll,
+    },
   ] = useEdgeInterceptors(outerContainerRef);
+  const { footerStyle } = useFooterWidth({
+    containerRef: outerContainerRef,
+    isEnabled: hasFooter,
+  });
 
   const { collection } = state;
   const { columns } = collection;
@@ -73,6 +87,7 @@ export function Table<C extends Column, R extends RowType>(
   const dataGridClassName = classNames(
     styles.DataGrid,
     styles[variationName("size", size)],
+    hasFooter && styles.hasFooter,
   );
 
   const tableClassName = classNames(
@@ -89,6 +104,7 @@ export function Table<C extends Column, R extends RowType>(
   const style = {
     ...getComponentToken("data-grid", "max-rows", String(maxRows)),
     ...expandedRowStyle,
+    ...footerStyle,
   } as CSSProperties;
 
   const context = useMemo(() => {
@@ -99,6 +115,7 @@ export function Table<C extends Column, R extends RowType>(
       hasRowActions,
       hasOnRowAction,
       isTopEdgeUnderScroll,
+      isBottomEdgeUnderScroll,
       isLeftEdgeUnderScroll,
       isRightEdgeUnderScroll,
     };
@@ -109,6 +126,7 @@ export function Table<C extends Column, R extends RowType>(
     hasRowActions,
     hasOnRowAction,
     isTopEdgeUnderScroll,
+    isBottomEdgeUnderScroll,
     isLeftEdgeUnderScroll,
     isRightEdgeUnderScroll,
   ]);
@@ -168,6 +186,7 @@ export function Table<C extends Column, R extends RowType>(
             </ExpandedRowContent>
           )}
           {renderInterceptors()}
+          {renderFooter && <FooterShell>{renderFooter()}</FooterShell>}
         </div>
       </div>
     </DataGridTableContext.Provider>

--- a/easy-ui-react/src/DataGrid/_mixins.scss
+++ b/easy-ui-react/src/DataGrid/_mixins.scss
@@ -1,6 +1,6 @@
 @use "../styles/common" as *;
 
-@mixin shadow($direction, $backdrop: false) {
+@mixin shadow($direction) {
   @if $direction == top {
     bottom: 100%;
     left: 0;
@@ -25,7 +25,6 @@
     @error "Unknown direction #{$direction}.";
   }
 
-  &::before,
   &::after {
     content: "";
     position: absolute;
@@ -33,17 +32,6 @@
     left: 0;
     right: 0;
     bottom: 0;
-  }
-  @if $backdrop {
-    &::before {
-      background-image: linear-gradient(
-        to #{$direction},
-        component-token("data-grid", "cell-bg") 65%,
-        transparent
-      );
-    }
-  }
-  &::after {
     background-image: linear-gradient(
       to #{$direction},
       component-token("data-grid", "sticky-shadow-color"),

--- a/easy-ui-react/src/DataGrid/_mixins.scss
+++ b/easy-ui-react/src/DataGrid/_mixins.scss
@@ -1,6 +1,9 @@
 @use "../styles/common" as *;
 
-@mixin shadow($direction) {
+@mixin shadow(
+  $direction,
+  $opacity: component-token("data-grid", "sticky-shadow-opacity")
+) {
   @if $direction == top {
     bottom: 100%;
     left: 0;
@@ -37,6 +40,6 @@
       component-token("data-grid", "sticky-shadow-color"),
       transparent
     );
-    opacity: component-token("data-grid", "sticky-shadow-opacity");
+    opacity: $opacity;
   }
 }

--- a/easy-ui-react/src/DataGrid/context.ts
+++ b/easy-ui-react/src/DataGrid/context.ts
@@ -24,6 +24,7 @@ type DataGridTableContextType = {
   hasRowActions: boolean;
   hasOnRowAction: boolean;
   isTopEdgeUnderScroll: boolean;
+  isBottomEdgeUnderScroll: boolean;
   isLeftEdgeUnderScroll: boolean;
   isRightEdgeUnderScroll: boolean;
 };

--- a/easy-ui-react/src/DataGrid/types.ts
+++ b/easy-ui-react/src/DataGrid/types.ts
@@ -142,6 +142,17 @@ export type DataGridProps<
   renderEmptyState?: () => ReactNode;
 
   /**
+   * Renders a footer that sticks to the bottom of the data grid.
+   *
+   * @remarks
+   * The data grid supplies the sticky container, its top border, and the shadow
+   * it casts over rows scrolling underneath. What goes inside is up to the
+   * consumer; `<DataGrid.Footer />` lays content out into start, center, and
+   * end regions. The footer stays mounted through empty and loading states.
+   */
+  renderFooter?: () => ReactNode;
+
+  /**
    * Whether the table is currently loading.
    * @default false
    */

--- a/easy-ui-react/src/DataGrid/useFooterWidth.ts
+++ b/easy-ui-react/src/DataGrid/useFooterWidth.ts
@@ -1,0 +1,63 @@
+import { useResizeObserver } from "@react-aria/utils";
+import {
+  CSSProperties,
+  MutableRefObject,
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useState,
+} from "react";
+import { getComponentToken } from "../utilities/css";
+
+/**
+ * Measures the visible width of the data grid's scroll container so that the
+ * footer can be pinned horizontally while the grid scrolls sideways.
+ *
+ * @remarks
+ * The footer is a sticky child of the inner container, which is as wide as the
+ * table itself. Sticking to the left edge of the scroll port therefore requires
+ * knowing how wide that scroll port is, which CSS alone can't express from
+ * inside the scrolled content.
+ *
+ * @param containerRef Scroll container element of the data grid
+ * @param isEnabled Whether a footer is being rendered
+ * @returns style holding the measured footer width
+ */
+export function useFooterWidth({
+  containerRef,
+  isEnabled,
+}: {
+  containerRef: MutableRefObject<HTMLDivElement | null>;
+  isEnabled: boolean;
+}) {
+  const [footerWidth, setFooterWidth] = useState<number | null>(null);
+
+  const measure = useCallback(() => {
+    const $container = containerRef.current;
+    if (!isEnabled || !$container) {
+      return;
+    }
+    // `clientWidth` excludes the vertical scrollbar, keeping the footer from
+    // sitting underneath it
+    const width = $container.clientWidth;
+    setFooterWidth((prevWidth) => (prevWidth === width ? prevWidth : width));
+  }, [containerRef, isEnabled]);
+
+  useLayoutEffect(() => {
+    measure();
+  }, [measure]);
+
+  useResizeObserver({ ref: containerRef, onResize: measure });
+
+  const footerStyle = useMemo(() => {
+    return {
+      ...getComponentToken(
+        "data-grid",
+        "footer-width",
+        footerWidth === null ? "100%" : `${footerWidth}px`,
+      ),
+    } as CSSProperties;
+  }, [footerWidth]);
+
+  return { footerStyle };
+}

--- a/easy-ui-react/src/Pagination/Pagination.mdx
+++ b/easy-ui-react/src/Pagination/Pagination.mdx
@@ -27,6 +27,12 @@ Supplying `onFirst` and `onLast` adds buttons for jumping to either end. They're
 
 <Canvas of={PaginationStories.WithPageNumbers} />
 
+## Sizes
+
+The numbered scheme comes in two sizes through `size`. `md` is the default; `sm` is the compact bar used in places like a `<DataGrid />` footer. `size` has no effect on the dropdown scheme, which has a single size.
+
+<Canvas of={PaginationStories.WithPageNumbersSmall} />
+
 ## Disabled
 
 A `<Pagination />` can be disabled using `isDisabled`.

--- a/easy-ui-react/src/Pagination/Pagination.mdx
+++ b/easy-ui-react/src/Pagination/Pagination.mdx
@@ -33,6 +33,14 @@ The numbered scheme comes in two sizes through `size`. `md` is the default; `sm`
 
 <Canvas of={PaginationStories.WithPageNumbersSmall} />
 
+## With Rows Per Page
+
+`<Pagination.RowsPerPage />` is a fully controlled menu for choosing how many rows a page shows. It renders on its own alongside a `<Pagination />` rather than inside one, which only accepts a scheme as its child, and it takes the same `size` values so the two line up.
+
+<Canvas of={PaginationStories.WithRowsPerPage} />
+
+<Canvas of={PaginationStories.WithRowsPerPageSmall} />
+
 ## Disabled
 
 A `<Pagination />` can be disabled using `isDisabled`.
@@ -52,3 +60,7 @@ A `<Pagination />` can be disabled using `isDisabled`.
 ### Pagination.Pages
 
 <ArgTypes of={Pagination.Pages} />
+
+### Pagination.RowsPerPage
+
+<ArgTypes of={Pagination.RowsPerPage} />

--- a/easy-ui-react/src/Pagination/Pagination.mdx
+++ b/easy-ui-react/src/Pagination/Pagination.mdx
@@ -27,6 +27,18 @@ Supplying `onFirst` and `onLast` adds buttons for jumping to either end. They're
 
 <Canvas of={PaginationStories.WithPageNumbers} />
 
+## With Page Numbers Only
+
+Every control around the page numbers is optional, so a short run of pages can stand on its own by leaving the handlers off.
+
+<Canvas of={PaginationStories.WithPageNumbersOnly} />
+
+## With Page Numbers and Nav Buttons
+
+Supplying only `onPrevious` and `onNext` steps a page at a time without the jump buttons. Raising `siblingCount` past the number of pages keeps the whole run in view rather than truncating it.
+
+<Canvas of={PaginationStories.WithPageNumbersAndNavButtons} />
+
 ## Sizes
 
 The numbered scheme comes in two sizes through `size`. `md` is the default; `sm` is the compact bar used in places like a `<DataGrid />` footer. `size` has no effect on the dropdown scheme, which has a single size.

--- a/easy-ui-react/src/Pagination/Pagination.mdx
+++ b/easy-ui-react/src/Pagination/Pagination.mdx
@@ -13,9 +13,19 @@ A `<Pagination />` component enabled the user to divide large amounts of content
 
 ## With Page Dropdown
 
-A `<Pagination />` supports a dropdown menu for users to select specific page by including `<Pagination.Dropdown />` as children. `<Pagination.Dropdown />` is the only children `<Pagination />` accept.
+A `<Pagination />` supports a dropdown menu for users to select specific page by including `<Pagination.Dropdown />` as children.
 
 <Canvas of={PaginationStories.WithPageDropdown} />
+
+## With Page Numbers
+
+A `<Pagination />` supports a numbered scheme where each nearby page gets its own button by including `<Pagination.Pages />` as children. Pages that fall outside the range around the current page are truncated with an ellipsis; tune how many pages surround the current one with `siblingCount`, and pin pages to the ends of the range with `boundaryCount`.
+
+Supplying `onFirst` and `onLast` adds buttons for jumping to either end. They're only available in this scheme.
+
+`<Pagination.Dropdown />` and `<Pagination.Pages />` are the only children `<Pagination />` accepts, and which one is supplied determines the scheme that renders.
+
+<Canvas of={PaginationStories.WithPageNumbers} />
 
 ## Disabled
 
@@ -32,3 +42,7 @@ A `<Pagination />` can be disabled using `isDisabled`.
 ### Pagination.Dropdown
 
 <ArgTypes of={Pagination.Dropdown} />
+
+### Pagination.Pages
+
+<ArgTypes of={Pagination.Pages} />

--- a/easy-ui-react/src/Pagination/Pagination.module.scss
+++ b/easy-ui-react/src/Pagination/Pagination.module.scss
@@ -38,3 +38,81 @@
   border-right: design-token("shape.border_width.1") solid
     design-token("color.neutral.200");
 }
+
+// The numbered scheme spaces its controls apart instead of fusing them into a
+// single pill, so it opts out of the shared arrow/menu button chrome entirely
+.paged {
+  display: flex;
+  align-items: center;
+  gap: design-token("space.1.5");
+}
+
+.pageRow {
+  display: flex;
+  align-items: center;
+  gap: design-token("space.0.5");
+}
+
+.pagedButton {
+  @include font-style("subtitle2");
+
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 24px;
+  height: 24px;
+  color: design-token("color.primary.800");
+  border-radius: design-token("shape.border_radius.md");
+
+  &:not(:disabled) {
+    cursor: pointer;
+  }
+}
+
+.jumpButton {
+  min-width: 54px;
+}
+
+.navButton,
+.jumpButton {
+  background: design-token("color.neutral.000");
+  border: design-token("shape.border_width.1") solid
+    design-token("color.neutral.200");
+
+  &:disabled {
+    color: design-token("color.neutral.300");
+    background: design-token("color.neutral.025");
+    border-color: design-token("color.neutral.100");
+  }
+
+  &:hover:not(:disabled):not(:active) {
+    color: design-token("color.primary.500");
+  }
+}
+
+// There's no left-facing chevron in the icon set, so the next chevron is flipped
+.navButtonPrevious {
+  transform: rotate(180deg);
+}
+
+.pageButton {
+  background: design-token("color.neutral.000");
+
+  &:disabled {
+    color: design-token("color.neutral.300");
+  }
+
+  &:hover:not(:disabled):not(:active):not(.pageButtonCurrent) {
+    background: design-token("color.neutral.050");
+  }
+}
+
+.pageButtonCurrent {
+  color: design-token("color.neutral.000");
+  background: design-token("color.primary.500");
+}
+
+.ellipsis {
+  color: design-token("color.neutral.500");
+}

--- a/easy-ui-react/src/Pagination/Pagination.module.scss
+++ b/easy-ui-react/src/Pagination/Pagination.module.scss
@@ -47,10 +47,13 @@
   gap: component-token("pagination", "control-gap");
 }
 
+// The page numbers read as one tight run at either size, so this gap only has
+// to keep adjacent squares from fusing. It's the gaps between the scheme's
+// groups that scale.
 .pageRow {
   display: flex;
   align-items: center;
-  gap: component-token("pagination", "page-gap");
+  gap: design-token("space.0.5");
 }
 
 // Shared box and type for every cell in the scheme, including the ellipsis,
@@ -128,23 +131,39 @@
 // together. Only the numbered scheme is sized; the dropdown scheme has a single
 // size in design.
 .sizeSm {
-  @include component-token("pagination", "control-size", 24px);
-  @include component-token("pagination", "jump-control-width", 54px);
+  @include component-token(
+    "pagination",
+    "control-size",
+    design-token("space.3")
+  );
+  @include component-token(
+    "pagination",
+    "jump-control-width",
+    design-token("space.7")
+  );
   @include component-token(
     "pagination",
     "control-gap",
     design-token("space.1.5")
   );
-  @include component-token("pagination", "page-gap", design-token("space.0.5"));
 }
 
 .sizeMd {
-  @include component-token("pagination", "control-size", 38px);
-  @include component-token("pagination", "jump-control-width", 72px);
-  // Design's larger gaps sit between steps of the space scale, so they're
-  // spelled out rather than rounded to a token
-  @include component-token("pagination", "control-gap", 18px);
-  @include component-token("pagination", "page-gap", 6px);
+  @include component-token(
+    "pagination",
+    "control-size",
+    design-token("space.5")
+  );
+  @include component-token(
+    "pagination",
+    "jump-control-width",
+    design-token("space.9")
+  );
+  @include component-token(
+    "pagination",
+    "control-gap",
+    design-token("space.2")
+  );
 }
 
 // `<UnstyledButton />` only inherits font size and line height, so the buttons

--- a/easy-ui-react/src/Pagination/Pagination.module.scss
+++ b/easy-ui-react/src/Pagination/Pagination.module.scss
@@ -44,34 +44,37 @@
 .paged {
   display: flex;
   align-items: center;
-  gap: design-token("space.1.5");
+  gap: component-token("pagination", "control-gap");
 }
 
 .pageRow {
   display: flex;
   align-items: center;
-  gap: design-token("space.0.5");
+  gap: component-token("pagination", "page-gap");
 }
 
+// Shared box and type for every cell in the scheme, including the ellipsis,
+// which isn't a control and so gets none of the behavior below
 .pagedButton {
-  @include font-style("subtitle2");
-
   box-sizing: border-box;
   display: flex;
   align-items: center;
   justify-content: center;
-  min-width: 24px;
-  height: 24px;
+  min-width: component-token("pagination", "control-size");
+  height: component-token("pagination", "control-size");
   color: design-token("color.primary.800");
   border-radius: design-token("shape.border_radius.md");
+}
 
-  &:not(:disabled) {
-    cursor: pointer;
-  }
+// A label can outgrow the square, so the buttons carrying one keep it off the
+// edge. The chevron buttons hold their square, since an icon can't outgrow it.
+.jumpButton,
+.pageButton {
+  padding: 0 design-token("space.0.5");
 }
 
 .jumpButton {
-  min-width: 54px;
+  min-width: component-token("pagination", "jump-control-width");
 }
 
 .navButton,
@@ -79,6 +82,10 @@
   background: design-token("color.neutral.000");
   border: design-token("shape.border_width.1") solid
     design-token("color.neutral.200");
+
+  &:not(:disabled) {
+    cursor: pointer;
+  }
 
   &:disabled {
     color: design-token("color.neutral.300");
@@ -99,6 +106,10 @@
 .pageButton {
   background: design-token("color.neutral.000");
 
+  &:not(:disabled) {
+    cursor: pointer;
+  }
+
   &:disabled {
     color: design-token("color.neutral.300");
   }
@@ -113,6 +124,35 @@
   background: design-token("color.primary.500");
 }
 
-.ellipsis {
-  color: design-token("color.neutral.500");
+// Both sizes are described in one place each so the parts of the scheme grow
+// together. Only the numbered scheme is sized; the dropdown scheme has a single
+// size in design.
+.sizeSm {
+  @include component-token("pagination", "control-size", 24px);
+  @include component-token("pagination", "jump-control-width", 54px);
+  @include component-token(
+    "pagination",
+    "control-gap",
+    design-token("space.1.5")
+  );
+  @include component-token("pagination", "page-gap", design-token("space.0.5"));
+}
+
+.sizeMd {
+  @include component-token("pagination", "control-size", 38px);
+  @include component-token("pagination", "jump-control-width", 72px);
+  // Design's larger gaps sit between steps of the space scale, so they're
+  // spelled out rather than rounded to a token
+  @include component-token("pagination", "control-gap", 18px);
+  @include component-token("pagination", "page-gap", 6px);
+}
+
+// `<UnstyledButton />` only inherits font size and line height, so the buttons
+// take their type directly rather than through the nav
+.sizeSm .pagedButton {
+  @include font-style("small-button");
+}
+
+.sizeMd .pagedButton {
+  @include font-style("button");
 }

--- a/easy-ui-react/src/Pagination/Pagination.module.scss
+++ b/easy-ui-react/src/Pagination/Pagination.module.scss
@@ -96,8 +96,11 @@
     border-color: design-token("color.neutral.100");
   }
 
+  // Hovering tints the box the way the page buttons beside it do rather than
+  // pulling the label toward blue, which reads louder than a control that only
+  // steps or jumps the page warrants
   &:hover:not(:disabled):not(:active) {
-    color: design-token("color.primary.500");
+    background: design-token("color.neutral.050");
   }
 }
 

--- a/easy-ui-react/src/Pagination/Pagination.stories.tsx
+++ b/easy-ui-react/src/Pagination/Pagination.stories.tsx
@@ -85,6 +85,41 @@ export const WithPageNumbersSmall: Story = {
   render: () => <PageNumbersExample size="sm" />,
 };
 
+export const WithPageNumbersOnly: Story = {
+  render: () => {
+    const [page, setPage] = React.useState(1);
+    return (
+      <Pagination label="Example Pagination with Page Numbers Only">
+        <Pagination.Pages count={3} page={page} onSelect={setPage} />
+      </Pagination>
+    );
+  },
+};
+
+export const WithPageNumbersAndNavButtons: Story = {
+  render: () => {
+    const [page, setPage] = React.useState(1);
+    const totalPage = 8;
+    return (
+      <Pagination
+        label="Example Pagination with Page Numbers and Nav Buttons"
+        onPrevious={() => setPage((prev) => prev - 1)}
+        onNext={() => setPage((prev) => prev + 1)}
+        hasPrevious={page > 1}
+        hasNext={totalPage > page}
+      >
+        {/* Enough siblings to keep every page in the run, so nothing truncates */}
+        <Pagination.Pages
+          count={totalPage}
+          page={page}
+          siblingCount={3}
+          onSelect={setPage}
+        />
+      </Pagination>
+    );
+  },
+};
+
 function RowsPerPageExample({ size }: { size?: PaginationSize }) {
   const [rowsPerPage, setRowsPerPage] = React.useState(50);
   return (

--- a/easy-ui-react/src/Pagination/Pagination.stories.tsx
+++ b/easy-ui-react/src/Pagination/Pagination.stories.tsx
@@ -54,6 +54,30 @@ export const WithPageDropdown: Story = {
   },
 };
 
+export const WithPageNumbers: Story = {
+  render: () => {
+    const [page, setPage] = React.useState(1);
+    const totalPage = 10;
+    const hasPrevious = page > 1;
+    const hasNext = totalPage > page;
+    return (
+      <Pagination
+        label="Example Pagination with Page Numbers"
+        onFirst={() => setPage(1)}
+        onPrevious={() => setPage((prev) => prev - 1)}
+        onNext={() => setPage((prev) => prev + 1)}
+        onLast={() => setPage(totalPage)}
+        hasFirst={hasPrevious}
+        hasPrevious={hasPrevious}
+        hasNext={hasNext}
+        hasLast={hasNext}
+      >
+        <Pagination.Pages count={totalPage} page={page} onSelect={setPage} />
+      </Pagination>
+    );
+  },
+};
+
 export const Disabled: Story = {
   render: () => (
     <Pagination

--- a/easy-ui-react/src/Pagination/Pagination.stories.tsx
+++ b/easy-ui-react/src/Pagination/Pagination.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react-vite";
 import React from "react";
-import { Pagination } from "./Pagination";
+import { Pagination, PaginationSize } from "./Pagination";
 
 type Story = StoryObj<typeof Pagination>;
 
@@ -54,28 +54,35 @@ export const WithPageDropdown: Story = {
   },
 };
 
+function PageNumbersExample({ size }: { size?: PaginationSize }) {
+  const [page, setPage] = React.useState(1);
+  const totalPage = 10;
+  const hasPrevious = page > 1;
+  const hasNext = totalPage > page;
+  return (
+    <Pagination
+      label="Example Pagination with Page Numbers"
+      size={size}
+      onFirst={() => setPage(1)}
+      onPrevious={() => setPage((prev) => prev - 1)}
+      onNext={() => setPage((prev) => prev + 1)}
+      onLast={() => setPage(totalPage)}
+      hasFirst={hasPrevious}
+      hasPrevious={hasPrevious}
+      hasNext={hasNext}
+      hasLast={hasNext}
+    >
+      <Pagination.Pages count={totalPage} page={page} onSelect={setPage} />
+    </Pagination>
+  );
+}
+
 export const WithPageNumbers: Story = {
-  render: () => {
-    const [page, setPage] = React.useState(1);
-    const totalPage = 10;
-    const hasPrevious = page > 1;
-    const hasNext = totalPage > page;
-    return (
-      <Pagination
-        label="Example Pagination with Page Numbers"
-        onFirst={() => setPage(1)}
-        onPrevious={() => setPage((prev) => prev - 1)}
-        onNext={() => setPage((prev) => prev + 1)}
-        onLast={() => setPage(totalPage)}
-        hasFirst={hasPrevious}
-        hasPrevious={hasPrevious}
-        hasNext={hasNext}
-        hasLast={hasNext}
-      >
-        <Pagination.Pages count={totalPage} page={page} onSelect={setPage} />
-      </Pagination>
-    );
-  },
+  render: () => <PageNumbersExample />,
+};
+
+export const WithPageNumbersSmall: Story = {
+  render: () => <PageNumbersExample size="sm" />,
 };
 
 export const Disabled: Story = {

--- a/easy-ui-react/src/Pagination/Pagination.stories.tsx
+++ b/easy-ui-react/src/Pagination/Pagination.stories.tsx
@@ -85,6 +85,26 @@ export const WithPageNumbersSmall: Story = {
   render: () => <PageNumbersExample size="sm" />,
 };
 
+function RowsPerPageExample({ size }: { size?: PaginationSize }) {
+  const [rowsPerPage, setRowsPerPage] = React.useState(50);
+  return (
+    <Pagination.RowsPerPage
+      rowsPerPage={rowsPerPage}
+      options={[25, 50, 100]}
+      onChange={setRowsPerPage}
+      size={size}
+    />
+  );
+}
+
+export const WithRowsPerPage: Story = {
+  render: () => <RowsPerPageExample />,
+};
+
+export const WithRowsPerPageSmall: Story = {
+  render: () => <RowsPerPageExample size="sm" />,
+};
+
 export const Disabled: Story = {
   render: () => (
     <Pagination

--- a/easy-ui-react/src/Pagination/Pagination.test.tsx
+++ b/easy-ui-react/src/Pagination/Pagination.test.tsx
@@ -188,6 +188,49 @@ describe("<Pagination />", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("should render pages at the medium size by default", () => {
+    render(
+      createPagination({
+        label: "Example Pagination",
+        children: <Pagination.Pages onSelect={() => {}} page={5} count={10} />,
+      }),
+    );
+    expect(screen.getByRole("navigation")).toHaveAttribute(
+      "class",
+      expect.stringContaining("sizeMd"),
+    );
+  });
+
+  it("should render pages at the small size", () => {
+    render(
+      createPagination({
+        label: "Example Pagination",
+        size: "sm",
+        children: <Pagination.Pages onSelect={() => {}} page={5} count={10} />,
+      }),
+    );
+    expect(screen.getByRole("navigation")).toHaveAttribute(
+      "class",
+      expect.stringContaining("sizeSm"),
+    );
+  });
+
+  it("should not size the dropdown scheme", () => {
+    render(
+      createPagination({
+        label: "Example Pagination",
+        size: "sm",
+        children: (
+          <Pagination.Dropdown onSelect={() => {}} page={1} count={10} />
+        ),
+      }),
+    );
+    expect(screen.getByRole("navigation")).not.toHaveAttribute(
+      "class",
+      expect.stringContaining("size"),
+    );
+  });
+
   it("should render pages as disabled", () => {
     render(
       createPagination({

--- a/easy-ui-react/src/Pagination/Pagination.test.tsx
+++ b/easy-ui-react/src/Pagination/Pagination.test.tsx
@@ -189,6 +189,67 @@ describe("<Pagination />", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("should omit the previous and next buttons without their handlers", () => {
+    render(
+      createPagination({
+        label: "Example Pagination",
+        children: <Pagination.Pages onSelect={() => {}} page={5} count={10} />,
+      }),
+    );
+    expect(
+      screen.queryByRole("button", { name: /previous/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /next/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Page 5 of 10" }),
+    ).toBeInTheDocument();
+  });
+
+  it("should step a page at a time without the jump buttons", async () => {
+    const handleNext = vi.fn();
+    const handlePrevious = vi.fn();
+    const { user } = render(
+      createPagination({
+        label: "Example Pagination",
+        onPrevious: handlePrevious,
+        onNext: handleNext,
+        hasPrevious: true,
+        hasNext: true,
+        children: <Pagination.Pages onSelect={() => {}} page={5} count={10} />,
+      }),
+    );
+    await userClick(user, screen.getByRole("button", { name: /previous/i }));
+    expect(handlePrevious).toHaveBeenCalled();
+    await userClick(user, screen.getByRole("button", { name: /next/i }));
+    expect(handleNext).toHaveBeenCalled();
+    expect(
+      screen.queryByRole("button", { name: /first/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should render every page when the sibling count covers the range", () => {
+    render(
+      createPagination({
+        label: "Example Pagination",
+        children: (
+          <Pagination.Pages
+            onSelect={() => {}}
+            page={1}
+            count={8}
+            siblingCount={3}
+          />
+        ),
+      }),
+    );
+    for (let page = 1; page <= 8; page++) {
+      expect(
+        screen.getByRole("button", { name: `Page ${page} of 8` }),
+      ).toBeInTheDocument();
+    }
+  });
+
   it("should render pages at the medium size by default", () => {
     render(
       createPagination({

--- a/easy-ui-react/src/Pagination/Pagination.test.tsx
+++ b/easy-ui-react/src/Pagination/Pagination.test.tsx
@@ -120,6 +120,87 @@ describe("<Pagination />", () => {
     ).toThrow("children must be Pagination.Dropdown");
     restoreConsoleError();
   });
+
+  it("should render pagination component with pages", () => {
+    render(
+      createPagination({
+        label: "Example Pagination",
+        children: <Pagination.Pages onSelect={() => {}} page={1} count={10} />,
+      }),
+    );
+    expect(
+      screen.getByRole("button", { name: "Page 1 of 10" }),
+    ).toHaveAttribute("aria-current", "page");
+    expect(
+      screen.getByRole("button", { name: "Page 6 of 10" }),
+    ).toBeInTheDocument();
+    // Pages beyond the range around the current page are truncated
+    expect(
+      screen.queryByRole("button", { name: "Page 7 of 10" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("could select a page from the pages", async () => {
+    const handleSelect = vi.fn();
+    const { user } = render(
+      createPagination({
+        label: "Example Pagination",
+        children: (
+          <Pagination.Pages onSelect={handleSelect} page={1} count={10} />
+        ),
+      }),
+    );
+    await userClick(user, screen.getByRole("button", { name: "Page 3 of 10" }));
+    expect(handleSelect).toHaveBeenCalledWith(3);
+  });
+
+  it("should jump to the first and last page", async () => {
+    const handleFirst = vi.fn();
+    const handleLast = vi.fn();
+    const { user } = render(
+      createPagination({
+        label: "Example Pagination",
+        onFirst: handleFirst,
+        onLast: handleLast,
+        hasFirst: true,
+        hasLast: true,
+        children: <Pagination.Pages onSelect={() => {}} page={5} count={10} />,
+      }),
+    );
+    await userClick(user, screen.getByRole("button", { name: /first/i }));
+    expect(handleFirst).toHaveBeenCalled();
+    await userClick(user, screen.getByRole("button", { name: /last/i }));
+    expect(handleLast).toHaveBeenCalled();
+  });
+
+  it("should omit the first and last buttons without their handlers", () => {
+    render(
+      createPagination({
+        label: "Example Pagination",
+        children: <Pagination.Pages onSelect={() => {}} page={5} count={10} />,
+      }),
+    );
+    expect(
+      screen.queryByRole("button", { name: /first/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /last/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should render pages as disabled", () => {
+    render(
+      createPagination({
+        label: "Example Pagination",
+        isDisabled: true,
+        hasFirst: true,
+        onFirst: () => {},
+        children: <Pagination.Pages onSelect={() => {}} page={5} count={10} />,
+      }),
+    );
+    expect(screen.getByRole("button", { name: /first/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Page 5 of 10" })).toBeDisabled();
+  });
 });
 
 function createPagination(props: PaginationProps) {

--- a/easy-ui-react/src/Pagination/Pagination.test.tsx
+++ b/easy-ui-react/src/Pagination/Pagination.test.tsx
@@ -8,6 +8,7 @@ import {
   userClick,
 } from "../utilities/test";
 import { Pagination, PaginationProps } from "./Pagination";
+import { PaginationRowsPerPageProps } from "./PaginationRowsPerPage";
 
 describe("<Pagination />", () => {
   let restoreGetComputedStyle: () => void;
@@ -246,6 +247,76 @@ describe("<Pagination />", () => {
   });
 });
 
+describe("<Pagination.RowsPerPage />", () => {
+  let restoreGetComputedStyle: () => void;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    restoreGetComputedStyle = mockGetComputedStyle();
+  });
+
+  afterEach(() => {
+    restoreGetComputedStyle();
+    vi.useRealTimers();
+  });
+
+  it("should render the label alongside the current count", () => {
+    render(createRowsPerPage());
+    expect(screen.getByText("Rows Per Page:")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /rows per page: 50/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("should support a custom label", () => {
+    render(createRowsPerPage({ label: "Per page:" }));
+    expect(
+      screen.getByRole("button", { name: /per page: 50/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("should select another count", async () => {
+    const handleChange = vi.fn();
+    const { user } = render(createRowsPerPage({ onChange: handleChange }));
+    await userClick(user, screen.getByRole("button"));
+    expect(screen.getAllByRole("menuitemradio").length).toBe(3);
+    await userClick(user, screen.getByRole("menuitemradio", { name: "100" }));
+    expect(handleChange).toHaveBeenCalledWith(100);
+  });
+
+  it("should render at the medium size by default", () => {
+    render(createRowsPerPage());
+    expect(screen.getByRole("button")).toHaveAttribute(
+      "class",
+      expect.stringContaining("sizeMd"),
+    );
+  });
+
+  it("should render at the small size", () => {
+    render(createRowsPerPage({ size: "sm" }));
+    expect(screen.getByRole("button")).toHaveAttribute(
+      "class",
+      expect.stringContaining("sizeSm"),
+    );
+  });
+
+  it("should render as disabled", () => {
+    render(createRowsPerPage({ isDisabled: true }));
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+});
+
 function createPagination(props: PaginationProps) {
   return <Pagination {...props} />;
+}
+
+function createRowsPerPage(props: Partial<PaginationRowsPerPageProps> = {}) {
+  return (
+    <Pagination.RowsPerPage
+      rowsPerPage={50}
+      options={[25, 50, 100]}
+      onChange={() => {}}
+      {...props}
+    />
+  );
 }

--- a/easy-ui-react/src/Pagination/Pagination.tsx
+++ b/easy-ui-react/src/Pagination/Pagination.tsx
@@ -13,8 +13,10 @@ import {
 } from "./PaginationPagedButtons";
 import { PaginationPages, PaginationPagesProps } from "./PaginationPages";
 import { getDisplayNameFromReactNode } from "../utilities/react";
-import { classNames } from "../utilities/css";
+import { classNames, variationName } from "../utilities/css";
 import styles from "./Pagination.module.scss";
+
+export type PaginationSize = "sm" | "md";
 
 export type PaginationProps = {
   /**
@@ -60,6 +62,12 @@ export type PaginationProps = {
    * Accessible label for Pagination, used for aria-label.
    */
   label: string;
+  /**
+   * Size of the pagination controls. Only relevant in the numbered scheme;
+   * the dropdown scheme has a single size.
+   * @default md
+   */
+  size?: PaginationSize;
   /**
    * Whether the Pagination component should be disabled.
    */
@@ -142,6 +150,7 @@ export function Pagination(props: PaginationProps) {
     onFirst,
     onLast,
     label,
+    size = "md",
     isDisabled,
     children,
   } = props;
@@ -166,6 +175,7 @@ export function Pagination(props: PaginationProps) {
   const className = classNames(
     styles.pagination,
     isPaged && styles.paged,
+    isPaged && styles[variationName("size", size)],
     isDisabled && styles.disabled,
   );
 
@@ -182,6 +192,7 @@ export function Pagination(props: PaginationProps) {
         )}
         <PaginationNavButton
           direction="previous"
+          size={size}
           aria-label="Previous"
           onPress={onPrevious}
           isDisabled={!hasPrevious || isDisabled}
@@ -191,6 +202,7 @@ export function Pagination(props: PaginationProps) {
         })}
         <PaginationNavButton
           direction="next"
+          size={size}
           aria-label="Next"
           onPress={onNext}
           isDisabled={!hasNext || isDisabled}

--- a/easy-ui-react/src/Pagination/Pagination.tsx
+++ b/easy-ui-react/src/Pagination/Pagination.tsx
@@ -42,11 +42,13 @@ export type PaginationProps = {
    */
   hasLast?: boolean;
   /**
-   * Callback when previous button is clicked.
+   * Callback when previous button is clicked. In the numbered scheme, supplying
+   * this renders a previous page button; the dropdown scheme always has one.
    */
   onPrevious?: () => void;
   /**
-   * Callback when next button is clicked.
+   * Callback when next button is clicked. In the numbered scheme, supplying
+   * this renders a next page button; the dropdown scheme always has one.
    */
   onNext?: () => void;
   /**
@@ -191,23 +193,30 @@ export function Pagination(props: PaginationProps) {
             First
           </PaginationJumpButton>
         )}
-        <PaginationNavButton
-          direction="previous"
-          size={size}
-          aria-label="Previous"
-          onPress={onPrevious}
-          isDisabled={!hasPrevious || isDisabled}
-        />
+        {/* Per design, a short run of pages can stand on its own, so the
+            chevrons come and go with their handlers the way the jump buttons
+            do rather than always being part of the scheme */}
+        {onPrevious && (
+          <PaginationNavButton
+            direction="previous"
+            size={size}
+            aria-label="Previous"
+            onPress={onPrevious}
+            isDisabled={!hasPrevious || isDisabled}
+          />
+        )}
         {cloneElement(children as ReactElement<PaginationPagesProps>, {
           isDisabled,
         })}
-        <PaginationNavButton
-          direction="next"
-          size={size}
-          aria-label="Next"
-          onPress={onNext}
-          isDisabled={!hasNext || isDisabled}
-        />
+        {onNext && (
+          <PaginationNavButton
+            direction="next"
+            size={size}
+            aria-label="Next"
+            onPress={onNext}
+            isDisabled={!hasNext || isDisabled}
+          />
+        )}
         {onLast && (
           <PaginationJumpButton
             onPress={onLast}

--- a/easy-ui-react/src/Pagination/Pagination.tsx
+++ b/easy-ui-react/src/Pagination/Pagination.tsx
@@ -7,6 +7,11 @@ import {
   PaginationDropdown,
   PaginationDropdownProps,
 } from "./PaginationDropdown";
+import {
+  PaginationJumpButton,
+  PaginationNavButton,
+} from "./PaginationPagedButtons";
+import { PaginationPages, PaginationPagesProps } from "./PaginationPages";
 import { getDisplayNameFromReactNode } from "../utilities/react";
 import { classNames } from "../utilities/css";
 import styles from "./Pagination.module.scss";
@@ -23,6 +28,17 @@ export type PaginationProps = {
    */
   hasNext?: boolean;
   /**
+   * Whether there is a first page to jump to. Only relevant alongside
+   * `onFirst`.
+   * @default false
+   */
+  hasFirst?: boolean;
+  /**
+   * Whether there is a last page to jump to. Only relevant alongside `onLast`.
+   * @default false
+   */
+  hasLast?: boolean;
+  /**
    * Callback when previous button is clicked.
    */
   onPrevious?: () => void;
@@ -30,6 +46,16 @@ export type PaginationProps = {
    * Callback when next button is clicked.
    */
   onNext?: () => void;
+  /**
+   * Callback when the first page button is clicked. Supplying this renders a
+   * first page button; it's only available in the numbered scheme.
+   */
+  onFirst?: () => void;
+  /**
+   * Callback when the last page button is clicked. Supplying this renders a
+   * last page button; it's only available in the numbered scheme.
+   */
+  onLast?: () => void;
   /**
    * Accessible label for Pagination, used for aria-label.
    */
@@ -39,10 +65,11 @@ export type PaginationProps = {
    */
   isDisabled?: boolean;
   /**
-   * The children of `<Pagination />` component only
-   * accept `<Pagination.Dropdown />`.
+   * The children of `<Pagination />` component only accept
+   * `<Pagination.Dropdown />` or `<Pagination.Pages />`. Which one is supplied
+   * determines the scheme the pagination renders in.
    */
-  children?: ReactElement<PaginationDropdownProps>;
+  children?: ReactElement<PaginationDropdownProps | PaginationPagesProps>;
 };
 
 /**
@@ -81,6 +108,24 @@ export type PaginationProps = {
  * ```
  *
  * @example
+ * _With Pages:_
+ * ```tsx
+ * <Pagination
+ *  label="Example with Pages"
+ *  onFirst={handleFirst}
+ *  onPrevious={handlePrevious}
+ *  onNext={handleNext}
+ *  onLast={handleLast}
+ *  hasFirst
+ *  hasPrevious
+ *  hasNext
+ *  hasLast
+ * >
+ *  <Pagination.Pages count={10} page={4} onSelect={handleSelect} />
+ * </Pagination>
+ * ```
+ *
+ * @example
  * _Disabled:_
  * ```tsx
  * <Pagination label="Example Disabled" isDisabled />
@@ -90,22 +135,76 @@ export function Pagination(props: PaginationProps) {
   const {
     hasPrevious = false,
     hasNext = false,
+    hasFirst = false,
+    hasLast = false,
     onPrevious,
     onNext,
+    onFirst,
+    onLast,
     label,
     isDisabled,
     children,
   } = props;
-  const className = classNames(
-    styles.pagination,
-    isDisabled && styles.disabled,
-  );
+
+  const childDisplayName = children
+    ? getDisplayNameFromReactNode(children)
+    : null;
 
   if (
     children &&
-    getDisplayNameFromReactNode(children) !== PaginationDropdown.displayName
+    childDisplayName !== PaginationDropdown.displayName &&
+    childDisplayName !== PaginationPages.displayName
   ) {
-    throw new Error(`children must be ${PaginationDropdown.displayName}`);
+    throw new Error(
+      `children must be ${PaginationDropdown.displayName} or ${PaginationPages.displayName}`,
+    );
+  }
+
+  // The scheme is inferred from the child rather than configured, since the two
+  // schemes differ only in how they let the user reach a page
+  const isPaged = childDisplayName === PaginationPages.displayName;
+  const className = classNames(
+    styles.pagination,
+    isPaged && styles.paged,
+    isDisabled && styles.disabled,
+  );
+
+  if (isPaged) {
+    return (
+      <nav aria-label={label} className={className}>
+        {onFirst && (
+          <PaginationJumpButton
+            onPress={onFirst}
+            isDisabled={!hasFirst || isDisabled}
+          >
+            First
+          </PaginationJumpButton>
+        )}
+        <PaginationNavButton
+          direction="previous"
+          aria-label="Previous"
+          onPress={onPrevious}
+          isDisabled={!hasPrevious || isDisabled}
+        />
+        {cloneElement(children as ReactElement<PaginationPagesProps>, {
+          isDisabled,
+        })}
+        <PaginationNavButton
+          direction="next"
+          aria-label="Next"
+          onPress={onNext}
+          isDisabled={!hasNext || isDisabled}
+        />
+        {onLast && (
+          <PaginationJumpButton
+            onPress={onLast}
+            isDisabled={!hasLast || isDisabled}
+          >
+            Last
+          </PaginationJumpButton>
+        )}
+      </nav>
+    );
   }
 
   return (
@@ -130,3 +229,4 @@ export function Pagination(props: PaginationProps) {
 }
 
 Pagination.Dropdown = PaginationDropdown;
+Pagination.Pages = PaginationPages;

--- a/easy-ui-react/src/Pagination/Pagination.tsx
+++ b/easy-ui-react/src/Pagination/Pagination.tsx
@@ -12,6 +12,7 @@ import {
   PaginationNavButton,
 } from "./PaginationPagedButtons";
 import { PaginationPages, PaginationPagesProps } from "./PaginationPages";
+import { PaginationRowsPerPage } from "./PaginationRowsPerPage";
 import { getDisplayNameFromReactNode } from "../utilities/react";
 import { classNames, variationName } from "../utilities/css";
 import styles from "./Pagination.module.scss";
@@ -242,3 +243,12 @@ export function Pagination(props: PaginationProps) {
 
 Pagination.Dropdown = PaginationDropdown;
 Pagination.Pages = PaginationPages;
+
+/**
+ * A menu for choosing how many rows a page shows.
+ *
+ * @remarks
+ * Rendered on its own alongside a `<Pagination />` rather than inside one,
+ * which only accepts a scheme as its child.
+ */
+Pagination.RowsPerPage = PaginationRowsPerPage;

--- a/easy-ui-react/src/Pagination/PaginationPagedButtons.tsx
+++ b/easy-ui-react/src/Pagination/PaginationPagedButtons.tsx
@@ -3,11 +3,13 @@ import React from "react";
 import { Icon } from "../Icon";
 import { UnstyledButton, UnstyledButtonProps } from "../UnstyledButton";
 import { classNames } from "../utilities/css";
+import type { PaginationSize } from "./Pagination";
 
 import styles from "./Pagination.module.scss";
 
 type PaginationNavButtonProps = Omit<UnstyledButtonProps, "children"> & {
   direction: "previous" | "next";
+  size?: PaginationSize;
 };
 
 /**
@@ -15,7 +17,10 @@ type PaginationNavButtonProps = Omit<UnstyledButtonProps, "children"> & {
  * pagination scheme.
  */
 export function PaginationNavButton(props: PaginationNavButtonProps) {
-  const { direction, ...buttonProps } = props;
+  const { direction, size = "md", ...buttonProps } = props;
+  // The chevron is sized in React rather than CSS, so it has to branch on the
+  // size the rest of the scheme reads from component tokens
+  const iconSize = size === "sm" ? "xs" : "md";
   return (
     <UnstyledButton
       {...buttonProps}
@@ -25,7 +30,7 @@ export function PaginationNavButton(props: PaginationNavButtonProps) {
         direction === "previous" && styles.navButtonPrevious,
       )}
     >
-      <Icon symbol={ChevronRight400} size="xs" />
+      <Icon symbol={ChevronRight400} size={iconSize} />
     </UnstyledButton>
   );
 }
@@ -77,11 +82,10 @@ export function PaginationPageButton(props: PaginationPageButtonProps) {
  * Non-interactive marker standing in for a truncated run of pages.
  */
 export function PaginationEllipsis() {
+  // Takes the buttons' box and type so it lines up with them, but none of their
+  // chrome or affordances, since there's nothing here to press
   return (
-    <span
-      aria-hidden="true"
-      className={classNames(styles.pagedButton, styles.ellipsis)}
-    >
+    <span aria-hidden="true" className={styles.pagedButton}>
       &hellip;
     </span>
   );

--- a/easy-ui-react/src/Pagination/PaginationPagedButtons.tsx
+++ b/easy-ui-react/src/Pagination/PaginationPagedButtons.tsx
@@ -1,0 +1,88 @@
+import ChevronRight400 from "@easypost/easy-ui-icons/ChevronRight400";
+import React from "react";
+import { Icon } from "../Icon";
+import { UnstyledButton, UnstyledButtonProps } from "../UnstyledButton";
+import { classNames } from "../utilities/css";
+
+import styles from "./Pagination.module.scss";
+
+type PaginationNavButtonProps = Omit<UnstyledButtonProps, "children"> & {
+  direction: "previous" | "next";
+};
+
+/**
+ * Single-chevron button for stepping one page at a time within the numbered
+ * pagination scheme.
+ */
+export function PaginationNavButton(props: PaginationNavButtonProps) {
+  const { direction, ...buttonProps } = props;
+  return (
+    <UnstyledButton
+      {...buttonProps}
+      className={classNames(
+        styles.pagedButton,
+        styles.navButton,
+        direction === "previous" && styles.navButtonPrevious,
+      )}
+    >
+      <Icon symbol={ChevronRight400} size="xs" />
+    </UnstyledButton>
+  );
+}
+
+type PaginationJumpButtonProps = UnstyledButtonProps;
+
+/**
+ * Text button for jumping to the first or last page within the numbered
+ * pagination scheme.
+ */
+export function PaginationJumpButton(props: PaginationJumpButtonProps) {
+  const { children, ...buttonProps } = props;
+  return (
+    <UnstyledButton
+      {...buttonProps}
+      className={classNames(styles.pagedButton, styles.jumpButton)}
+    >
+      {children}
+    </UnstyledButton>
+  );
+}
+
+type PaginationPageButtonProps = Omit<UnstyledButtonProps, "children"> & {
+  page: number;
+  isCurrent: boolean;
+};
+
+/**
+ * Button for a single page within the numbered pagination scheme.
+ */
+export function PaginationPageButton(props: PaginationPageButtonProps) {
+  const { page, isCurrent, ...buttonProps } = props;
+  return (
+    <UnstyledButton
+      {...buttonProps}
+      aria-current={isCurrent ? "page" : undefined}
+      className={classNames(
+        styles.pagedButton,
+        styles.pageButton,
+        isCurrent && styles.pageButtonCurrent,
+      )}
+    >
+      {page}
+    </UnstyledButton>
+  );
+}
+
+/**
+ * Non-interactive marker standing in for a truncated run of pages.
+ */
+export function PaginationEllipsis() {
+  return (
+    <span
+      aria-hidden="true"
+      className={classNames(styles.pagedButton, styles.ellipsis)}
+    >
+      &hellip;
+    </span>
+  );
+}

--- a/easy-ui-react/src/Pagination/PaginationPages.test.ts
+++ b/easy-ui-react/src/Pagination/PaginationPages.test.ts
@@ -1,0 +1,108 @@
+import { getPaginationRange } from "./PaginationPages";
+
+describe("getPaginationRange()", () => {
+  const defaults = { siblingCount: 2, boundaryCount: 0 };
+
+  it("should return nothing without any pages", () => {
+    expect(getPaginationRange({ page: 1, count: 0, ...defaults })).toEqual([]);
+  });
+
+  it("should return every page when they all fit", () => {
+    expect(getPaginationRange({ page: 1, count: 1, ...defaults })).toEqual([1]);
+    expect(getPaginationRange({ page: 1, count: 3, ...defaults })).toEqual([
+      1, 2, 3,
+    ]);
+  });
+
+  it("should truncate the end when the current page is near the start", () => {
+    expect(getPaginationRange({ page: 1, count: 10, ...defaults })).toEqual([
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      "ellipsis",
+    ]);
+  });
+
+  it("should truncate the start when the current page is near the end", () => {
+    expect(getPaginationRange({ page: 10, count: 10, ...defaults })).toEqual([
+      "ellipsis",
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+    ]);
+  });
+
+  it("should truncate both ends when the current page is in the middle", () => {
+    expect(getPaginationRange({ page: 5, count: 10, ...defaults })).toEqual([
+      "ellipsis",
+      3,
+      4,
+      5,
+      6,
+      7,
+      "ellipsis",
+    ]);
+  });
+
+  it("should pin the boundaries when a boundary count is given", () => {
+    expect(
+      getPaginationRange({
+        page: 1,
+        count: 10,
+        siblingCount: 1,
+        boundaryCount: 1,
+      }),
+    ).toEqual([1, 2, 3, 4, 5, "ellipsis", 10]);
+  });
+
+  it("should show a lone hidden page rather than truncate it", () => {
+    const range = getPaginationRange({
+      page: 4,
+      count: 8,
+      siblingCount: 1,
+      boundaryCount: 1,
+    });
+    // Only page 2 sits between the start boundary and the siblings, so showing
+    // it costs no more room than an ellipsis would. Pages 6 and 7 are both
+    // hidden on the other side, so that side still truncates
+    expect(range).toEqual([1, 2, 3, 4, 5, "ellipsis", 8]);
+  });
+
+  it("should not repeat a page", () => {
+    for (let count = 1; count <= 12; count++) {
+      for (let page = 1; page <= count; page++) {
+        const range = getPaginationRange({ page, count, ...defaults });
+        const pages = range.filter((item) => item !== "ellipsis");
+        expect(new Set(pages).size).toBe(pages.length);
+      }
+    }
+  });
+
+  it("should keep pages in ascending order", () => {
+    for (let count = 1; count <= 12; count++) {
+      for (let page = 1; page <= count; page++) {
+        const range = getPaginationRange({ page, count, ...defaults });
+        const pages = range.filter(
+          (item): item is number => item !== "ellipsis",
+        );
+        expect(pages).toEqual([...pages].sort((a, b) => a - b));
+      }
+    }
+  });
+
+  it("should always include the current page", () => {
+    for (let count = 1; count <= 12; count++) {
+      for (let page = 1; page <= count; page++) {
+        expect(getPaginationRange({ page, count, ...defaults })).toContain(
+          page,
+        );
+      }
+    }
+  });
+});

--- a/easy-ui-react/src/Pagination/PaginationPages.tsx
+++ b/easy-ui-react/src/Pagination/PaginationPages.tsx
@@ -1,0 +1,176 @@
+import React from "react";
+import {
+  PaginationEllipsis,
+  PaginationPageButton,
+} from "./PaginationPagedButtons";
+
+import styles from "./Pagination.module.scss";
+
+export type PaginationPagesProps = {
+  /**
+   * The current page.
+   */
+  page: number;
+  /**
+   * The total number of pages.
+   */
+  count: number;
+  /**
+   * Callback when a page is selected.
+   */
+  onSelect: (page: number) => void;
+  /**
+   * How many pages to show on either side of the current page.
+   *
+   * @default 2
+   */
+  siblingCount?: number;
+  /**
+   * How many pages to pin at the start and end of the range. Defaults to none,
+   * since `<Pagination />`'s first and last buttons cover the boundaries.
+   *
+   * @default 0
+   */
+  boundaryCount?: number;
+  /**
+   * Whether the pages should be disabled.
+   */
+  isDisabled?: boolean;
+};
+
+const ELLIPSIS = "ellipsis" as const;
+
+/**
+ * Renders a range of individually selectable page numbers, truncating runs of
+ * pages that fall outside of the range with an ellipsis.
+ *
+ * @remarks
+ * Use as a child of `<Pagination />` in place of `<Pagination.Dropdown />`.
+ * Supplying it switches `<Pagination />` to its numbered scheme.
+ */
+export function PaginationPages(props: PaginationPagesProps) {
+  const {
+    page,
+    count,
+    onSelect,
+    siblingCount = 2,
+    boundaryCount = 0,
+    isDisabled,
+  } = props;
+
+  const items = getPaginationRange({
+    page,
+    count,
+    siblingCount,
+    boundaryCount,
+  });
+
+  return (
+    <div className={styles.pageRow}>
+      {items.map((item, i) =>
+        item === ELLIPSIS ? (
+          // Ellipses are interchangeable, so their index is a stable enough key
+          <PaginationEllipsis key={`${ELLIPSIS}-${i}`} />
+        ) : (
+          <PaginationPageButton
+            key={item}
+            page={item}
+            isCurrent={item === page}
+            isDisabled={isDisabled}
+            aria-label={`Page ${item} of ${count}`}
+            onPress={() => onSelect(item)}
+          />
+        ),
+      )}
+    </div>
+  );
+}
+
+/**
+ * Builds the list of pages to render, inserting ellipses where pages are
+ * truncated.
+ *
+ * @returns page numbers interleaved with ellipsis markers
+ */
+export function getPaginationRange({
+  page,
+  count,
+  siblingCount,
+  boundaryCount,
+}: {
+  page: number;
+  count: number;
+  siblingCount: number;
+  boundaryCount: number;
+}) {
+  if (count <= 0) {
+    return [];
+  }
+
+  const startPages = range(1, Math.min(boundaryCount, count));
+  const endPages = range(
+    Math.max(count - boundaryCount + 1, boundaryCount + 1),
+    count,
+  );
+
+  const siblingsStart = Math.max(
+    Math.min(page - siblingCount, count - boundaryCount - siblingCount * 2 - 1),
+    boundaryCount + 2,
+  );
+  const siblingsEnd = Math.min(
+    Math.max(page + siblingCount, boundaryCount + siblingCount * 2 + 2),
+    endPages.length > 0 ? endPages[0] - 2 : count - 1,
+  );
+
+  return [
+    ...startPages,
+    ...getStartTruncation({ siblingsStart, boundaryCount, count }),
+    ...range(siblingsStart, siblingsEnd),
+    ...getEndTruncation({ siblingsEnd, boundaryCount, count }),
+    ...endPages,
+  ];
+}
+
+function getStartTruncation({
+  siblingsStart,
+  boundaryCount,
+  count,
+}: {
+  siblingsStart: number;
+  boundaryCount: number;
+  count: number;
+}) {
+  if (siblingsStart > boundaryCount + 2) {
+    return [ELLIPSIS];
+  }
+  // Only one page is being hidden, so show it rather than truncate it
+  if (boundaryCount + 1 < count - boundaryCount) {
+    return [boundaryCount + 1];
+  }
+  return [];
+}
+
+function getEndTruncation({
+  siblingsEnd,
+  boundaryCount,
+  count,
+}: {
+  siblingsEnd: number;
+  boundaryCount: number;
+  count: number;
+}) {
+  if (siblingsEnd < count - boundaryCount - 1) {
+    return [ELLIPSIS];
+  }
+  if (count - boundaryCount > boundaryCount) {
+    return [count - boundaryCount];
+  }
+  return [];
+}
+
+function range(start: number, end: number) {
+  const length = end - start + 1;
+  return length > 0 ? Array.from({ length }, (_, i) => start + i) : [];
+}
+
+PaginationPages.displayName = "Pagination.Pages";

--- a/easy-ui-react/src/Pagination/PaginationRowsPerPage.module.scss
+++ b/easy-ui-react/src/Pagination/PaginationRowsPerPage.module.scss
@@ -13,7 +13,7 @@
   display: flex;
   align-items: center;
   gap: design-token("space.1");
-  color: design-token("color.neutral.900");
+  color: design-token("color.neutral.800");
   background: design-token("color.neutral.000");
   border: design-token("shape.border_width.1") solid
     design-token("color.neutral.200");

--- a/easy-ui-react/src/Pagination/PaginationRowsPerPage.module.scss
+++ b/easy-ui-react/src/Pagination/PaginationRowsPerPage.module.scss
@@ -1,20 +1,18 @@
 @use "../styles/common" as *;
 
-.RowsPerPageMenu {
+// The gap between the label and the trigger reads as the same tight pairing at
+// either size, so it doesn't scale
+.RowsPerPage {
   display: flex;
   align-items: center;
   gap: design-token("space.0.5");
 }
 
 .trigger {
-  @include font-style("body2");
-
   box-sizing: border-box;
   display: flex;
   align-items: center;
   gap: design-token("space.1");
-  height: 24px;
-  padding: 0 design-token("space.1");
   color: design-token("color.neutral.900");
   background: design-token("color.neutral.000");
   border: design-token("shape.border_width.1") solid
@@ -34,4 +32,21 @@
   &:hover:not(:disabled):not(:active) {
     color: design-token("color.primary.500");
   }
+}
+
+// The size classes land on the trigger itself, since it's the only part of the
+// control that scales. `<UnstyledButton />` only inherits font size and line
+// height, so the type is set here rather than on the label's ancestor.
+.sizeSm {
+  @include font-style("body2");
+
+  height: design-token("space.3");
+  padding: 0 design-token("space.1.5");
+}
+
+.sizeMd {
+  @include font-style("body1");
+
+  height: design-token("space.5");
+  padding: 0 design-token("space.2");
 }

--- a/easy-ui-react/src/Pagination/PaginationRowsPerPage.module.scss
+++ b/easy-ui-react/src/Pagination/PaginationRowsPerPage.module.scss
@@ -29,8 +29,9 @@
     border-color: design-token("color.neutral.100");
   }
 
+  // Tints the box on hover, the same as the pagination controls it sits beside
   &:hover:not(:disabled):not(:active) {
-    color: design-token("color.primary.500");
+    background: design-token("color.neutral.050");
   }
 }
 

--- a/easy-ui-react/src/Pagination/PaginationRowsPerPage.tsx
+++ b/easy-ui-react/src/Pagination/PaginationRowsPerPage.tsx
@@ -5,10 +5,12 @@ import { Icon } from "../Icon";
 import { Menu } from "../Menu";
 import { Text } from "../Text";
 import { UnstyledButton } from "../UnstyledButton";
+import { classNames, variationName } from "../utilities/css";
+import type { PaginationSize } from "./Pagination";
 
-import styles from "./RowsPerPageMenu.module.scss";
+import styles from "./PaginationRowsPerPage.module.scss";
 
-export type DataGridRowsPerPageMenuProps = {
+export type PaginationRowsPerPageProps = {
   /** The number of rows currently shown per page. */
   rowsPerPage: number;
 
@@ -24,32 +26,41 @@ export type DataGridRowsPerPageMenuProps = {
    */
   label?: string;
 
+  /**
+   * Size of the control. Matches the sizes of the numbered `<Pagination />`
+   * scheme so the two can sit side by side.
+   * @default md
+   */
+  size?: PaginationSize;
+
   /** Whether the menu should be disabled. */
   isDisabled?: boolean;
 };
 
 /**
- * A fully controlled menu for choosing how many rows a data grid page shows.
+ * A fully controlled menu for choosing how many rows a page shows.
  *
  * @remarks
- * Intended for the end region of a `<DataGrid.Footer />`, though it carries no
- * dependency on the footer and can be placed anywhere.
+ * Rendered on its own rather than as a child of `<Pagination />`, which only
+ * accepts a scheme. It lives here because page size is a pagination concern and
+ * its sizes are drawn to match the numbered scheme's.
  *
  * @example
  * ```tsx
- * <DataGrid.RowsPerPageMenu
+ * <Pagination.RowsPerPage
  *   rowsPerPage={rowsPerPage}
  *   options={[25, 50, 100]}
  *   onChange={setRowsPerPage}
  * />
  * ```
  */
-export function DataGridRowsPerPageMenu(props: DataGridRowsPerPageMenuProps) {
+export function PaginationRowsPerPage(props: PaginationRowsPerPageProps) {
   const {
     rowsPerPage,
     options,
     onChange,
     label = "Rows Per Page:",
+    size = "md",
     isDisabled,
   } = props;
 
@@ -61,19 +72,28 @@ export function DataGridRowsPerPageMenu(props: DataGridRowsPerPageMenuProps) {
   const triggerLabelledBy = `${labelId} ${valueId}`;
 
   return (
-    <div className={styles.RowsPerPageMenu}>
-      <Text id={labelId} variant="body2" color="neutral.900">
+    <div className={styles.RowsPerPage}>
+      <Text
+        id={labelId}
+        variant={size === "sm" ? "body2" : "body1"}
+        color="neutral.900"
+      >
         {label}
       </Text>
       <Menu isDisabled={isDisabled}>
         <Menu.Trigger>
           <UnstyledButton
-            className={styles.trigger}
+            className={classNames(
+              styles.trigger,
+              styles[variationName("size", size)],
+            )}
             aria-labelledby={triggerLabelledBy}
             isDisabled={isDisabled}
           >
             <span id={valueId}>{rowsPerPage}</span>
-            <Icon symbol={ExpandMore400} size="xs" />
+            {/* Design holds the chevron at 24px in both sizes, which is the
+                icon's own default */}
+            <Icon symbol={ExpandMore400} size="md" />
           </UnstyledButton>
         </Menu.Trigger>
         <Menu.Overlay
@@ -110,4 +130,4 @@ function getSelectedKey(keys: "all" | Set<Key>): Key | null {
   return key ?? null;
 }
 
-DataGridRowsPerPageMenu.displayName = "DataGrid.RowsPerPageMenu";
+PaginationRowsPerPage.displayName = "Pagination.RowsPerPage";

--- a/easy-ui-react/src/Pagination/PaginationRowsPerPage.tsx
+++ b/easy-ui-react/src/Pagination/PaginationRowsPerPage.tsx
@@ -76,7 +76,7 @@ export function PaginationRowsPerPage(props: PaginationRowsPerPageProps) {
       <Text
         id={labelId}
         variant={size === "sm" ? "body2" : "body1"}
-        color="neutral.900"
+        color="neutral.800"
       >
         {label}
       </Text>


### PR DESCRIPTION
## 📝 Changes

Adds a sticky footer to `<DataGrid />` and the pagination pieces it's built from.

**`<DataGrid />`**

- `renderFooter` renders a bar pinned to the bottom of the scroll container, modeled on the existing sticky header — it reuses the edge interceptors for its shadow-on-scroll and pins horizontally so it stays put while rows scroll sideways.
- `<DataGrid.Footer />` lays the bar out with purely positional `start`, `center`, and `end` slots, so it stays unaware of what it holds and the data grid isn't tied to any one pagination scheme.
- `<DataGrid.Pagination />` and `<DataGrid.RowsPerPage />` are fully controlled presets for the common case. Either can be swapped for a custom control, or `renderFooter` can skip `<DataGrid.Footer />` entirely.
- Sticky shadows are lightened (opacity `0.5` → `0.35`), which affects the frozen column shadows as well as the new footer's.

**`<Pagination />`**

- `<Pagination.Pages />` is a numbered scheme alongside the existing `<Pagination.Dropdown />`, for when the user should be able to see and reach nearby pages directly. The scheme is inferred from the child rather than configured. Optional `First`/`Last` jump buttons keep the ends of a long range reachable once it truncates.
- `<Pagination.RowsPerPage />` is a fully controlled page-size menu. It's a sibling of `<Pagination />` rather than a child, since that slot takes a scheme and the two sit side by side in design.
- Both take a `size` of `sm` or `md`, resolved to the nearest tokens on the space scale.

## ✅ Checklist

Easy UI has certain UX standards that must be met. In general, non-trivial changes should meet the following criteria:

- [x] Visuals match Design Specs in Figma
- [x] Stories accompany any component changes
- [x] Code is in accordance with our style guide
- [x] Design tokens are utilized
- [x] Unit tests accompany any component changes
- [x] TSDoc is written for any API surface area
- [x] Specs are up-to-date
- [x] Console is free from warnings
- [x] No accessibility violations are reported
- [x] Cross-browser check is performed (Chrome, Safari, Firefox)
- [x] Changeset is added

~Strikethrough~ any items that are not applicable to this pull request.
