### PR TITLE
feat(MultiSelect): add iconAtStart and size props

### DIFF
--- a/.changeset/chilly-friends-repeat.md
+++ b/.changeset/chilly-friends-repeat.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": minor
+---
+
+Add iconAtStart and size prop (sm/md/lg) to MultiSelect, matching the API Select already has. The size also scales the selected pills, so a small field gets smaller pills.PillGroup now takes a size prop (sm/md) to support that

--- a/easy-ui-react/src/MultiSelect/MultiSelect.mdx
+++ b/easy-ui-react/src/MultiSelect/MultiSelect.mdx
@@ -22,6 +22,24 @@ This variant of the `<MultiSelect />` includes icons next to each option. It use
 
 <Canvas of={MultiSelectStories.WithIcons} />
 
+## Start Icon
+
+Use `iconAtStart` to add a left aligned icon.
+
+<Canvas of={MultiSelectStories.WithStartIcon} />
+
+## Small MultiSelect
+
+Set `size="sm"` for a small `<MultiSelect />`.
+
+<Canvas of={MultiSelectStories.SmallMultiSelect} />
+
+## Large MultiSelect
+
+Set `size="lg"` for a large `<MultiSelect />`.
+
+<Canvas of={MultiSelectStories.LargeMultiSelect} />
+
 ## Disabled Keys
 
 You can disable specific items from being selected by using the `disabledKeys` prop. This is useful when some options should be unselectable.

--- a/easy-ui-react/src/MultiSelect/MultiSelect.module.scss
+++ b/easy-ui-react/src/MultiSelect/MultiSelect.module.scss
@@ -87,7 +87,7 @@
   height: design-token("space.3");
 }
 
-.multiSelectSizeSm {
+.sizeSm {
   min-height: component-token("inputfield", "max-height-sm");
   padding: calc(
       #{design-token("space.0.5")} - #{design-token("shape.border_width.1")}
@@ -101,7 +101,7 @@
   }
 }
 
-.multiSelectSizeLg {
+.sizeLg {
   min-height: design-token("space.7");
   padding: calc(
       #{design-token("space.1.5")} - #{design-token("shape.border_width.1")}

--- a/easy-ui-react/src/MultiSelect/MultiSelect.module.scss
+++ b/easy-ui-react/src/MultiSelect/MultiSelect.module.scss
@@ -12,12 +12,12 @@
   flex-direction: row;
   flex-wrap: wrap;
   align-items: center;
-  gap: design-token("space.2");
+  gap: design-token("space.1");
 
   padding: calc(
       #{design-token("space.1")} - #{design-token("shape.border_width.1")}
     )
-    design-token("space.2");
+    design-token("space.1.5");
   background-color: component-token("inputfield", "color.background");
   border: design-token("shape.border_width.1") solid
     component-token("inputfield", "color.border.resting");

--- a/easy-ui-react/src/MultiSelect/MultiSelect.module.scss
+++ b/easy-ui-react/src/MultiSelect/MultiSelect.module.scss
@@ -14,7 +14,10 @@
   align-items: center;
   gap: design-token("space.2");
 
-  padding: calc(#{design-token("space.1")} - 1px) design-token("space.2");
+  padding: calc(
+      #{design-token("space.1")} - #{design-token("shape.border_width.1")}
+    )
+    design-token("space.2");
   background-color: component-token("inputfield", "color.background");
   border: design-token("shape.border_width.1") solid
     component-token("inputfield", "color.border.resting");
@@ -26,6 +29,13 @@
     box-shadow: component-token("inputfield", "box_shadow");
     border-color: component-token("inputfield", "color.border.engaged");
   }
+}
+
+.iconAtStart {
+  display: inline-flex;
+  align-items: center;
+  color: component-token("inputfield", "color.text.gray.resting");
+  pointer-events: none;
 }
 
 .comboBoxContainer {
@@ -75,4 +85,26 @@
   justify-content: center;
   width: design-token("space.3");
   height: design-token("space.3");
+}
+
+.multiSelectSizeSm {
+  min-height: component-token("inputfield", "max-height-sm");
+  padding: calc(
+      #{design-token("space.0.5")} - #{design-token("shape.border_width.1")}
+    )
+    design-token("space.1.5");
+
+  .input {
+    @include font-style("body2");
+    padding: design-token("space.0.5") 0;
+    margin: calc(#{design-token("space.0.5")} * -1) 0;
+  }
+}
+
+.multiSelectSizeLg {
+  min-height: design-token("space.7");
+  padding: calc(
+      #{design-token("space.1.5")} - #{design-token("shape.border_width.1")}
+    )
+    design-token("space.1.5");
 }

--- a/easy-ui-react/src/MultiSelect/MultiSelect.stories.tsx
+++ b/easy-ui-react/src/MultiSelect/MultiSelect.stories.tsx
@@ -1,3 +1,4 @@
+import CalendarMonthIcon from "@easypost/easy-ui-icons/CalendarMonth";
 import { Meta, StoryObj } from "@storybook/react-vite";
 import React, { useCallback } from "react";
 import { HorizontalStack } from "../HorizontalStack";
@@ -175,6 +176,125 @@ export const WithIcons: Story = {
               {item.icon && <Icon symbol={item.icon} />}
               <MultiSelect.OptionText>{item.label}</MultiSelect.OptionText>
             </HorizontalStack>
+          </MultiSelect.Option>
+        )}
+      </MultiSelect>
+    );
+  },
+};
+
+export const WithStartIcon: Story = {
+  render: () => {
+    const [selectedItems, setSelectedItems] = React.useState<Item[]>([
+      fruits[0],
+    ]);
+    const { contains } = useFilter({ sensitivity: "base" });
+    const filter = useCallback(
+      (item: Item, filterText: string) => contains(item.label, filterText),
+      [contains],
+    );
+    const list = useListData<Item>({
+      initialSelectedKeys: selectedItems.map((i) => i.key),
+      initialItems: fruits,
+      filter,
+    });
+    return (
+      <MultiSelect
+        iconAtStart={CalendarMonthIcon}
+        dropdownItems={list.items}
+        inputValue={list.filterText}
+        onInputChange={list.setFilterText}
+        selectedItems={selectedItems}
+        onSelectionChange={setSelectedItems}
+        placeholder="Select a fruit"
+        maxItemsUntilScroll={10}
+        renderPill={(item) => (
+          <MultiSelect.Pill icon={item.icon} label={item.label} />
+        )}
+      >
+        {(item) => (
+          <MultiSelect.Option textValue={item.label}>
+            <MultiSelect.OptionText>{item.label}</MultiSelect.OptionText>
+          </MultiSelect.Option>
+        )}
+      </MultiSelect>
+    );
+  },
+};
+
+export const SmallMultiSelect: Story = {
+  render: () => {
+    const [selectedItems, setSelectedItems] = React.useState<Item[]>([
+      fruits[0],
+    ]);
+    const { contains } = useFilter({ sensitivity: "base" });
+    const filter = useCallback(
+      (item: Item, filterText: string) => contains(item.label, filterText),
+      [contains],
+    );
+    const list = useListData<Item>({
+      initialSelectedKeys: selectedItems.map((i) => i.key),
+      initialItems: fruits,
+      filter,
+    });
+    return (
+      <MultiSelect
+        size="sm"
+        iconAtStart={CalendarMonthIcon}
+        dropdownItems={list.items}
+        inputValue={list.filterText}
+        onInputChange={list.setFilterText}
+        selectedItems={selectedItems}
+        onSelectionChange={setSelectedItems}
+        placeholder="Select a fruit"
+        maxItemsUntilScroll={10}
+        renderPill={(item) => (
+          <MultiSelect.Pill icon={item.icon} label={item.label} />
+        )}
+      >
+        {(item) => (
+          <MultiSelect.Option textValue={item.label}>
+            <MultiSelect.OptionText>{item.label}</MultiSelect.OptionText>
+          </MultiSelect.Option>
+        )}
+      </MultiSelect>
+    );
+  },
+};
+
+export const LargeMultiSelect: Story = {
+  render: () => {
+    const [selectedItems, setSelectedItems] = React.useState<Item[]>([
+      fruits[0],
+    ]);
+    const { contains } = useFilter({ sensitivity: "base" });
+    const filter = useCallback(
+      (item: Item, filterText: string) => contains(item.label, filterText),
+      [contains],
+    );
+    const list = useListData<Item>({
+      initialSelectedKeys: selectedItems.map((i) => i.key),
+      initialItems: fruits,
+      filter,
+    });
+    return (
+      <MultiSelect
+        size="lg"
+        iconAtStart={CalendarMonthIcon}
+        dropdownItems={list.items}
+        inputValue={list.filterText}
+        onInputChange={list.setFilterText}
+        selectedItems={selectedItems}
+        onSelectionChange={setSelectedItems}
+        placeholder="Select a fruit"
+        maxItemsUntilScroll={10}
+        renderPill={(item) => (
+          <MultiSelect.Pill icon={item.icon} label={item.label} />
+        )}
+      >
+        {(item) => (
+          <MultiSelect.Option textValue={item.label}>
+            <MultiSelect.OptionText>{item.label}</MultiSelect.OptionText>
           </MultiSelect.Option>
         )}
       </MultiSelect>

--- a/easy-ui-react/src/MultiSelect/MultiSelect.test.tsx
+++ b/easy-ui-react/src/MultiSelect/MultiSelect.test.tsx
@@ -1,7 +1,9 @@
+import CalendarMonthIcon from "@easypost/easy-ui-icons/CalendarMonth";
 import { getByRole, screen } from "@testing-library/react";
 import { UserEvent } from "@testing-library/user-event";
 import React, { useCallback, useState } from "react";
 import { vi } from "vitest";
+import { IconSymbol } from "../types";
 import { mockGetComputedStyle, render, userClick } from "../utilities/test";
 import { Item, MultiSelect, useFilter, useListData } from "./MultiSelect";
 
@@ -60,6 +62,17 @@ describe("<MultiSelect />", () => {
     await clearSelectedItem(user, "Apple");
     expect(screen.queryByText("No selected items")).toBeInTheDocument();
   });
+
+  it("should render iconAtStart", async () => {
+    render(getMultiSelect({ iconAtStart: CalendarMonthIcon }));
+    // The dropdown-arrow icon renders by default; iconAtStart adds a second.
+    expect(screen.getAllByRole("img", { hidden: true })).toHaveLength(2);
+  });
+
+  it("should not render a start icon by default", async () => {
+    render(getMultiSelect());
+    expect(screen.getAllByRole("img", { hidden: true })).toHaveLength(1);
+  });
 });
 
 const fruits = [
@@ -87,8 +100,10 @@ const fruits = [
 
 const getMultiSelect = ({
   initialSelectedItems = [],
+  iconAtStart,
 }: {
   initialSelectedItems?: Item[];
+  iconAtStart?: IconSymbol;
 } = {}) => {
   function MultiSelectTest() {
     const [selectedItems, setSelectedItems] =
@@ -106,6 +121,7 @@ const getMultiSelect = ({
     return (
       <MultiSelect
         dropdownItems={list.items}
+        iconAtStart={iconAtStart}
         inputValue={list.filterText}
         onInputChange={list.setFilterText}
         selectedItems={selectedItems}

--- a/easy-ui-react/src/MultiSelect/MultiSelect.test.tsx
+++ b/easy-ui-react/src/MultiSelect/MultiSelect.test.tsx
@@ -5,7 +5,13 @@ import React, { useCallback, useState } from "react";
 import { vi } from "vitest";
 import { IconSymbol } from "../types";
 import { mockGetComputedStyle, render, userClick } from "../utilities/test";
-import { Item, MultiSelect, useFilter, useListData } from "./MultiSelect";
+import {
+  Item,
+  MultiSelect,
+  MultiSelectSize,
+  useFilter,
+  useListData,
+} from "./MultiSelect";
 
 describe("<MultiSelect />", () => {
   let restoreGetComputedStyle: () => void;
@@ -73,6 +79,51 @@ describe("<MultiSelect />", () => {
     render(getMultiSelect());
     expect(screen.getAllByRole("img", { hidden: true })).toHaveLength(1);
   });
+
+  it("should apply the size class for size='sm'", async () => {
+    const { container } = render(getMultiSelect({ size: "sm" }));
+    expect(container.firstChild).toHaveAttribute(
+      "class",
+      expect.stringContaining("sizeSm"),
+    );
+  });
+
+  it("should apply the size class for size='lg'", async () => {
+    const { container } = render(getMultiSelect({ size: "lg" }));
+    expect(container.firstChild).toHaveAttribute(
+      "class",
+      expect.stringContaining("sizeLg"),
+    );
+  });
+
+  it("should not apply a size class for the default md size", async () => {
+    const { container } = render(getMultiSelect());
+    expect(container.firstChild).not.toHaveAttribute(
+      "class",
+      expect.stringContaining("sizeSm"),
+    );
+    expect(container.firstChild).not.toHaveAttribute(
+      "class",
+      expect.stringContaining("sizeLg"),
+    );
+  });
+
+  it("should render smaller selected pills only for size='sm'", async () => {
+    const sm = render(
+      getMultiSelect({ size: "sm", initialSelectedItems: [fruits[0]] }),
+    );
+    expect(getSelectedItem("Apple")).toHaveAttribute(
+      "class",
+      expect.stringContaining("sizeSm"),
+    );
+    sm.unmount();
+
+    render(getMultiSelect({ size: "md", initialSelectedItems: [fruits[0]] }));
+    expect(getSelectedItem("Apple")).not.toHaveAttribute(
+      "class",
+      expect.stringContaining("sizeSm"),
+    );
+  });
 });
 
 const fruits = [
@@ -101,9 +152,11 @@ const fruits = [
 const getMultiSelect = ({
   initialSelectedItems = [],
   iconAtStart,
+  size,
 }: {
   initialSelectedItems?: Item[];
   iconAtStart?: IconSymbol;
+  size?: MultiSelectSize;
 } = {}) => {
   function MultiSelectTest() {
     const [selectedItems, setSelectedItems] =
@@ -128,6 +181,7 @@ const getMultiSelect = ({
         onSelectionChange={setSelectedItems}
         placeholder="Select a fruit"
         maxItemsUntilScroll={10}
+        size={size}
         renderPill={(item) => (
           <MultiSelect.Pill icon={item.icon} label={item.label} />
         )}

--- a/easy-ui-react/src/MultiSelect/MultiSelect.tsx
+++ b/easy-ui-react/src/MultiSelect/MultiSelect.tsx
@@ -4,6 +4,7 @@ import { Key, useFilter, VisuallyHidden } from "react-aria";
 import { Button, ComboBox, ComboBoxProps, Input } from "react-aria-components";
 import { AsyncListData, useAsyncList, useListData } from "react-stately";
 import { Icon } from "../Icon";
+import { mapIconSize } from "../InputField/utilities";
 import { MenuOverlayProps } from "../Menu/MenuOverlay";
 import { DEFAULT_MAX_ITEMS_UNTIL_SCROLL } from "../Menu/utilities";
 import { PillGroup, PillProps, PillBackground } from "../PillGroup";
@@ -257,7 +258,7 @@ export function MultiSelect<T extends Item>(props: MultiSelectProps<T>) {
     >
       {iconAtStart && (
         <span className={styles.iconAtStart}>
-          <Icon symbol={iconAtStart} />
+          <Icon symbol={iconAtStart} size={mapIconSize(size)} />
         </span>
       )}
       {selectedItems.length > 0 ? (
@@ -269,6 +270,7 @@ export function MultiSelect<T extends Item>(props: MultiSelectProps<T>) {
           background={pillBackground}
           isBorderless={isPillBorderless}
           size={size === "sm" ? "sm" : "md"}
+          isFlattened
         >
           {renderPill}
         </PillGroup>

--- a/easy-ui-react/src/MultiSelect/MultiSelect.tsx
+++ b/easy-ui-react/src/MultiSelect/MultiSelect.tsx
@@ -252,7 +252,7 @@ export function MultiSelect<T extends Item>(props: MultiSelectProps<T>) {
       ref={rootRef}
       className={classNames(
         styles.MultiSelect,
-        styles[variationName("multiSelectSize", size)],
+        styles[variationName("size", size)],
       )}
     >
       {iconAtStart && (

--- a/easy-ui-react/src/MultiSelect/MultiSelect.tsx
+++ b/easy-ui-react/src/MultiSelect/MultiSelect.tsx
@@ -7,6 +7,8 @@ import { Icon } from "../Icon";
 import { MenuOverlayProps } from "../Menu/MenuOverlay";
 import { DEFAULT_MAX_ITEMS_UNTIL_SCROLL } from "../Menu/utilities";
 import { PillGroup, PillProps, PillBackground } from "../PillGroup";
+import { IconSymbol } from "../types";
+import { classNames, variationName } from "../utilities/css";
 import {
   MultiSelectDropdown,
   MultiSelectDropdownOption,
@@ -18,6 +20,8 @@ import styles from "./MultiSelect.module.scss";
 import { Text } from "../Text";
 
 export type Item = { key: Key } & PillProps;
+
+export type MultiSelectSize = "sm" | "md" | "lg";
 
 export type MultiSelectProps<T extends object> = {
   /**
@@ -37,6 +41,11 @@ export type MultiSelectProps<T extends object> = {
    * from a ComboBox component and represent the available options for selection.
    */
   dropdownItems: ComboBoxProps<T>["items"];
+
+  /**
+   * Left aligned icon on the multi-select field.
+   */
+  iconAtStart?: IconSymbol;
 
   /**
    * The current input value in the multi-select input field. This is used to filter or search
@@ -85,6 +94,13 @@ export type MultiSelectProps<T extends object> = {
    * the currently selected items.
    */
   selectedItems: T[];
+
+  /**
+   * Size affects the overall size of the multi-select field, and it also
+   * influences the size of the selected item pills.
+   * @default md
+   */
+  size?: MultiSelectSize;
 
   /**
    * The background of individual pills. Maps to token theme colors.
@@ -151,6 +167,7 @@ export function MultiSelect<T extends Item>(props: MultiSelectProps<T>) {
     children,
     disabledKeys,
     dropdownItems = [],
+    iconAtStart,
     inputValue,
     isLoading,
     maxItemsUntilScroll = DEFAULT_MAX_ITEMS_UNTIL_SCROLL,
@@ -159,6 +176,7 @@ export function MultiSelect<T extends Item>(props: MultiSelectProps<T>) {
     placeholder,
     renderPill,
     selectedItems,
+    size = "md",
     pillBackground,
     isPillBorderless,
   } = props;
@@ -230,7 +248,18 @@ export function MultiSelect<T extends Item>(props: MultiSelectProps<T>) {
   };
 
   return (
-    <div ref={rootRef} className={styles.MultiSelect}>
+    <div
+      ref={rootRef}
+      className={classNames(
+        styles.MultiSelect,
+        styles[variationName("multiSelectSize", size)],
+      )}
+    >
+      {iconAtStart && (
+        <span className={styles.iconAtStart}>
+          <Icon symbol={iconAtStart} />
+        </span>
+      )}
       {selectedItems.length > 0 ? (
         <PillGroup
           items={selectedItems}
@@ -239,6 +268,7 @@ export function MultiSelect<T extends Item>(props: MultiSelectProps<T>) {
           label="Selected items"
           background={pillBackground}
           isBorderless={isPillBorderless}
+          size={size === "sm" ? "sm" : "md"}
         >
           {renderPill}
         </PillGroup>

--- a/easy-ui-react/src/PillGroup/PillGroup.mdx
+++ b/easy-ui-react/src/PillGroup/PillGroup.mdx
@@ -123,6 +123,12 @@ The `isBorderless` prop controls whether or not individual pills render with a b
 
 <Canvas of={PillStories.Border} />
 
+## Size
+
+The `size` prop controls the size of individual pills. Supported sizes are `sm` and `md` (default).
+
+<Canvas of={PillStories.Small} />
+
 ## Properties
 
 ### PillGroup props
@@ -146,6 +152,12 @@ export type PillGroupProps<T> = Pick<TagGroupProps, "onRemove"> &
      * @default false
      */
     isBorderless?: boolean;
+    /**
+     * Size of individual pills.
+     *
+     * @default md
+     */
+    size?: PillSize;
   };
 
 export type PillProps = {

--- a/easy-ui-react/src/PillGroup/PillGroup.module.scss
+++ b/easy-ui-react/src/PillGroup/PillGroup.module.scss
@@ -37,3 +37,10 @@
   min-width: 0;
   @include responsive-prop("pill-group", "gap", gap);
 }
+
+// Dissolve the group and list boxes so pills join the parent's flex flow
+// (e.g. inline with a MultiSelect's leading icon and input). Defined after
+// `.list` so `display: contents` wins over its `display: flex`.
+.flattened {
+  display: contents;
+}

--- a/easy-ui-react/src/PillGroup/PillGroup.module.scss
+++ b/easy-ui-react/src/PillGroup/PillGroup.module.scss
@@ -18,6 +18,12 @@
   border: none;
 }
 
+.small {
+  padding: calc(
+    #{design-token("space.0.5")} - #{design-token("shape.border_width.1")}
+  );
+}
+
 .remove {
   @include unstyled.button;
   cursor: pointer;

--- a/easy-ui-react/src/PillGroup/PillGroup.module.scss
+++ b/easy-ui-react/src/PillGroup/PillGroup.module.scss
@@ -18,7 +18,7 @@
   border: none;
 }
 
-.small {
+.sizeSm {
   padding: calc(
     #{design-token("space.0.5")} - #{design-token("shape.border_width.1")}
   );

--- a/easy-ui-react/src/PillGroup/PillGroup.stories.tsx
+++ b/easy-ui-react/src/PillGroup/PillGroup.stories.tsx
@@ -61,6 +61,20 @@ export const ImageSymbol: Story = {
   },
 };
 
+export const Small: Story = {
+  render: Template.bind({}),
+  args: {
+    size: "sm",
+    children: (
+      <>
+        <PillGroup.Pill label="First Last #123" icon={LocalShippingIcon} />
+        <PillGroup.Pill label="First Last #456" icon={LocalShippingIcon} />
+        <PillGroup.Pill label="First Last #789" icon={LocalShippingIcon} />
+      </>
+    ),
+  },
+};
+
 export const Positioning: Story = {
   args: {
     children: (

--- a/easy-ui-react/src/PillGroup/PillGroup.test.tsx
+++ b/easy-ui-react/src/PillGroup/PillGroup.test.tsx
@@ -70,6 +70,30 @@ describe("<PillGroup />", () => {
     );
   });
 
+  it("propagates size to pills, applying the sm class at size='sm'", () => {
+    render(
+      <PillGroup label="Label" size="sm">
+        <PillGroup.Pill label="Foobaz 123" />
+      </PillGroup>,
+    );
+    expect(screen.getByRole("row", { name: "Foobaz 123" })).toHaveAttribute(
+      "class",
+      expect.stringContaining("sizeSm"),
+    );
+  });
+
+  it("does not apply the sm class at the default md size", () => {
+    render(
+      <PillGroup label="Label">
+        <PillGroup.Pill label="Foobaz 123" />
+      </PillGroup>,
+    );
+    expect(screen.getByRole("row", { name: "Foobaz 123" })).not.toHaveAttribute(
+      "class",
+      expect.stringContaining("sizeSm"),
+    );
+  });
+
   it("supports onRemove callback function", async () => {
     const callbackFn = vi.fn();
     const { user } = render(

--- a/easy-ui-react/src/PillGroup/PillGroup.tsx
+++ b/easy-ui-react/src/PillGroup/PillGroup.tsx
@@ -57,6 +57,15 @@ export type PillGroupProps<T> = Pick<TagGroupProps, "onRemove"> &
      * @default md
      */
     size?: PillSize;
+    /**
+     * When true, the group and list use `display: contents` so the pills
+     * participate directly in the parent's layout flow (e.g. an input field
+     * with inline tags). Intended for internal composition.
+     *
+     * @default false
+     * @private
+     */
+    isFlattened?: boolean;
   };
 
 /**
@@ -120,6 +129,7 @@ export function PillGroup<T extends object>(props: PillGroupProps<T>) {
     background = "neutral.000",
     isBorderless = false,
     size = "md",
+    isFlattened = false,
   } = props;
   const {
     align,
@@ -150,11 +160,18 @@ export function PillGroup<T extends object>(props: PillGroupProps<T>) {
   } as React.CSSProperties;
   return (
     <InternalPillGroupContext.Provider value={context}>
-      <TagGroup {...props}>
+      <TagGroup
+        {...props}
+        className={isFlattened ? styles.flattened : undefined}
+      >
         <Text visuallyHidden>
           <Label>{label}</Label>
         </Text>
-        <TagList items={items} className={styles.list} style={style}>
+        <TagList
+          items={items}
+          className={classNames(styles.list, isFlattened && styles.flattened)}
+          style={style}
+        >
           {children}
         </TagList>
       </TagGroup>

--- a/easy-ui-react/src/PillGroup/PillGroup.tsx
+++ b/easy-ui-react/src/PillGroup/PillGroup.tsx
@@ -21,6 +21,8 @@ import { HorizontalStackProps } from "../HorizontalStack";
 
 export type PillBackground = ThemeTokenNamespace<"color">;
 
+export type PillSize = "sm" | "md";
+
 /**
  * Assists in managing state for list data for `<PillGroup />`
  *
@@ -48,6 +50,12 @@ export type PillGroupProps<T> = Pick<TagGroupProps, "onRemove"> &
      * @default false
      */
     isBorderless?: boolean;
+    /**
+     * Size of individual pills.
+     *
+     * @default md
+     */
+    size?: PillSize;
   };
 
 /**
@@ -110,6 +118,7 @@ export function PillGroup<T extends object>(props: PillGroupProps<T>) {
     horizontalStackContainerProps = {},
     background = "neutral.000",
     isBorderless = false,
+    size = "md",
   } = props;
   const {
     align,
@@ -123,8 +132,9 @@ export function PillGroup<T extends object>(props: PillGroupProps<T>) {
     return {
       background,
       isBorderless,
+      size,
     };
-  }, [background, isBorderless]);
+  }, [background, isBorderless, size]);
 
   const style = {
     ...getResponsiveDesignToken("pill-group", "gap", "space", gap),
@@ -160,20 +170,27 @@ export type PillProps = {
 
 function Pill(props: PillProps) {
   const { label, icon } = props;
-  const { background, isBorderless } = useInternalPillGroupContext();
+  const { background, isBorderless, size } = useInternalPillGroupContext();
 
   const style = {
     ...getComponentThemeToken("pill", "background", "color", background),
   } as React.CSSProperties;
 
-  const className = classNames(styles.Pill, isBorderless && styles.borderless);
+  const className = classNames(
+    styles.Pill,
+    isBorderless && styles.borderless,
+    size === "sm" && styles.small,
+  );
 
   return (
     <Tag textValue={label} className={className} style={style} {...props}>
       {({ allowsRemoving }) => (
         <>
           {icon && <Icon size="xs" symbol={icon} color="primary.700" />}
-          <Text color="primary.800" variant="subtitle2">
+          <Text
+            color="primary.800"
+            variant={size === "sm" ? "caption" : "subtitle2"}
+          >
             {label}
           </Text>
           {allowsRemoving && (

--- a/easy-ui-react/src/PillGroup/PillGroup.tsx
+++ b/easy-ui-react/src/PillGroup/PillGroup.tsx
@@ -11,6 +11,7 @@ import {
   getResponsiveDesignToken,
   getComponentThemeToken,
   classNames,
+  variationName,
 } from "../utilities/css";
 import {
   InternalPillGroupContext,
@@ -179,7 +180,7 @@ function Pill(props: PillProps) {
   const className = classNames(
     styles.Pill,
     isBorderless && styles.borderless,
-    size === "sm" && styles.small,
+    styles[variationName("size", size)],
   );
 
   return (

--- a/easy-ui-react/src/PillGroup/PillGroupContext.tsx
+++ b/easy-ui-react/src/PillGroup/PillGroupContext.tsx
@@ -1,9 +1,10 @@
 import { createContext, useContext } from "react";
-import { PillBackground } from "./PillGroup";
+import { PillBackground, PillSize } from "./PillGroup";
 
 type InternalPillGroupContextType = {
   background: PillBackground;
   isBorderless: boolean;
+  size: PillSize;
 };
 
 export const InternalPillGroupContext =


### PR DESCRIPTION
## 📝 Changes

`MultiSelect` now supports `iconAtStart` and  `size` (`sm`, `md`, `lg`)  props, matching `Select`

`PillGroup` now supports a `size` prop (`sm`, `md`) to render smaller pills

## ✅ Checklist

Easy UI has certain UX standards that must be met. In general, non-trivial changes should meet the following criteria:

- [x] Visuals match Design Specs in Figma
- [x] Stories accompany any component changes
- [x] Code is in accordance with our style guide
- [x] Design tokens are utilized
- [x] Unit tests accompany any component changes
- [x] TSDoc is written for any API surface area
- [x] Specs are up-to-date
- [x] Console is free from warnings
- [x] No accessibility violations are reported
- [x] Cross-browser check is performed (Chrome, Safari, Firefox)
- [x] Changeset is added

~Strikethrough~ any items that are not applicable to this pull request.
