### PR TITLE
fix(Tabs): render underline at exact width on fractional device pixel ratios

### DIFF
--- a/.changeset/lucky-tabs-underline.md
+++ b/.changeset/lucky-tabs-underline.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+Fix `TabNav` and `TabPanels` underline rendering at the wrong width on fractional device pixel ratios

--- a/easy-ui-react/src/Tabs/Tabs.module.scss
+++ b/easy-ui-react/src/Tabs/Tabs.module.scss
@@ -5,7 +5,7 @@
 .Tabs {
   @include Tabs.border-tokens;
   @include component-token("tab-nav", "indicator-height", 1px);
-  @include component-token("tab-nav", "indicator-width", 0);
+  @include component-token("tab-nav", "indicator-width", 0px);
   @include component-token("tab-nav", "indicator-position", 0);
   @include component-token(
     "tab-nav",
@@ -66,14 +66,19 @@
   left: 0;
   bottom: 0;
   height: component-token("tab-nav", "indicator-height");
-  width: 1px;
+
+  // the width is set directly rather than by scaling a 1px element. scaling a
+  // 1px element is subject to device pixel rounding: the 1px box is snapped to
+  // a whole device pixel before the scale is applied, so at a device pixel
+  // ratio that isn't a whole number — e.g. a 2x display at 67% browser zoom —
+  // the underline renders proportionally short or long
+  width: component-token("tab-nav", "indicator-width");
 
   background: component-token("tab-nav", "current-page-color");
-  transform: translateX(#{component-token("tab-nav", "indicator-position")})
-    scaleX(#{component-token("tab-nav", "indicator-width")});
+  transform: translateX(#{component-token("tab-nav", "indicator-position")});
   transform-origin: left;
 
-  transition-property: transform;
+  transition-property: transform, width;
   transition-duration: 0.2s;
   transition-timing-function: ease-in-out;
 }

--- a/easy-ui-react/src/Tabs/Tabs.tsx
+++ b/easy-ui-react/src/Tabs/Tabs.tsx
@@ -59,7 +59,7 @@ export function Tabs(props: TabsProps) {
   useScrollbar({ navRef, containerRef });
 
   const style = {
-    ...getComponentToken("tab-nav", "indicator-width", String(indicatorWidth)),
+    ...getComponentToken("tab-nav", "indicator-width", `${indicatorWidth}px`),
     ...getComponentToken(
       "tab-nav",
       "indicator-position",


### PR DESCRIPTION
## 📝 Changes

<img width="485" height="107" alt="image" src="https://github.com/user-attachments/assets/f4c14f4f-e672-4e1f-8564-7814835faf0b" />

The active tab underline was a `width: 1px` div stretched with `transform: scaleX(<measured px>)`. Chrome snaps the 1px box to a whole device pixel before applying the scale, so at any non-integer device pixel ratio the bar is off by that rounding factor. The `translateX` position isn't snapped, which is why the left edge lands correctly and only the width is wrong.

Measured in Chrome 152 rendering a 411.5px bar:

| DPR   | expected | actual                  |
| ----- | -------- | ----------------------- |
| 1.0   | 412      | 411                     |
| 1.25  | 514      | 411 (0.80x)             |
| 1.333 | 548      | 411 (0.75x)             |
| 1.5   | 617      | 823 (1.33x, too long)   |
| 2.0   | 823      | 823                     |
| 2.667 | 1098     | 1235 (1.13x, too long)  |

Set the indicator's real `width` from the measured value and keep `translateX` for position only, transitioning `transform, width`. Exact at every DPR with the same animation.

Refs SHPE-1667
