### PR TITLE
fix(DataGrid): paint header background past the column edges

### DIFF
--- a/.changeset/dull-columns-hide.md
+++ b/.changeset/dull-columns-hide.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+Fix `DataGrid` painting hairline seams between header columns on fractional device pixel ratios

--- a/easy-ui-react/src/DataGrid/ColumnHeader.module.scss
+++ b/easy-ui-react/src/DataGrid/ColumnHeader.module.scss
@@ -4,11 +4,32 @@
 .ColumnHeader {
   position: sticky;
   top: 0;
-  background: component-token("data-grid", "header-bg");
   color: component-token("data-grid", "header-text");
   outline: none;
   padding: 0 design-token("space.2");
   z-index: component-token("data-grid", "column-z-index");
+
+  // the background is painted by an overlay that bleeds past the cell's side
+  // edges rather than by the cell itself. columns are laid out at fractional
+  // widths, and at a device pixel ratio that isn't a whole number — e.g. a 2x
+  // display at 67% browser zoom — neither cell fully covers the device pixel
+  // their shared edge lands in, so the rows behind the header show through as a
+  // hairline seam between the columns. bleeding the backgrounds into each other
+  // covers that pixel from both sides. the overlap can't be seen: every cell in
+  // the row paints the same color, and the bleed at the two ends of the row is
+  // clipped by the grid's own scroll container. 2px covers a whole device pixel
+  // down to a ratio of 0.5, i.e. a 1x display zoomed out to 50%
+  &::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: -2px;
+    right: -2px;
+    background: component-token("data-grid", "header-bg");
+    pointer-events: none;
+    z-index: -1;
+  }
 }
 
 .content {


### PR DESCRIPTION
## 📝 Changes

Fixes occasional DataGrid header seams.

Before:

<img width="auto" height="240" alt="image" src="https://github.com/user-attachments/assets/f22c54b0-3c81-41a1-972d-75f7e9e032f5" />

After:

<img width="auto" height="240" alt="image" src="https://github.com/user-attachments/assets/0473d86a-a864-4196-99c4-0720a760e406" />

Column header cells are laid out at fractional widths, so a shared edge between two of them lands mid-device-pixel. At a device pixel ratio that isn't a whole number, neither cell's background fully covers that pixel -- measured coverage is ~0.67 -- and the rows behind the sticky header show through as a hairline seam. Integer ratios never show it, which is why it appears intermittently while resizing: resizing sweeps the column edges through sub-pixel offsets.

Paint the background from a pseudo-element that bleeds 2px past both side edges instead of from the cell itself, so each boundary pixel is covered from both sides. The overlap is invisible because every cell in the row paints the same color and the bleed at the ends of the row is clipped by the grid's scroll container.

Verified over 336 width/ratio configurations on the reported story and across 6 DataGrid stories: 806 -> 0 and 714 -> 0 seam pixels, with no rendering change at integer ratios outside the grid's rounded corners.
