### PR TITLE
feat(DataGrid): support maxRows="auto" to fit the container's height

### DIFF
--- a/.changeset/datagrid-auto-max-rows.md
+++ b/.changeset/datagrid-auto-max-rows.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": minor
+---
+
+Adds `maxRows="auto"` to `<DataGrid />`, which bounds the data grid by the height its container makes available and scrolls the rows within it rather than showing a set number of rows. It shrinks to its rows when they don't fill that space, and a container that stretches it instead turns the auto height into a fill that anchors the footer to the bottom of the layout. Sizing is handled entirely in CSS, so nothing is measured in JavaScript

--- a/documentation/specs/DataGrid.md
+++ b/documentation/specs/DataGrid.md
@@ -64,8 +64,11 @@ type DataGridProps<C extends Column> = AriaLabelingProps & {
    */
   headerVariant?: "primary" | "secondary" | "emphasized";
 
-  /** Constrains the height of the data grid to a set number of rows. */
-  maxRows?: number;
+  /**
+   * Constrains the height of the data grid to a set number of rows, or to the
+   * height its container makes available with `auto`.
+   */
+  maxRows?: number | "auto";
 
   /** Handler that is called when a user performs an action on the cell. */
   onCellAction?: (key: Key) => void;

--- a/easy-ui-react/src/DataGrid/DataGrid.mdx
+++ b/easy-ui-react/src/DataGrid/DataGrid.mdx
@@ -54,7 +54,8 @@ const rows = [
   defaultExpandedKey={1}
   expandedKey={1}
   onExpandedChange={(key) => {}}
-  // Customize how many rows show before scroll
+  // Customize how many rows show before scroll, or use "auto" to fit the
+  // height the container makes available
   maxRows={7}
   // Enable selection. Can be "multiple" or "single"
   selectionMode="multiple"
@@ -304,6 +305,57 @@ The regions accept anything, so a footer needn't paginate at all.
 ### Footer with an Empty State
 
 <Canvas of={DataGridStories.FooterWithEmptyState} />
+
+## Auto Height
+
+`maxRows` takes `auto` in place of a row count, which bounds the data grid by the height its container makes available and scrolls the rows within it. This suits a data grid in a fluid layout, where the room it has to work with comes from the page rather than from a number settled on in advance.
+
+<Canvas of={DataGridStories.AutoHeight} />
+
+<Controls of={DataGridStories.AutoHeight} />
+
+An auto height data grid shrinks to its rows when they don't fill the space it's offered, so it never draws an empty region beneath the last row.
+
+<Canvas of={DataGridStories.AutoHeightWithFewRows} />
+
+Some ancestor has to establish a height for `auto` to have space to work from. It needn't be the data grid's parent; a height set once at the top of a layout carries down through flex and grid tracks.
+
+```tsx
+// The height is established once, and the levels beneath it pass it down
+<div style={{ height: "100dvh", display: "flex", flexDirection: "column" }}>
+  <PageHeader />
+  <div
+    style={{
+      display: "flex",
+      flexDirection: "column",
+      flex: "1 1 auto",
+      minHeight: 0,
+    }}
+  >
+    <DataGrid maxRows="auto" {...props} />
+  </div>
+</div>
+```
+
+Two things to watch for in the surrounding layout:
+
+- Flex and grid items between that height and the data grid need `min-height: 0`. They floor at their content height otherwise, which lets the data grid run past the bottom of the layout instead of scrolling inside it.
+- A plain block container holding a sibling above the data grid measures `auto` against the container's whole height rather than the room left over, which overflows it. Laying that container out as a flex column or a grid resolves it.
+
+With no height established anywhere above it, `auto` has nothing to bound the data grid by, and it falls back to drawing every row.
+
+### Filling a Container
+
+A container that stretches the data grid rather than letting it shrink turns the auto height into a fill. The rows take the extra room and the footer holds the bottom of the layout however few rows there are, which is what a data grid anchored to the foot of a page wants.
+
+<Canvas of={DataGridStories.AutoHeightFillingItsContainer} />
+
+```tsx
+// A single track stretches the data grid to the full height of the container
+<div style={{ height: "100dvh", display: "grid", gridTemplateRows: "1fr" }}>
+  <DataGrid maxRows="auto" {...props} />
+</div>
+```
 
 ## Properties
 

--- a/easy-ui-react/src/DataGrid/DataGrid.module.scss
+++ b/easy-ui-react/src/DataGrid/DataGrid.module.scss
@@ -110,6 +110,34 @@
   @include DataGrid.hide-scrollbars;
 }
 
+// `maxRows="auto"` bounds the grid by the space its container offers instead of
+// a row count. Laying the frame out as a flex column is what makes that work
+// without measuring anything: the footer takes its height off the top of the
+// space, the rows scroll in what's left, and the browser does the subtraction.
+.maxRowsAuto {
+  display: flex;
+  flex-direction: column;
+  // Shrink into the room a flex container leaves over, but never grow into it,
+  // so a grid holding a few rows stays only as tall as those rows
+  flex: 0 1 auto;
+  // Flex and grid items floor at their content height by default, which is what
+  // would otherwise stop the frame shrinking far enough for the rows to scroll
+  min-height: 0;
+  // Bounds the frame in a container that sizes itself rather than its children.
+  // Resolves to no bound at all when no ancestor establishes a height, which
+  // falls the grid back to drawing every row.
+  max-height: 100%;
+
+  .scrollContainer {
+    // The container's height stands in for the row count as the grid's bound
+    max-height: none;
+    min-height: 0;
+    // Takes up whatever height the frame is given past its rows, so the footer
+    // stays at the foot of the frame when a container stretches it taller
+    flex: 1 1 auto;
+  }
+}
+
 .sizeSm {
   @include component-token("data-grid", "header-row-height", 32px);
   @include component-token("data-grid", "body-row-height", 32px);

--- a/easy-ui-react/src/DataGrid/DataGrid.stories.tsx
+++ b/easy-ui-react/src/DataGrid/DataGrid.stories.tsx
@@ -2,7 +2,7 @@ import CheckCircleIcon from "@easypost/easy-ui-icons/CheckCircle";
 import ErrorIcon from "@easypost/easy-ui-icons/Error";
 import { action } from "storybook/actions";
 import { Meta, StoryObj } from "@storybook/react-vite";
-import React, { useState } from "react";
+import React, { ReactNode, useState } from "react";
 import { Key } from "react-aria";
 import { useAsyncList } from "react-stately";
 import { Icon } from "../Icon";
@@ -75,6 +75,12 @@ const rows = [
     lastActive: "2023-06-06",
   },
 ];
+
+// More rows than the auto height stories' layout has room for, so the data grid
+// has something to scroll within the space it's given
+const manyRows = Array.from({ length: 4 }, (_, i) =>
+  rows.map((row) => ({ ...row, key: `${row.key}-${i}` })),
+).flat();
 
 const Template = (args: Partial<DataGridProps>) => {
   return (
@@ -360,6 +366,48 @@ export const FooterWithEmptyState: Story = {
   },
 };
 
+export const AutoHeight: Story = {
+  render: AutoHeightTemplate.bind({}),
+  args: {
+    "aria-label": "Example data grid sized to its container",
+    maxRows: "auto",
+    rows: manyRows,
+  },
+  parameters: {
+    controls: {
+      include: ["maxRows", "size"],
+    },
+  },
+};
+
+export const AutoHeightWithFewRows: Story = {
+  render: AutoHeightTemplate.bind({}),
+  args: {
+    "aria-label": "Example data grid sized to its container with few rows",
+    maxRows: "auto",
+    rows: rows.slice(0, 2),
+  },
+  parameters: {
+    controls: {
+      include: ["maxRows", "size"],
+    },
+  },
+};
+
+export const AutoHeightFillingItsContainer: Story = {
+  render: AutoHeightFillTemplate.bind({}),
+  args: {
+    "aria-label": "Example data grid filling its container",
+    maxRows: "auto",
+    rows: rows.slice(0, 2),
+  },
+  parameters: {
+    controls: {
+      include: ["maxRows", "size"],
+    },
+  },
+};
+
 function WithSortTemplate(args: Partial<DataGridProps>) {
   // https://react-spectrum.adobe.com/react-stately/useAsyncList.html
   const list = useAsyncList({
@@ -417,5 +465,59 @@ function WithFooterTemplate(args: Partial<DataGridProps>) {
       )}
       {...args}
     />
+  );
+}
+
+function AutoHeightTemplate(args: Partial<DataGridProps>) {
+  return (
+    <FluidHeightLayout>
+      <WithFooterTemplate {...args} />
+    </FluidHeightLayout>
+  );
+}
+
+function AutoHeightFillTemplate(args: Partial<DataGridProps>) {
+  return (
+    <StretchedHeightLayout>
+      <WithFooterTemplate {...args} />
+    </StretchedHeightLayout>
+  );
+}
+
+/**
+ * Stands in for a page shell: one ancestor establishes a height and the levels
+ * beneath it pass that height down through flex without restating it. This is
+ * the layout `maxRows="auto"` is meant for, and the data grid shrinks to its
+ * rows here when they don't fill the space.
+ */
+function FluidHeightLayout({ children }: { children: ReactNode }) {
+  return (
+    <div style={{ height: 320, display: "flex", flexDirection: "column" }}>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          flex: "1 1 auto",
+          // Flex items floor at their content height without this, which would
+          // let the data grid run past the bottom of the layout
+          minHeight: 0,
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * A container that stretches the data grid rather than letting it shrink, which
+ * turns the auto height into a fill: the rows take the extra room and the footer
+ * stays at the bottom of the layout however few rows there are.
+ */
+function StretchedHeightLayout({ children }: { children: ReactNode }) {
+  return (
+    <div style={{ height: 320, display: "grid", gridTemplateRows: "1fr" }}>
+      {children}
+    </div>
   );
 }

--- a/easy-ui-react/src/DataGrid/DataGrid.test.tsx
+++ b/easy-ui-react/src/DataGrid/DataGrid.test.tsx
@@ -46,6 +46,33 @@ describe("<DataGrid />", () => {
     expect(getOuterContainer()).toHaveStyle(
       getComponentToken("data-grid", "max-rows", "8"),
     );
+    expect(getOuterContainer().className).not.toContain("maxRowsAuto");
+  });
+
+  it("should support an auto height", () => {
+    render(createDataGrid({ maxRows: "auto" }));
+    expect(getOuterContainer()).toHaveAttribute(
+      "class",
+      expect.stringContaining("maxRowsAuto"),
+    );
+    // The container's height stands in for the row count, so the token that the
+    // row count drives is left unset for the styles to fall back on
+    expect(
+      getOuterContainer().style.getPropertyValue(getMaxRowsTokenName()),
+    ).toBe("");
+  });
+
+  it("should keep the footer out of the scroll container at an auto height", () => {
+    render(
+      createDataGrid({
+        maxRows: "auto",
+        renderFooter: () => <DataGrid.Footer center={<span>Center</span>} />,
+      }),
+    );
+    // The frame lays itself out as a flex column at an auto height, which only
+    // works while the footer is a sibling of the region that scrolls
+    expect(getScrollContainer()).not.toContainElement(getFooter());
+    expect(getOuterContainer()).toContainElement(getFooter());
   });
 
   it("should support a header variant", () => {
@@ -408,6 +435,15 @@ function getFooter() {
   return getOuterContainer().querySelector(
     "[data-ezui-data-grid-footer]",
   ) as HTMLElement;
+}
+
+// Reads the custom property name off of the token helper rather than spelling it
+// out, so these tests don't pin down how tokens are named
+function getMaxRowsTokenName() {
+  const [name] = Object.keys(
+    getComponentToken("data-grid", "max-rows", "ignored"),
+  );
+  return name;
 }
 
 function getHead() {

--- a/easy-ui-react/src/DataGrid/Footer.module.scss
+++ b/easy-ui-react/src/DataGrid/Footer.module.scss
@@ -19,6 +19,10 @@
   min-height: calc(
     design-token("space.6") + component-token("data-grid", "border-width")
   );
+  // The frame lays itself out as a flex column when the grid takes its height
+  // from its container, and the bar holds onto its own height there instead of
+  // surrendering it to the rows
+  flex-shrink: 0;
   // Content too wide for the frame stays reachable rather than being clipped by
   // the frame's radius. Height stays auto, so this never scrolls vertically.
   overflow-x: auto;

--- a/easy-ui-react/src/DataGrid/Table.tsx
+++ b/easy-ui-react/src/DataGrid/Table.tsx
@@ -72,6 +72,8 @@ export function Table<C extends Column, R extends RowType>(
   const { collection } = state;
   const { columns } = collection;
 
+  const isAutoHeight = maxRows === "auto";
+
   const hasSelection = columns.some((c) => c.props.isSelectionCell);
   const hasExpansion = columns.some((c) => c.key === EXPAND_COLUMN_KEY);
   const hasRowActions = columns.some((c) => c.key === ACTIONS_COLUMN_KEY);
@@ -80,6 +82,7 @@ export function Table<C extends Column, R extends RowType>(
   const dataGridClassName = classNames(
     styles.DataGrid,
     styles[variationName("size", size)],
+    isAutoHeight && styles.maxRowsAuto,
   );
 
   const tableClassName = classNames(
@@ -94,7 +97,13 @@ export function Table<C extends Column, R extends RowType>(
   );
 
   const style = {
-    ...getComponentToken("data-grid", "max-rows", String(maxRows)),
+    // An auto height data grid takes its bound from its container rather than a
+    // row count, so it leaves this token unset for the styles to fall back on
+    ...getComponentToken(
+      "data-grid",
+      "max-rows",
+      isAutoHeight ? undefined : String(maxRows),
+    ),
     ...expandedRowStyle,
   } as CSSProperties;
 

--- a/easy-ui-react/src/DataGrid/types.ts
+++ b/easy-ui-react/src/DataGrid/types.ts
@@ -87,8 +87,20 @@ export type DataGridProps<
    */
   headerVariant?: "primary" | "secondary" | "emphasized";
 
-  /** Constrains the height of the data grid to a set number of rows. */
-  maxRows?: number;
+  /**
+   * Constrains the height of the data grid to a set number of rows, or to the
+   * height its container makes available with `auto`.
+   *
+   * @remarks
+   * `auto` keeps the data grid within the space its container offers and
+   * scrolls the rows inside that space, which suits a data grid that should
+   * fill a fluid layout rather than a fixed count of rows. It shrinks to its
+   * rows when they don't fill that space, so it never draws an empty region
+   * beneath them. Some ancestor has to establish a height for there to be
+   * space to work from; with none, the data grid falls back to drawing every
+   * row.
+   */
+  maxRows?: number | "auto";
 
   /** Handler that is called when a user performs an action on the cell. */
   onCellAction?: (key: RowKey<R>) => void;


### PR DESCRIPTION
Bounds the data grid by the height its container makes available and scrolls the rows inside that space, instead of a hard-coded row count. The frame lays itself out as a flex column, so the footer takes its height off the top of the space and the rows scroll in what is left -- the browser does the subtraction and nothing is measured in JS.

The grid shrinks to its rows when they do not fill the space, so it never draws an empty region beneath them. A container that stretches its children (for example `grid-template-rows: 1fr`) turns the same value into a fill, which is documented as an opt-in recipe rather than baked into the prop.

The numeric path is untouched: `auto` leaves the max-rows component token unset and the styles fall back on the container instead.
