### PR TITLE
fix(DatePicker): render label through the shared InputField label

### DIFF
--- a/.changeset/fuzzy-labels-align.md
+++ b/.changeset/fuzzy-labels-align.md
@@ -1,0 +1,5 @@
+---
+"@easypost/easy-ui": patch
+---
+
+Render `DatePicker` and `DateRangePicker` labels through the shared `InputField` label so they match `TextField` and `Select` in spacing, color, and error state

--- a/easy-ui-react/src/DatePicker/DatePicker.mdx
+++ b/easy-ui-react/src/DatePicker/DatePicker.mdx
@@ -17,6 +17,12 @@ A `<DatePicker />` component allows users to set default selected date (uncontro
 
 <Canvas of={DatePickerStories.DefaultValue} />
 
+## Label
+
+Use `label` to render a visible label above the `<DatePicker />`. The label is rendered with the same styles as the label on `<TextField />` and `<Select />`, so date pickers line up with neighboring fields. Use `aria-label` instead when the date picker has no visible label.
+
+<Canvas of={DatePickerStories.Label} />
+
 ## Sizes
 
 Use `size="sm"` to render a smaller `<DatePicker />`.

--- a/easy-ui-react/src/DatePicker/DatePicker.stories.tsx
+++ b/easy-ui-react/src/DatePicker/DatePicker.stories.tsx
@@ -8,6 +8,7 @@ import {
   endOfWeek,
 } from "@internationalized/date";
 import { InputDecorator } from "../utilities/storybook";
+import { TextField } from "../TextField";
 import { DatePicker, DatePickerProps } from "./DatePicker";
 
 type Story = StoryObj<typeof DatePicker>;
@@ -32,6 +33,16 @@ export const DefaultValue: Story = {
   args: {
     defaultValue: today(getLocalTimeZone()),
   },
+};
+
+export const Label: Story = {
+  render: () => (
+    <>
+      <TextField label="Text field" placeholder="Placeholder text" />
+      <DatePicker label="Date picker" />
+      <DatePicker size="sm" label="Small date picker" />
+    </>
+  ),
 };
 
 export const Sizes: Story = {

--- a/easy-ui-react/src/DatePicker/DatePicker.test.tsx
+++ b/easy-ui-react/src/DatePicker/DatePicker.test.tsx
@@ -9,6 +9,7 @@ import {
 } from "@internationalized/date";
 import { DateValue } from "react-aria";
 import { render } from "../utilities/test";
+import { TextField } from "../TextField";
 import { DatePicker } from "./DatePicker";
 import { clickElement } from "../RangeCalendar/RangeCalendar.test";
 
@@ -106,6 +107,25 @@ describe("<DatePicker />", () => {
     expect(screen.getByRole("group")).toHaveAttribute("aria-disabled");
     const dateFields = screen.getAllByRole("spinbutton");
     dateFields.every((field) => expect(field).toHaveAttribute("aria-disabled"));
+  });
+
+  it("should render its label like other input fields", () => {
+    render(
+      <>
+        <TextField label="Text field" />
+        <DatePicker label="Date picker" />
+      </>,
+    );
+    const textFieldLabel = screen.getByText("Text field");
+    const datePickerLabel = screen.getByText("Date picker");
+    expect(datePickerLabel.tagName).toBe(textFieldLabel.tagName);
+    expect(datePickerLabel.className).toBe(textFieldLabel.className);
+    expect(datePickerLabel.getAttribute("style")).toBe(
+      textFieldLabel.getAttribute("style"),
+    );
+    expect(datePickerLabel.parentElement?.className).toBe(
+      textFieldLabel.parentElement?.className,
+    );
   });
 
   it("should show error message when date is invalid", async () => {

--- a/easy-ui-react/src/DatePicker/DatePickerBase.tsx
+++ b/easy-ui-react/src/DatePicker/DatePickerBase.tsx
@@ -9,7 +9,7 @@ import { DatePickerState, DateRangePickerState } from "react-stately";
 import { FocusableElement, GroupDOMAttributes } from "@react-types/shared";
 import { DatePickerTrigger } from "./DatePickerTrigger";
 import { DatePickerOverlay } from "./DatePickerOverlay";
-import { Text } from "../Text";
+import { Label } from "../InputField/Label";
 import { logWarningForMissingAriaLabel } from "../InputField/utilities";
 import { classNames, variationName } from "../utilities/css";
 import styles from "./DatePicker.module.scss";
@@ -50,7 +50,7 @@ export function DatePickerBase(props: DatePickerProps) {
     children,
     state,
   } = props;
-  const { size } = triggerProps;
+  const { size, isInvalid } = triggerProps;
   const triggerRef = React.useRef(null);
 
   logWarningForMissingAriaLabel(label, ariaLabel);
@@ -62,13 +62,9 @@ export function DatePickerBase(props: DatePickerProps) {
   return (
     <div className={className}>
       {label && (
-        <Text
-          {...labelProps}
-          variant={size === "sm" ? "body2" : "body1"}
-          color="primary.800"
-        >
+        <Label fieldSize={size} hasError={isInvalid} {...labelProps}>
           {label}
-        </Text>
+        </Label>
       )}
       <DatePickerTrigger
         {...triggerProps}

--- a/easy-ui-react/src/DateRangePicker/DateRangePicker.mdx
+++ b/easy-ui-react/src/DateRangePicker/DateRangePicker.mdx
@@ -17,6 +17,12 @@ A `<DateRangePicker />` component allows users to set default selected date (unc
 
 <Canvas of={DateRangePickerStories.DefaultValue} />
 
+## Label
+
+Use `label` to render a visible label above the `<DateRangePicker />`. The label is rendered with the same styles as the label on `<TextField />` and `<Select />`, so date range pickers line up with neighboring fields. Use `aria-label` instead when the date range picker has no visible label.
+
+<Canvas of={DateRangePickerStories.Label} />
+
 ## Sizes
 
 Use `size="sm"` to render a smaller `<DateRangePicker />`.

--- a/easy-ui-react/src/DateRangePicker/DateRangePicker.stories.tsx
+++ b/easy-ui-react/src/DateRangePicker/DateRangePicker.stories.tsx
@@ -3,6 +3,7 @@ import { Meta, StoryObj } from "@storybook/react-vite";
 import { today, getLocalTimeZone } from "@internationalized/date";
 import { DateRange } from "react-aria";
 import { InputDecorator } from "../utilities/storybook";
+import { TextField } from "../TextField";
 import { DateRangePicker, DateRangePickerProps } from "./DateRangePicker";
 
 type Story = StoryObj<typeof DateRangePicker>;
@@ -30,6 +31,16 @@ export const DefaultValue: Story = {
       end: today(getLocalTimeZone()),
     },
   },
+};
+
+export const Label: Story = {
+  render: () => (
+    <>
+      <TextField label="Text field" placeholder="Placeholder text" />
+      <DateRangePicker label="Date range picker" />
+      <DateRangePicker size="sm" label="Small date range picker" />
+    </>
+  ),
 };
 
 export const Sizes: Story = {


### PR DESCRIPTION
## 📝 Changes

<img width="475" height="262" alt="image" src="https://github.com/user-attachments/assets/3504fcbd-c9a5-4fa6-87d1-0fbc6262cca3" />

`DatePickerBase` rendered its label as a bare `Text` span with a hardcoded `primary.800` color, while `TextField` and `Select` route theirs through the shared `InputField` `Label`. The date picker label therefore missed the label spacing (`space.0-5` bottom margin), ignored the surrounding text color, and never picked up the error color when the field was invalid, so it did not line up with neighboring fields.

Use `Label` in `DatePickerBase`, passing the trigger's size and invalid state through, so `DatePicker` and `DateRangePicker` labels match every other labeled input.
